### PR TITLE
Introduce Amazon Block Storage  Manager (EBS)

### DIFF
--- a/app/models/manageiq/providers/amazon/block_storage_manager.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager.rb
@@ -1,0 +1,37 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager < ManageIQ::Providers::StorageManager
+  require_nested :RefreshParser
+  require_nested :RefreshWorker
+  require_nested :Refresher
+
+  include ManageIQ::Providers::Amazon::ManagerMixin
+  include ManageIQ::Providers::StorageManager::BlockMixin
+
+  delegate :availability_zones,
+           :authentication_check,
+           :authentication_status,
+           :authentications,
+           :authentication_for_summary,
+           :zone,
+           :connect,
+           :verify_credentials,
+           :with_provider_connection,
+           :address,
+           :ip_address,
+           :hostname,
+           :default_endpoint,
+           :endpoints,
+           :to        => :parent_manager,
+           :allow_nil => true
+
+  def self.ems_type
+    @ems_type ||= "ec2_block_storage".freeze
+  end
+
+  def self.description
+    @description ||= "Amazon EBS".freeze
+  end
+
+  def self.hostname_required?
+    false
+  end
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/cloud_volume.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolume < ::CloudVolume
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/cloud_volume_snapshot.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolumeSnapshot < ::CloudVolumeSnapshot
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/refresh_parser.rb
@@ -1,0 +1,76 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::RefreshParser
+  include ManageIQ::Providers::Amazon::RefreshHelperMethods
+
+  def initialize(ems, options = nil)
+    @ems        = ems
+    @aws_ec2    = ems.connect
+    @data       = {}
+    @data_index = {}
+    @options    = options || {}
+  end
+
+  def ems_inv_to_hashes
+    log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
+
+    $aws_log.info("#{log_header}...")
+    get_volumes
+    get_snapshots
+
+    $aws_log.info("#{log_header}...Complete")
+
+    @data
+  end
+
+  def get_volumes
+    volumes = @aws_ec2.client.describe_volumes[:volumes]
+    process_collection(volumes, :cloud_volumes) { |volume| parse_volume(volume) }
+  end
+
+  def get_snapshots
+    snapshots = @aws_ec2.client.describe_snapshots(:owner_ids => [:self])[:snapshots]
+    process_collection(snapshots, :cloud_volume_snapshots) { |snap| parse_snapshot(snap) }
+  end
+
+  def parse_volume(volume)
+    uid = volume.volume_id
+
+    new_result = {
+      :type          => self.class.volume_type,
+      :ems_ref       => uid,
+      :name          => uid,
+      :status        => volume.state,
+      :creation_time => volume.create_time,
+      :volume_type   => volume.volume_type,
+      :size          => volume.size.to_i.gigabytes
+    }
+
+    return uid, new_result
+  end
+
+  def parse_snapshot(snap)
+    uid = snap.snapshot_id
+
+    new_result = {
+      :ems_ref       => uid,
+      :type          => self.class.volume_snapshot_type,
+      :name          => snap.snapshot_id,
+      :status        => snap.state,
+      :creation_time => snap.start_time,
+      :description   => snap.description,
+      :size          => snap.volume_size,
+      :volume        => @data_index.fetch_path(:cloud_volumes, snap.volume_id)
+    }
+
+    return uid, new_result
+  end
+
+  class << self
+    def volume_type
+      "ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolume"
+    end
+
+    def volume_snapshot_type
+      "ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolumeSnapshot"
+    end
+  end
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/refresh_parser_inventory_object.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/refresh_parser_inventory_object.rb
@@ -1,0 +1,63 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::RefreshParserInventoryObject < ::ManagerRefresh::RefreshParserInventoryObject
+  include ManageIQ::Providers::Amazon::RefreshHelperMethods
+
+  def populate_inventory_collections
+    log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{inventory.ems.name}] id: [#{inventory.ems.id}]"
+
+    $aws_log.info("#{log_header}...}")
+    get_volumes
+    get_snapshots
+    $aws_log.info("#{log_header}...Complete")
+
+    inventory_collections
+  end
+
+  private
+
+  def get_volumes
+    process_inventory_collection(inventory.cloud_volumes, :cloud_volumes) { |volume| parse_volume(volume) }
+  end
+
+  def get_snapshots
+    process_inventory_collection(inventory.cloud_volume_snapshots, :cloud_volume_snapshots) { |snap| parse_snapshot(snap) }
+  end
+
+  def parse_volume(volume)
+    uid = volume['volume_id']
+
+    {
+      :type          => self.class.volume_type,
+      :ems_ref       => uid,
+      :name          => uid,
+      :status        => volume['state'],
+      :creation_time => volume['create_time'],
+      :volume_type   => volume['volume_type'],
+      :size          => volume['size'].to_i.gigabytes
+    }
+  end
+
+  def parse_snapshot(snap)
+    uid = snap['snapshot_id']
+
+    {
+      :ems_ref       => uid,
+      :type          => self.class.volume_snapshot_type,
+      :name          => snap['snapshot_id'],
+      :status        => snap['state'],
+      :creation_time => snap['start_time'],
+      :description   => snap['description'],
+      :size          => snap['volume_size'],
+      :cloud_volume  => inventory_collections[:cloud_volumes].lazy_find(snap['volume_id'])
+    }
+  end
+
+  class << self
+    def volume_type
+      "ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolume"
+    end
+
+    def volume_snapshot_type
+      "ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolumeSnapshot"
+    end
+  end
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/refresh_worker.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::RefreshWorker < ::MiqEmsRefreshWorker
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Amazon::BlockStorageManager
+  end
+
+  def self.settings_name
+    :ems_refresh_worker_amazon_block_storage
+  end
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/refresh_worker/runner.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::RefreshWorker::Runner <
+  ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/refresher.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/refresher.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Amazon::BlockStorageManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+  include ::EmsRefresh::Refreshers::EmsRefresherMixin
+
+  def parse_legacy_inventory(ems)
+    ManageIQ::Providers::Amazon::BlockStorageManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+  end
+end

--- a/app/models/manageiq/providers/amazon/block_storage_manager/refresher.rb
+++ b/app/models/manageiq/providers/amazon/block_storage_manager/refresher.rb
@@ -1,7 +1,43 @@
-class ManageIQ::Providers::Amazon::BlockStorageManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-  include ::EmsRefresh::Refreshers::EmsRefresherMixin
+module ManageIQ::Providers
+  class Amazon::BlockStorageManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+    include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-  def parse_legacy_inventory(ems)
-    ManageIQ::Providers::Amazon::BlockStorageManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+    def collect_inventory_for_targets(ems, targets)
+      targets_with_data = targets.collect do |target|
+        target_name = target.try(:name) || target.try(:event_type)
+
+        _log.info "Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]..."
+
+        inventory = if refresher_options.try(:[], :inventory_object_refresh)
+                      ManageIQ::Providers::Amazon::Inventory::Factory.inventory(ems, target)
+                    else
+                      nil
+                    end
+
+        _log.info "Filtering inventory...Complete"
+        [target, inventory]
+      end
+
+      targets_with_data
+    end
+
+    def parse_targeted_inventory(ems, _target, inventory)
+      log_header = format_ems_for_logging(ems)
+      _log.debug "#{log_header} Parsing inventory..."
+      hashes, = Benchmark.realtime_block(:parse_inventory) do
+        if refresher_options.try(:[], :inventory_object_refresh)
+          ManageIQ::Providers::Amazon::BlockStorageManager::RefreshParserInventoryObject.new(inventory).populate_inventory_collections
+        else
+          ManageIQ::Providers::Amazon::BlockStorageManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+        end
+      end
+      _log.debug "#{log_header} Parsing inventory...Complete"
+
+      hashes
+    end
+
+    def post_process_refresh_classes
+      []
+    end
   end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -58,8 +58,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
            :to        => :block_storage_manager,
            :allow_nil => true
 
-  before_create :ensure_managers,
-                :ensure_block_storage_managers
+  before_create :ensure_managers
 
   supports :provisioning
   supports :regions
@@ -70,14 +69,11 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     network_manager.name            = "#{name} Network Manager"
     network_manager.zone_id         = zone_id
     network_manager.provider_region = provider_region
-  end
 
-  def ensure_block_storage_managers
     build_block_storage_manager unless block_storage_manager
     block_storage_manager.name            = "#{name} Block Storage Manager"
     block_storage_manager.zone_id         = zone_id
     block_storage_manager.provider_region = provider_region
-    true
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/amazon/inventory/factory.rb
+++ b/app/models/manageiq/providers/amazon/inventory/factory.rb
@@ -14,6 +14,8 @@ class ManageIQ::Providers::Amazon::Inventory::Factory
         ManageIQ::Providers::Amazon::Inventory::Targets::CloudManager.new(ems, target)
       when ManageIQ::Providers::Amazon::NetworkManager
         ManageIQ::Providers::Amazon::Inventory::Targets::NetworkManager.new(ems, target)
+      when ManageIQ::Providers::Amazon::BlockStorageManager
+        ManageIQ::Providers::Amazon::Inventory::Targets::BlockStorageManager.new(ems, target)
       else
         ManageIQ::Providers::Amazon::Inventory::Targets::CloudManager.new(ems, target)
       end

--- a/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
+++ b/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
@@ -278,4 +278,20 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
 
     init_data(::LoadBalancerHealthCheckMember, attributes, extra_attributes)
   end
+
+  def cloud_volumes_init_data(extra_attributes = {})
+    attributes = {
+      :association => :cloud_volumes,
+    }
+
+    init_data(::ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolume, attributes, extra_attributes)
+  end
+
+  def cloud_volume_snapshots_init_data(extra_attributes = {})
+    attributes = {
+      :association => :cloud_volume_snapshots,
+    }
+
+    init_data(::ManageIQ::Providers::Amazon::BlockStorageManager::CloudVolumeSnapshot, attributes, extra_attributes)
+  end
 end

--- a/app/models/manageiq/providers/amazon/inventory/targets/block_storage_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/targets/block_storage_manager.rb
@@ -1,0 +1,13 @@
+class ManageIQ::Providers::Amazon::Inventory::Targets::BlockStorageManager < ManageIQ::Providers::Amazon::Inventory::Targets
+  def initialize_inventory_collections
+    add_inventory_collections(%i(cloud_volumes cloud_volume_snapshots))
+  end
+
+  def cloud_volumes
+    HashCollection.new(aws_ec2.client.describe_volumes[:volumes])
+  end
+
+  def cloud_volume_snapshots
+    HashCollection.new(aws_ec2.client.describe_snapshots(:owner_ids => [:self])[:snapshots])
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,3 +43,4 @@
       :ems_refresh_worker:
         :ems_refresh_worker_amazon: {}
         :ems_refresh_worker_amazon_network: {}
+        :ems_refresh_worker_amazon_block_storage: {}

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -33,7 +33,7 @@ module AwsRefresherSpecCommon
       :cloud_subnet                  => 10,
       :custom_attribute              => 0,
       :disk                          => 10,
-      :ext_management_system         => 2,
+      :ext_management_system         => 3,
       :firewall_rule                 => 119,
       :flavor                        => 56,
       :floating_ip                   => 12,

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -30,6 +30,8 @@ module AwsStubs
       :security_group_count                            => scaling * 20,
       :inbound_firewall_rule_per_security_group_count  => scaling * 5,
       :outbound_firewall_rule_per_security_group_count => scaling * 5,
+      :cloud_volume_count                              => scaling * 5,
+      :cloud_volume_snapshot_count                     => scaling * 5,
     }
   end
 
