### PR TITLE
fix connection of events to ems_ref

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
@@ -49,7 +49,7 @@ module ManageIQ::Providers::Amazon::CloudManager::EventParser
   def self.parse_vm_ref(event)
     resource_type = event["configurationItem"]["resourceType"]
     # other ways to find the VM?
-    event.fetch_path("configurationItem", "resourceId") if resource_type == "Aws::EC2::Instance"
+    event.fetch_path("configurationItem", "resourceId") if resource_type == "AWS::EC2::Instance"
   end
 
   def self.parse_availability_zone_ref(event)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
+  context ".event_to_hash" do
+    it "parses vm_ems_ref into event" do
+      message = JSON.parse(File.read(File.join(File.dirname(__FILE__), "/event_catcher/sqs_message.json")))
+      event   = JSON.parse(message['Message'])
+      event["eventType"] = 'AWS_EC2_Instance_UPDATE'
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-06199fba')
+    end
+  end
+end


### PR DESCRIPTION
I guess since the switch to aws-sdk-v2 we are not associating events to vms anymore 😢 
But nobody noticed... What does that mean?

added a test to make sure it does not happen again

@blomquisg euwe ? But there is no BZ for it...