### PR TITLE
more intention revealing detection of vpc

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
@@ -356,7 +356,7 @@ class ManageIQ::Providers::Amazon::NetworkManager::RefreshParser
   end
 
   def parse_floating_ip(ip)
-    cloud_network_only = ip.domain["vpc"] ? true : false
+    cloud_network_only = ip.domain == "vpc" ? true : false
     address            = ip.public_ip
     uid                = cloud_network_only ? ip.allocation_id : ip.public_ip
 


### PR DESCRIPTION
ok, heads up, I tested it and yes, it returns a string. This would work because 
```ruby
"vpc"['vpc'] == 'vpc'
"standard"['vpc'] == nil
```

but thats not really intention revealing :)

so do you mind changing it to

```ruby
cloud_network_only = ip.domain == "vpc" ? true : false
```

from this PR
https://github.com/ManageIQ/manageiq-providers-amazon/pull/43#discussion-diff-78062693


@blomquisg please review and merge