### PR TITLE
Amazon CloudManager supports provisioning via automate

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -44,6 +44,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   before_validation :ensure_managers
 
+  supports :provisioning
+
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name            = "#{name} Network Manager"


### PR DESCRIPTION
removed hardcoded classes that support provisioning from miq_provision

Managers of providers answer the question wether they support
provisioning via automate or not. The BaseManager does not by default.

related PR https://github.com/ManageIQ/manageiq/pull/8351