@@ -355,5 +357,37 @@ module AwsStubs
       mocked_instance_healths << health.to_h
     end
     mocked_instance_healths
+  end
+
+  def mocked_cloud_volumes
+    mocked_cloud_volumes = []
+    test_counts[:cloud_volume_count].times do |i|
+      mocked_cloud_volumes << {
+        :availability_zone => "us-east-1e",
+        :create_time       => Time.now,
+        :size              => i,
+        :state             => "in-use",
+        :volume_id         => "volume_id_#{i}",
+        :volume_type       => "standard"
+      }
+    end
+
+    { :volumes => mocked_cloud_volumes }
+  end
+
+  def mocked_cloud_volume_snapshots
+    mocked_cloud_volume_snapshots = []
+    test_counts[:cloud_volume_snapshot_count].times do |i|
+      mocked_cloud_volume_snapshots << {
+        :snapshot_id => "snapshot_id_#{i}",
+        :description => "snapshot_desc_#{i}",
+        :start_time  => Time.now,
+        :volume_size => i,
+        :state       => "completed",
+        :volume_id   => "volume_id_#{i}",
+      }
+    end
+
+    { :snapshots => mocked_cloud_volume_snapshots }
   end
 end

--- a/spec/models/manageiq/providers/amazon/block_storage_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/block_storage_manager/stubbed_refresher_spec.rb
@@ -13,10 +13,10 @@ describe ManageIQ::Providers::Amazon::BlockStorageManager::Refresher do
     end
 
     # Test all kinds of refreshes, DTO refresh, DTO with batch saving and the original refresh
