### PR TITLE
require aws-sdk also in translate_exception

### DIFF
--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -28,6 +28,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
   end
 
   def translate_exception(err)
+    require 'aws-sdk'
     case err
     when Aws::EC2::Errors::SignatureDoesNotMatch
       MiqException::MiqHostError.new "SignatureMismatch - check your AWS Secret Access Key and signing method"
@@ -70,14 +71,12 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     #
 
     def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri = nil)
-      proxy_uri ||= VMDB::Util.http_proxy_uri
-
       require 'aws-sdk'
       Aws.const_get(service)::Resource.new(
         :access_key_id     => access_key_id,
         :secret_access_key => secret_access_key,
         :region            => region,
-        :http_proxy        => proxy_uri,
+        :http_proxy        => proxy_uri || VMDB::Util.http_proxy_uri,
         :logger            => $aws_log,
         :log_level         => :debug,
         :log_formatter     => Aws::Log::Formatter.new(Aws::Log::Formatter.default.pattern.chomp)


### PR DESCRIPTION
because for [verify_credentials](https://github.com/ManageIQ/manageiq-providers-amazon/blob/7dc6a4b72dfe9b2c63ffdf658cd75298e1c49f9a/app/models/manageiq/providers/amazon/manager_mixin.rb#L48) an exception could also occur before raw_connect

Or maybe the execption happend in [VMDB::Util.http_proxy_uri](https://github.com/ManageIQ/manageiq-providers-amazon/blob/7dc6a4b72dfe9b2c63ffdf658cd75298e1c49f9a/app/models/manageiq/providers/amazon/manager_mixin.rb#L73) - thats why I moved it further down

this might have been the reason in this issue https://github.com/ManageIQ/manageiq/issues/9342

@blomquisg review and merge?