### PR TITLE
Add CodeClimate test coverage reporter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --require manageiq/spec/spec_helper
+--require spec_helper
 --color
 --order random

--- a/.rspec_ci
+++ b/.rspec_ci
@@ -1,4 +1,5 @@
 --require manageiq/spec/spec_helper
+--require spec_helper
 --color
 --order random
 --profile 25

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source 'https://rubygems.org'
 # development dependencies will be added by default to the :development group.
 gemspec
 
+group :test do
+  gem "codeclimate-test-reporter", :require => false
+end
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,11 @@ gem "rails",                           "~> 5.0.x", :git => "git://github.com/rai
 gem "rspec-rails",      "~>3.5.x"
 gem "ezcrypto",                "=0.7",              :require => false
 gem "more_core_extensions",    "~>2.0.0",           :require => false
-gem "linux_block_device", ">=0.1.0", :require => false
+
+if RbConfig::CONFIG["host_os"].include?("linux")
+  gem "linux_block_device", ">=0.1.0", :require => false
+end
+
 gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "addressable",             "~> 2.4",            :require => false
 gem "pg",                      "~>0.18.2",          :require => false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/manageiq-providers-amazon.svg)](http://badge.fury.io/rb/manageiq-providers-amazon)
 [![Build Status](https://travis-ci.org/ManageIQ/manageiq-providers-amazon.svg)](https://travis-ci.org/ManageIQ/manageiq-providers-amazon)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-providers-amazon.svg)](https://codeclimate.com/github/ManageIQ/manageiq-providers-amazon)
-[![Coverage Status](https://coveralls.io/repos/ManageIQ/manageiq-providers-amazon/badge.svg)](https://coveralls.io/github/ManageIQ/manageiq-providers-amazon)
+[![Test Coverage](https://codeclimate.com/github/ManageIQ/manageiq-providers-amazon/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/manageiq-providers-amazon/coverage)
 [![Dependency Status](https://gemnasium.com/ManageIQ/manageiq-providers-amazon.svg)](https://gemnasium.com/ManageIQ/manageiq-providers-amazon)
 
 ManageIQ plugin for the Amazon EC2 provider.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+VCR.configure do |config|
+  config.ignore_hosts 'codeclimate.com'
+end


### PR DESCRIPTION
@durandom Please review.

Two weird things I noticed locally which may change how we have to run the tests

1.  After `app:test:manageiq-providers-amazon:setup` I see `.I, [2016-06-28T16:38:38.999289 #96868]  INFO -- : Reporting coverage data to Code Climate.`.  This is probably because we run two separate steps.  We might want to try to find a way to make `bundle exec rake` to do the right thing, but that might be tricky.
2. After `app:test:manageiq-providers-amazon` I see `Coverage = 89.35%. Sending report to https://codeclimate.com for branch aws_move_to_gem... done.`  I'm not sure why it's choosing that branch except that that's the branch we use for the "dummy" app.  Once everything is on master, this is fine, but it's still very weird.

I see a bunch of other small, minor, oddities we should do after this is merged, so I'll make issues for those.