### PR TITLE
Allow additional_regions to be specified in settings

### DIFF
--- a/app/models/manageiq/providers/amazon/regions.rb
+++ b/app/models/manageiq/providers/amazon/regions.rb
@@ -69,7 +69,10 @@ module ManageIQ
       }
 
       def self.regions
-        REGIONS.except(*Array(Settings.ems.ems_amazon.try!(:disabled_regions)))
+        additional_regions = Hash(Settings.ems.ems_amazon.try!(:additional_regions)).stringify_keys
+        disabled_regions   = Array(Settings.ems.ems_amazon.try!(:disabled_regions))
+
+        REGIONS.merge(additional_regions).except(*disabled_regions)
       end
 
       def self.regions_by_hostname

--- a/spec/models/manageiq/providers/amazon/regions_spec.rb
+++ b/spec/models/manageiq/providers/amazon/regions_spec.rb
@@ -15,4 +15,64 @@ describe ManageIQ::Providers::Amazon::Regions do
       expect(described_class.names).not_to include('us-gov-west-1')
     end
   end
+
+  context "add regions via settings" do
+    context "with no additional regions set" do
+      let(:settings) do
+        {:ems => {:ems_amazon => {:additional_regions => nil}}}
+      end
+
+      it "returns standard regions" do
+        stub_settings(settings)
+        expect(described_class.names).to eql(described_class::REGIONS.keys)
+      end
+    end
+
+    context "with one additional" do
+      let(:settings) do
+        {
+          :ems => {
+            :ems_amazon => {
+              :additional_regions => {
+                :"my-custom-region" => {
+                  :name => "My First Custom Region"
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it "returns the custom regions" do
+        stub_settings(settings)
+        expect(described_class.names).to include("my-custom-region")
+      end
+    end
+
+    context "with additional regions and disabled regions" do
+      let(:settings) do
+        {
+          :ems => {
+            :ems_amazon => {
+              :disabled_regions   => ["my-custom-region-2"],
+              :additional_regions => {
+                :"my-custom-region-1" => {
+                  :name => "My First Custom Region"
+                },
+                :"my-custom-region-2" => {
+                  :name => "My Second Custom Region"
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it "disabled_regions overrides additional_regions" do
+        stub_settings(settings)
+        expect(described_class.names).to     include("my-custom-region-1")
+        expect(described_class.names).not_to include("my-custom-region-2")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add additional regions to be specified in settings, corresponding key in `config/settings.yml` added in https://github.com/ManageIQ/manageiq/pull/12965

https://bugzilla.redhat.com/show_bug.cgi?id=1389068