### PR TITLE
Workaround for a secondary fixed IP for ENI

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
@@ -347,7 +347,10 @@ class ManageIQ::Providers::Amazon::NetworkManager::RefreshParser
 
   def parse_network_port(network_port)
     uid                        = network_port.network_interface_id
-    cloud_subnet_network_ports = network_port.private_ip_addresses.map do |x|
+    # TODO(lsmola) AWS can have secondary private IP address assigned to the ENI, our current model does not allow that.
+    # Probably the best fix is, to expand unique index of the cloud_subnet_network_ports to include address. Also we
+    # need to expand our tests to include the secondary fixed IP. Then we can remove the .slice(0..0)
+    cloud_subnet_network_ports = network_port.private_ip_addresses.slice(0..0).map do |x|
       parse_cloud_subnet_network_port(x, network_port.subnet_id)
     end
     device                     = parent_manager_fetch_path(:vms, network_port.try(:attachment).try(:instance_id))


### PR DESCRIPTION
Purpose or Intent
-----------------

AWS can have secondary private IP address assigned to the ENI,
our current model does not allow that. Probably the best fix is,
to expand unique index of the cloud_subnet_network_ports to
include address. But as a backportable fix, we need to display
only the first one, since we can't backport a migration.


Steps for Testing/QA
-----------------

With this fix, having secondary fixed IP address on ENI will not fail refresh. Only first fixed IP will be visible though.