### PR TITLE
run all specs under spec/ and not only models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 before_install:
 - source ${TRAVIS_BUILD_DIR}/tools/ci/before_install.sh
 script:
-- bundle exec bin/rails app:test:manageiq-providers-amazon:setup app:test:manageiq-providers-amazon
+- bundle exec bin/rails app:test:providers:amazon:setup app:test:providers:amazon
 notifications:
   webhooks:
     urls:

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,14 +1,17 @@
 if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
   namespace :test do
-    namespace 'manageiq-providers-amazon' do
-      desc "Setup environment for amazon specs"
-      task :setup => [:initialize, :verify_no_db_access_loading_rails_environment, :setup_db]
-    end
+    namespace :providers do
+      namespace :amazon do
+        desc "Setup environment for amazon specs"
+        task :setup => [:initialize, :verify_no_db_access_loading_rails_environment, :setup_db]
+      end
 
-    desc "Run all amazon specs"
-    RSpec::Core::RakeTask.new('manageiq-providers-amazon' => [:initialize, "evm:compile_sti_loader"]) do |t|
-      EvmTestHelper.init_rspec_task(t)
-      t.pattern = FileList[ENGINE_ROOT + '/spec/models/**/*_spec.rb']
+      desc "Run all amazon specs"
+      RSpec::Core::RakeTask.new(:amazon => [:initialize, "evm:compile_sti_loader"]) do |t|
+        spec_dir = File.expand_path("../../spec", __dir__)
+        EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
+        t.pattern = FileList[spec_dir  + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb')
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+if ENV['CI']
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+end
+
 VCR.configure do |config|
-  config.ignore_hosts 'codeclimate.com'
+  config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Amazon::Engine.root, 'spec/vcr_cassettes')
 end


### PR DESCRIPTION
* removes ENGINE_ROOT to make the specs run from miq

```bash
~/src/manageiq master
❯ bundle exec rails test:providers:amazon
** master - DB vmdb_test on
** master - DB vmdb_test on

Randomized with seed 30066
.................................................................................................................

Finished in 13.21 seconds (files took 5.78 seconds to load)
113 examples, 0 failures

Randomized with seed 30066
```

* renames specs to providers:amazon for clarity

