### PR TITLE
Pull default rubocop configuration from ManageIQ/guides

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -36,10 +36,10 @@ engines:
     config: '.rubocop_cc.yml'
 prepare:
   fetch:
-  - url: "https://raw.githubusercontent.com/ManageIQ/manageiq/master/.rubocop_base.yml"
+  - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"
     path: ".rubocop_base.yml"
-  - url: "https://raw.githubusercontent.com/ManageIQ/manageiq/master/.rubocop_cc.yml"
-    path: ".rubocop_manageiq_cc.yml"
+  - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml"
+    path: ".rubocop_cc_base.yml"
 ratings:
   paths:
   - Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/manageiq/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
 # put all local rubocop config into .rubocop_local.yml as it will be loaded by .rubocop_cc.yml as well
 - .rubocop_local.yml

--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -1,4 +1,5 @@
 inherit_from:
 # this is downloaded by .codeclimate.yml
-- .rubocop_cc_mangeiq.yml
+- .rubocop_base.yml
+- .rubocop_cc_base.yml
 - .rubocop_local.yml


### PR DESCRIPTION
Depends on ManageIQ/guides#178