### PR TITLE
[EUWE] Fill guest_os correctly

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -166,8 +166,12 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     uid      = image.image_id
     location = image.image_location
     guest_os = (image.platform == "windows") ? "windows" : "linux"
+    if guest_os == "linux"
+      guest_os = OperatingSystem.normalize_os_name(location)
+      guest_os = "linux" if guest_os == "unknown"
+    end
 
-    name     = get_from_tags(image, :name)
+    name = get_from_tags(image, :name)
     name ||= image.name
     name ||= $1 if location =~ /^(.+?)(\.(image|img))?\.manifest\.xml$/
     name ||= uid


### PR DESCRIPTION
Fill guest_os correctly, inferring it from Image location

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1393547


Clean cherrypick of https://github.com/ManageIQ/manageiq-providers-amazon/pull/84/commits/8424752f464cb2691775cb457457b2d39c608403

from the PR https://github.com/ManageIQ/manageiq-providers-amazon/pull/84

the other commit of the PR is not relevant