### PR TITLE
Floating ip spec as shared example

### DIFF
--- a/spec/models/manageiq/providers/amazon/network_manager/floating_ip_spec.rb
+++ b/spec/models/manageiq/providers/amazon/network_manager/floating_ip_spec.rb
@@ -1,0 +1,3 @@
+describe ManageIQ::Providers::Amazon::NetworkManager::FloatingIp do
+  include_examples :floating_ip, 'amazon'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,5 @@ VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Amazon::Engine.root, 'spec/vcr_cassettes')
 end
+
+Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
this needs https://github.com/ManageIQ/manageiq/pull/11414 to be merged

future note: I'm thinking of running specs for STI models automatically. So a providers author does not have to include those, but once he inherits from a miq model, then the shared example for that is run.

cc @blomquisg 