### PR TITLE
Add managers in before_create callback instead of before_validation

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
            :to        => :network_manager,
            :allow_nil => true
 
-  before_validation :ensure_managers
+  before_create :ensure_managers
 
   supports :provisioning
   supports :regions


### PR DESCRIPTION
otherwise it could happen that one process deletes the manager
and another one saves it and the saving one would add back
a deleted manager.

https://bugzilla.redhat.com/show_bug.cgi?id=1389459
https://bugzilla.redhat.com/show_bug.cgi?id=1393675

https://github.com/ManageIQ/manageiq/pull/12878
https://github.com/ManageIQ/manageiq-providers-azure/pull/13