-    [{:dto_refresh => true},
-     {:dto_saving_strategy => :recursive, :dto_refresh => true},
-     {:dto_refresh => false}
-    ].each do |settings|
+    [{:inventory_object_refresh => true},
+     {:inventory_object_saving_strategy => :recursive, :inventory_object_refresh => true},
+     {:inventory_object_refresh => false}
+     ].each do |settings|
       context "with settings #{settings}" do
         before :each do
           allow(Settings.ems_refresh).to receive(:ec2_block_storage).and_return(settings)

--- a/spec/models/manageiq/providers/amazon/block_storage_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/block_storage_manager/stubbed_refresher_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../aws_helper'
 require_relative '../aws_stubs'
 
-describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
+describe ManageIQ::Providers::Amazon::BlockStorageManager::Refresher do
   include AwsStubs
 
   describe "refresh" do
@@ -13,13 +13,13 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
     end
 
     # Test all kinds of refreshes, DTO refresh, DTO with batch saving and the original refresh
-    [{:inventory_object_refresh => true},
-     {:inventory_object_saving_strategy => :recursive, :inventory_object_refresh => true},
-     {:inventory_object_refresh => false}
+    [{:dto_refresh => true},
+     {:dto_saving_strategy => :recursive, :dto_refresh => true},
+     {:dto_refresh => false}
     ].each do |settings|
       context "with settings #{settings}" do
         before :each do
-          allow(Settings.ems_refresh).to receive(:ec2_network).and_return(settings)
+          allow(Settings.ems_refresh).to receive(:ec2_block_storage).and_return(settings)
         end
 
         it "2 refreshes, first creates all entities, second updates all entitites" do
@@ -65,7 +65,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
     @ems.reload
 
     with_aws_stubbed(stub_responses) do
-      EmsRefresh.refresh(@ems.network_manager)
+      EmsRefresh.refresh(@ems.block_storage_manager)
     end
 
     @ems.reload
@@ -76,39 +76,14 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
   def stub_responses
     {
-      :elasticloadbalancing => {
-        :describe_load_balancers  => {
-          :load_balancer_descriptions => mocked_load_balancers
-        },
-        :describe_instance_health => {
-          :instance_states => mocked_instance_health
-        }
-      },
-      :ec2                  => {
-        :describe_regions            => {
-          :regions => [
-            {:region_name => 'us-east-1'},
-            {:region_name => 'us-west-1'},
-          ]
-        },
-        :describe_instances          => mocked_instances,
-        :describe_vpcs               => mocked_vpcs,
-        :describe_subnets            => mocked_subnets,
-        :describe_security_groups    => mocked_security_groups,
-        :describe_network_interfaces => mocked_network_ports,
-        :describe_addresses          => mocked_floating_ips
+      :ec2 => {
+        :describe_volumes   => mocked_cloud_volumes,
+        :describe_snapshots => mocked_cloud_volume_snapshots,
       }
     }
   end
 
   def expected_table_counts
-    firewall_rule_count = test_counts[:security_group_count] *
-      (test_counts[:outbound_firewall_rule_per_security_group_count] +
-        test_counts[:outbound_firewall_rule_per_security_group_count])
-
-    floating_ip_count = test_counts[:floating_ip_count] + test_counts[:network_port_count] +
-      test_counts[:instance_ec2_count]
-
     {
       :auth_private_key                  => 0,
       :ext_management_system             => 3,
@@ -131,24 +106,24 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
       :orchestration_stack_parameter     => 0,
       :orchestration_stack_output        => 0,
       :orchestration_stack_resource      => 0,
-      :security_group                    => test_counts[:security_group_count],
-      :firewall_rule                     => firewall_rule_count,
-      :network_port                      => test_counts[:instance_ec2_count] + test_counts[:network_port_count],
-      :cloud_network                     => test_counts[:vpc_count],
-      :floating_ip                       => floating_ip_count,
+      :security_group                    => 0,
+      :firewall_rule                     => 0,
+      :network_port                      => 0,
+      :cloud_network                     => 0,
+      :floating_ip                       => 0,
       :network_router                    => 0,
-      :cloud_subnet                      => test_counts[:subnet_count],
+      :cloud_subnet                      => 0,
       :custom_attribute                  => 0,
-      :load_balancer                     => test_counts[:load_balancer_count],
-      :load_balancer_pool                => test_counts[:load_balancer_count],
-      :load_balancer_pool_member         => test_counts[:load_balancer_instances_count],
-      :load_balancer_pool_member_pool    => test_counts[:load_balancer_count] * test_counts[:load_balancer_instances_count],
-      :load_balancer_listener            => test_counts[:load_balancer_count],
-      :load_balancer_listener_pool       => test_counts[:load_balancer_count],
-      :load_balancer_health_check        => test_counts[:load_balancer_count],
-      :load_balancer_health_check_member => test_counts[:load_balancer_count] * test_counts[:load_balancer_instances_count],
-      :cloud_volume                      => 0,
-      :cloud_volume_snapshot             => 0,
+      :load_balancer                     => 0,
+      :load_balancer_pool                => 0,
+      :load_balancer_pool_member         => 0,
+      :load_balancer_pool_member_pool    => 0,
+      :load_balancer_listener            => 0,
+      :load_balancer_listener_pool       => 0,
+      :load_balancer_health_check        => 0,
+      :load_balancer_health_check_member => 0,
+      :cloud_volume                      => test_counts[:cloud_volume_count],
+      :cloud_volume_snapshot             => test_counts[:cloud_volume_snapshot_count],
     }
   end
 
@@ -199,26 +174,13 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
   end
 
   def assert_ems
-    ems = @ems.network_manager
+    ems = @ems.block_storage_manager
 
-    expect(ems).to have_attributes(
-                     :api_version => nil, # TODO: Should be 3.0
-                     :uid_ems     => nil
-                   )
+    expect(ems).to have_attributes(:api_version => nil, # TODO: Should be 3.0
+                                   :uid_ems     => nil)
 
-    expect(ems.flavors.size).to eql(expected_table_counts[:flavor])
     expect(ems.availability_zones.size).to eql(expected_table_counts[:availability_zone])
-    expect(ems.vms_and_templates.size).to eql(expected_table_counts[:vm_or_template])
-    expect(ems.security_groups.size).to eql(expected_table_counts[:security_group])
-    expect(ems.network_ports.size).to eql(expected_table_counts[:network_port])
-    expect(ems.cloud_networks.size).to eql(expected_table_counts[:cloud_network])
-    expect(ems.floating_ips.size).to eql(expected_table_counts[:floating_ip])
-    expect(ems.network_routers.size).to eql(expected_table_counts[:network_router])
-    expect(ems.cloud_subnets.size).to eql(expected_table_counts[:cloud_subnet])
-    expect(ems.miq_templates.size).to eq(expected_table_counts[:miq_template])
-
-    expect(ems.orchestration_stacks.size).to eql(expected_table_counts[:orchestration_stack])
-
-    expect(ems.load_balancers.size).to eql(expected_table_counts[:load_balancer])
+    expect(ems.cloud_volumes.size).to eql(expected_table_counts[:cloud_volume])
+    expect(ems.cloud_volume_snapshots.size).to eql(expected_table_counts[:cloud_volume_snapshot])
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_table_counts
-    expect(ExtManagementSystem.count).to eq(2)
+    expect(ExtManagementSystem.count).to eq(3)
     expect(Flavor.count).to eq(56)
     expect(AvailabilityZone.count).to eq(3)
     expect(FloatingIp.count).to eq(3)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -132,7 +132,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
     {
       :auth_private_key                  => test_counts[:key_pair_count],
-      :ext_management_system             => 2,
+      :ext_management_system             => 3,
       # TODO(lsmola) collect all flavors for original refresh
       :flavor                            => @inventory_object_settings[:inventory_object_refresh] ? 57 : 56,
       :availability_zone                 => 5,
@@ -169,6 +169,8 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
       :load_balancer_listener_pool       => 0,
       :load_balancer_health_check        => 0,
       :load_balancer_health_check_member => 0,
+      :cloud_volume                      => 0,
+      :cloud_volume_snapshot             => 0,
     }
   end
 
@@ -211,6 +213,8 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
       :load_balancer_listener_pool       => LoadBalancerListenerPool.count,
       :load_balancer_health_check        => LoadBalancerHealthCheck.count,
       :load_balancer_health_check_member => LoadBalancerHealthCheckMember.count,
+      :cloud_volume                      => CloudVolume.count,
+      :cloud_volume_snapshot             => CloudVolumeSnapshot.count,
     }
 
     expect(actual).to eq expected_table_counts


### PR DESCRIPTION
This commit sets up the core structure of the new AWS EC2 block storage
manager. It provides just the basic stubs and tests that are to be
extended to allow for complete management of Amazon block storage

The refresher collects data about existing volumes and private
snapshots. Volumes are not yet linked to disks of virtual machines
collected by the cloud manager.

Depends on [Add storage manager mixins](https://github.com/ManageIQ/manageiq/pull/13384) PR from core repo.

@miq-bot add_label enhancement