### PR TITLE
make spec the default rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
 addons:
   postgresql: '9.4'
 before_install: bin/setup
-script:
-- bundle exec bin/rails app:test:providers:amazon:setup app:test:providers:amazon
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,13 @@
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
-
+require 'bundler/setup'
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
 
-APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
-load 'rails/tasks/engine.rake'
+begin
+  require 'rspec/core/rake_task'
+
+  APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
+  load 'rails/tasks/engine.rake'
+rescue LoadError
+end
 
 namespace :spec do
   task :setup => 'app:test:providers:amazon:setup'

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,11 @@ rescue LoadError
 end
 
 namespace :spec do
+  desc "Setup environment for specs"
   task :setup => 'app:test:providers:amazon:setup'
 end
 
+desc "Run all amazon specs"
 task :spec => 'app:test:providers:amazon'
+
 task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,15 @@ rescue LoadError
   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
 
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
 APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
 load 'rails/tasks/engine.rake'
+
+namespace :spec do
+  task :setup => 'app:test:providers:amazon:setup'
+end
+
+task :spec => 'app:test:providers:amazon'
+task :default => :spec

--- a/lib/manageiq-providers-amazon.rb
+++ b/lib/manageiq-providers-amazon.rb
@@ -1,0 +1,2 @@
+require "manageiq/providers/amazon/engine"
+require "manageiq/providers/amazon/version"


### PR DESCRIPTION
Following somewhat the setup in https://github.com/ManageIQ/manageiq-content/blob/master/Rakefile

now you can just `bundle exec rake` to run the tests.

I think it's worth keeping the tasks at [lib/tasks/spec.rake](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/lib/tasks/spec.rake) as they can be run within the manageiq app then as well.

I also added a explaining error to `Gemfile` in case `spec/manageiq` is not there

@bdunne @Fryguy wdyt?

If this is good, I'd add that to the provider generator