### PR TITLE
map event unknown to automate to ConfigurationItemChangeNotification

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
@@ -1,4 +1,31 @@
 module ManageIQ::Providers::Amazon::CloudManager::EventParser
+  # these have their own EmsEvent classes in automate
+  INSTANCE_EVENTS = %w(
+    AWS_EC2_Instance_CREATE
+    AWS_EC2_Instance_UPDATE
+    AWS_EC2_Instance_DELETE
+    AWS_EC2_Instance_running
+    AWS_EC2_Instance_shutting-down
+    AWS_EC2_Instance_stopped
+  ).to_set.freeze
+
+  def self.map_event_type(aws_event_type)
+    if INSTANCE_EVENTS.include?(aws_event_type)
+      aws_event_type
+    else
+      'ConfigurationItemChangeNotification'
+    end
+  end
+
+  def self.format_message(event)
+    changed_properties = event.fetch_path("configurationItemDiff", "changedProperties")
+    if changed_properties.present?
+      "#{event['eventType']}: #{changed_properties}"
+    else
+      "#{event['eventType']}"
+    end
+  end
+
   def self.event_to_hash(event, ems_id)
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
 
@@ -6,9 +33,9 @@ module ManageIQ::Providers::Amazon::CloudManager::EventParser
                "#{event["configurationItem"]["resourceId"]}]")
 
     event_hash = {
-      :event_type => event["eventType"],
+      :event_type => map_event_type(event["eventType"]),
       :source     => "AMAZON",
-      :message    => event["configurationItemDiff"],
+      :message    => format_message(event),
       :timestamp  => event["notificationCreationTime"],
       :full_data  => event,
       :ems_id     => ems_id


### PR DESCRIPTION
The AWS_EC2_Instance events have their own automate [events](https://github.com/ManageIQ/manageiq/tree/3921e87915b5a69937b9d4a70bb24ab71b97c165/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Amazon.class) connected, which trigger a refresh.

Other Events, such as a creation of an Elastic IP would not trigger a refresh.
On the other hand [ConfigurationItemChangeNotification](https://github.com/ManageIQ/manageiq/blob/3921e87915b5a69937b9d4a70bb24ab71b97c165/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Amazon.class/configurationitemchangenotification.yaml) is not used as a event_type.

So I rewrite all events that are _not_ AWS_EC2_Instance_.* to ConfigurationItemChangeNotification in order to trigger a refresh.

Here is a snapshot of what happens, when you setup a new Instance and EIP 
```ruby
irb(main):003:0> pp EmsEvent.where(source: 'AMAZON').map(&:event_type)
["AWS_EC2_VPC_UPDATE",
 "AWS_EC2_EIP_CREATE",
 "AWS_EC2_VPC_UPDATE",
 "AWS_EC2_NetworkInterface_CREATE",
 "AWS_EC2_SecurityGroup_UPDATE",
 "AWS_EC2_Subnet_UPDATE",
 "AWS_EC2_Instance_CREATE",
 "AWS_EC2_SecurityGroup_CREATE",
 "AWS_EC2_Instance_UPDATE",
 "AWS_EC2_EIP_CREATE",
 "AWS_EC2_NetworkInterface_UPDATE"]
```

All of the above, which are not `AWS_EC2_Instance_*` would be `ConfigurationItemChangeNotification`

Note the **Event Type** in the screenshot. I'm now prefixing the **Message** with the constructed AWS_<Resource>_<Action> and only display the change hash if present.

![image](https://cloud.githubusercontent.com/assets/161888/21346161/6ad4f244-c6a3-11e6-822a-a00e736b28dc.png)

fixes https://github.com/ManageIQ/manageiq/issues/10591
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1371222


