### PR TITLE
ems should be a NetworkManager

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -74,6 +74,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
     context "security_groups" do
       context "non cloud network" do
         it "#get_targets_for_ems" do
+          ems = FactoryGirl.create(:ems_amazon_network)
           sg = FactoryGirl.create(:security_group_amazon, :name => "sg_1", :ext_management_system => ems)
           ems.security_groups << sg
           filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, SecurityGroup,
@@ -85,6 +86,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
 
       context "cloud network" do
         it "#get_targets_for_ems" do
+          ems = FactoryGirl.create(:ems_amazon_network)
           cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems)
           sg_cn = FactoryGirl.create(:security_group_amazon, :name => "sg_2", :ext_management_system => ems,
                                      :cloud_network => cn1)


### PR DESCRIPTION
fixes broken specs. 
@Ladas did you do something recently that broke those? Otherwise I think rails was not really enforcing the correct STI class on those

```
Failures:

  1) ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow without applied tags security_groups non cloud network #get_targets_for_ems
     Failure/Error: sg = FactoryGirl.create(:security_group_amazon, :name => "sg_1", :ext_management_system => ems)

     ActiveRecord::AssociationTypeMismatch:
       ManageIQ::Providers::NetworkManager(#47312639897660) expected, got ManageIQ::Providers::Amazon::CloudManager(#47312663181500)
     # ./spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb:77:in `block (5 levels) in <top (required)>'
     # ./spec/manageiq/spec/spec_helper.rb:105:in `block (3 levels) in <top (required)>'
     # /home/hild/src/manageiq/spec/support/evm_spec_helper.rb:28:in `clear_caches'
     # ./spec/manageiq/spec/spec_helper.rb:105:in `block (2 levels) in <top (required)>'

  2) ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow without applied tags security_groups cloud network #get_targets_for_ems
     Failure/Error: cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems)

     ActiveRecord::AssociationTypeMismatch:
       ManageIQ::Providers::NetworkManager(#47312639897660) expected, got ManageIQ::Providers::Amazon::CloudManager(#47312663181500)
     # ./spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb:88:in `block (5 levels) in <top (required)>'
     # ./spec/manageiq/spec/spec_helper.rb:105:in `block (3 levels) in <top (required)>'
     # /home/hild/src/manageiq/spec/support/evm_spec_helper.rb:28:in `clear_caches'
     # ./spec/manageiq/spec/spec_helper.rb:105:in `block (2 levels) in <top (required)>'

```