### PR TITLE
Fix vpc floating ips refresh and association

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
@@ -1,7 +1,12 @@
 module ManageIQ::Providers::Amazon::CloudManager::Provision::Configuration
   def associate_floating_ip(ip_address)
+    # TODO(lsmola) this should be moved to FloatingIp model
     destination.with_provider_object do |instance|
-      instance.client.associate_address(:instance_id => instance.instance_id, :public_ip => ip_address)
+      if ip_address.cloud_network_only?
+        instance.client.associate_address(:instance_id => instance.instance_id, :allocation_id => ip_address.ems_ref)
+      else
+        instance.client.associate_address(:instance_id => instance.instance_id, :public_ip => ip_address.address)
+      end
     end
   end
 

--- a/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
@@ -350,14 +350,16 @@ class ManageIQ::Providers::Amazon::NetworkManager::RefreshParser
   end
 
   def parse_floating_ip(ip)
-    address = uid = ip.public_ip
+    cloud_network_only = ip.domain["vpc"] ? true : false
+    address            = ip.public_ip
+    uid                = cloud_network_only ? ip.allocation_id : ip.public_ip
 
     new_result = {
       :type               => self.class.floating_ip_type,
       :ems_ref            => uid,
       :address            => address,
       :fixed_ip_address   => ip.private_ip_address,
-      :cloud_network_only => ip.domain["vpc"] ? true : false,
+      :cloud_network_only => cloud_network_only,
       :network_port       => @data_index.fetch_path(:network_ports, ip.network_interface_id),
       :vm                 => parent_manager_fetch_path(:vms, ip.instance_id)
     }

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -179,7 +179,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(@ip1).to have_attributes(
       :address            => "54.208.119.197",
       :fixed_ip_address   => "10.0.0.254",
-      :ems_ref            => "54.208.119.197",
+      :ems_ref            => "eipalloc-ce53d7a0",
       :cloud_network_only => true
     )
 


### PR DESCRIPTION
In the provisioning workflow, we need to send allocation_id for a floating IP, otherwise the provisioning will fail, when deploying VPC VM

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1373438
    
Fixes issue:
https://github.com/ManageIQ/manageiq/issues/10586
