### PR TITLE
check if name is blank and use instance_id instead

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -200,9 +200,9 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     status = instance.state.name
     return if @options.ignore_terminated_instances && status.to_sym == :terminated
 
-    uid    = instance.id
-    name   = get_from_tags(instance, :name)
-    name ||= uid
+    uid  = instance.id
+    name = get_from_tags(instance, :name)
+    name = name.blank? ? uid : name
 
     flavor_uid = instance.instance_type
     @known_flavors << flavor_uid


### PR DESCRIPTION
# Before 
it could be that there is an empty string as the name of a vm. This would result in a validation error on `Vm` and failing the whole refresh.

# fixes 

https://bugzilla.redhat.com/show_bug.cgi?id=1353979

# steps to reproduce

* add a name to a instance in aws console
* clear the name and add an empty string as the name in aws console
* wait for the refresh to fail
