### PR TITLE
move floating ip factory from manageiq

### DIFF
--- a/spec/factories/floating_ip.rb
+++ b/spec/factories/floating_ip.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :floating_ip_amazon, :parent => :floating_ip,
+                               :class  => "ManageIQ::Providers::Amazon::NetworkManager::FloatingIp"
+end


### PR DESCRIPTION
Moving the floating_ip factory over here.

I'm thinking about creating factories for all STI models that are defined in a provider in a dynamic way.