### PR TITLE
remove stale methods that are superseded by supports :feature blocks

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/template.rb
@@ -18,8 +18,4 @@ class ManageIQ::Providers::Amazon::CloudManager::Template < ManageIQ::Providers:
       :message => 'Perform SmartState Analysis on this Image'
     }
   end
-
-  def validate_smartstate_analysis
-    validate_unsupported("Smartstate Analysis")
-  end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -70,14 +70,6 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
     POWER_STATES[raw_power_state.to_s] || "terminated"
   end
 
-  def validate_migrate
-    validate_supported
-  end
-
-  def validate_smartstate_analysis
-    validate_unsupported("Smartstate Analysis")
-  end
-
   def validate_timeline
     {:available => false,
      :message   => _("Timeline is not available for %{model}") % {:model => ui_lookup(:model => self.class.to_s)}}


### PR DESCRIPTION
`supports :migrate` was added in https://github.com/ManageIQ/manageiq/pull/9990
`supports :smartstate_analysis` was added in https://github.com/ManageIQ/manageiq/pull/9865