### PR TITLE
Add gettext catalog to ManageIQ::Providers::Amazon plugin

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,0 +1,3 @@
+Vmdb::Gettext::Domains.add_domain('ManageIQ_Providers_Amazon',
+  ManageIQ::Providers::Amazon::Engine.root.join('locale').to_s,
+  :po)

--- a/locale/ManageIQ_Providers_Amazon.pot
+++ b/locale/ManageIQ_Providers_Amazon.pot
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Amazon package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Amazon 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-30 14:51+0200\n"
+"PO-Revision-Date: 2016-08-30 14:51+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: ../app/models/manageiq/providers/amazon/cloud_manager/vm.rb:83 ../app/models/manageiq/providers/amazon/manager_mixin.rb:65
+msgid "Timeline is not available for %{model}"
+msgstr ""
+
+#: ../app/models/manageiq/providers/amazon/cloud_manager/template.rb:6
+msgid "not connected to ems"
+msgstr ""

--- a/locale/en/ManageIQ_Providers_Amazon.po
+++ b/locale/en/ManageIQ_Providers_Amazon.po
@@ -1,0 +1,24 @@
+# English translations for ManageIQ_Providers_Amazon package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Amazon package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Amazon 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-08-30 14:51+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"\n"
+
+msgid "Timeline is not available for %{model}"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""

--- a/locale/ja/ManageIQ_Providers_Amazon.po
+++ b/locale/ja/ManageIQ_Providers_Amazon.po
@@ -1,0 +1,24 @@
+# Japanese translations for ManageIQ_Providers_Amazon package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Amazon package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Amazon 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-08-30 14:51+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"\n"
+
+msgid "Timeline is not available for %{model}"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""

--- a/locale/zh_CN/ManageIQ_Providers_Amazon.po
+++ b/locale/zh_CN/ManageIQ_Providers_Amazon.po
@@ -1,0 +1,24 @@
+# Chinese translations for ManageIQ_Providers_Amazon package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ManageIQ_Providers_Amazon package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ManageIQ_Providers_Amazon 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2016-08-30 14:51+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Chinese\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"\n"
+
+msgid "Timeline is not available for %{model}"
+msgstr ""
+
+msgid "not connected to ems"
+msgstr ""


### PR DESCRIPTION
Changes:
* added a gettext catalog to the `ManageIQ::Providers::Amazon` provider plugin. The catalog was
generated automatically by invoking the following rake task in the ManageIQ git checkout:
```
    rake locale:plugin:find[ManageIQ::Providers::Amazon]
```
* The `ManageIQ::Providers::Amazon` plugin now registers its own catalog with the main ManageIQ
rails app. This way the provider plugin makes the fast_gettext engine aware of the plugin's gettext catalog.