### PR TITLE
bump aws-sdk version

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency("aws-sdk", ["~>2.2.19"])
+  s.add_dependency("aws-sdk", ["~>2"])
 end


### PR DESCRIPTION
they say we should use the major version only when defining the
dependency https://github.com/aws/aws-sdk-ruby#installation

we are now locked at 2.2.19 whereas they are at 2.6.6
reading their [Changelog](https://github.com/aws/aws-sdk-ruby/blob/master/CHANGELOG.md)  its mostly API updates and mostly for stuff we dont use - but some API updates for EC2 and ElasticLoadBalancer 

@Fryguy ok?
