### PR TITLE
Introduce Amazon S3 StorageManager

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory.rb
+++ b/app/models/manageiq/providers/amazon/inventory.rb
@@ -28,6 +28,10 @@ class ManageIQ::Providers::Amazon::Inventory
     @aws_elb ||= ems.connect(:service => :ElasticLoadBalancing)
   end
 
+  def aws_s3
+    @aws_s3 ||= ems.connect(:service => :S3)
+  end
+
   def instances
     []
   end

--- a/app/models/manageiq/providers/amazon/inventory/factory.rb
+++ b/app/models/manageiq/providers/amazon/inventory/factory.rb
@@ -16,6 +16,8 @@ class ManageIQ::Providers::Amazon::Inventory::Factory
         ManageIQ::Providers::Amazon::Inventory::Targets::NetworkManager.new(ems, target)
       when ManageIQ::Providers::Amazon::StorageManager::Ebs
         ManageIQ::Providers::Amazon::Inventory::Targets::StorageManager::Ebs.new(ems, target)
+      when ManageIQ::Providers::Amazon::StorageManager::S3
+        ManageIQ::Providers::Amazon::Inventory::Targets::StorageManager::S3.new(ems, target)
       else
         ManageIQ::Providers::Amazon::Inventory::Targets::CloudManager.new(ems, target)
       end

--- a/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
+++ b/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
@@ -294,4 +294,20 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
 
     init_data(::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot, attributes, extra_attributes)
   end
+
+  def cloud_object_store_containers_init_data(extra_attributes = {})
+    attributes = {
+      :association => :cloud_object_store_containers,
+    }
+
+    init_data(::CloudObjectStoreContainer, attributes, extra_attributes)
+  end
+
+  def cloud_object_store_objects_init_data(extra_attributes = {})
+    attributes = {
+      :association => :cloud_object_store_objects,
+    }
+
+    init_data(::CloudObjectStoreObject, attributes, extra_attributes)
+  end
 end

--- a/app/models/manageiq/providers/amazon/inventory/targets/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/targets/storage_manager/s3.rb
@@ -1,0 +1,14 @@
+class ManageIQ::Providers::Amazon::Inventory::Targets::StorageManager::S3 <
+  ManageIQ::Providers::Amazon::Inventory::Targets
+  def initialize_inventory_collections
+    add_inventory_collections(%i(cloud_object_store_containers cloud_object_store_objects))
+  end
+
+  def cloud_object_store_containers
+    HashCollection.new(aws_s3.client.list_buckets.buckets)
+  end
+
+  def cloud_object_store_objects
+    HashCollection.new([])
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -1,0 +1,36 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::StorageManager
+  require_nested :RefreshParser
+  require_nested :RefreshWorker
+  require_nested :Refresher
+
+  include ManageIQ::Providers::Amazon::ManagerMixin
+  include ManageIQ::Providers::StorageManager::ObjectMixin
+
+  delegate :authentication_check,
+           :authentication_status,
+           :authentications,
+           :authentication_for_summary,
+           :zone,
+           :connect,
+           :verify_credentials,
+           :with_provider_connection,
+           :address,
+           :ip_address,
+           :hostname,
+           :default_endpoint,
+           :endpoints,
+           :to        => :parent_manager,
+           :allow_nil => true
+
+  def self.ems_type
+    @ems_type ||= "s3".freeze
+  end
+
+  def self.description
+    @description ||= "Amazon S3".freeze
+  end
+
+  def self.hostname_required?
+    false
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
@@ -1,0 +1,53 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
+  include ManageIQ::Providers::Amazon::RefreshHelperMethods
+
+  def initialize(ems, options = nil)
+    @ems        = ems
+    @connection = ems.connect(:service => :S3)
+    @data       = {}
+    @data_index = {}
+    @options    = options || {}
+  end
+
+  def ems_inv_to_hashes
+    log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
+
+    $aws_log.info("#{log_header}...")
+    object_store
+
+    $aws_log.info("#{log_header}...Complete")
+
+    @data
+  end
+
+  def object_store
+    # TODO: change
+    buckets = @connection.client.list_buckets.buckets
+    process_collection(buckets, :cloud_object_store_containers) { |c| parse_container(c) }
+  end
+
+  def parse_container(bucket)
+    uid = bucket.name
+
+    new_result = {
+      :ems_ref => uid,
+      :key     => bucket.name
+    }
+    return uid, new_result
+  end
+
+  def parse_object(obj, bucket)
+    uid = obj.key
+
+    new_result = {
+      :ems_ref        => uid,
+      :etag           => obj.etag,
+      :last_modified  => obj.last_modified,
+      :content_length => obj.size,
+      :key            => obj.key,
+      #:content_type   => obj.content_type,
+      :container      => bucket
+    }
+    return uid, new_result
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
 
   def initialize(ems, options = nil)
     @ems        = ems
-    @connection = ems.connect(:service => :S3)
+    @aws_s3     = ems.connect(:service => :S3)
     @data       = {}
     @data_index = {}
     @options    = options || {}
@@ -21,8 +21,7 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
   end
 
   def object_store
-    # TODO: change
-    buckets = @connection.client.list_buckets.buckets
+    buckets = @aws_s3.client.list_buckets.buckets
     process_collection(buckets, :cloud_object_store_containers) { |c| parse_container(c) }
   end
 

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser_inventory_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser_inventory_object.rb
@@ -1,0 +1,30 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParserInventoryObject < ::ManagerRefresh::RefreshParserInventoryObject
+  include ManageIQ::Providers::Amazon::RefreshHelperMethods
+
+  def populate_inventory_collections
+    log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{inventory.ems.name}] id: [#{inventory.ems.id}]"
+
+    $aws_log.info("#{log_header}...}")
+    object_store
+    $aws_log.info("#{log_header}...Complete")
+
+    inventory_collections
+  end
+
+  private
+
+  def object_store
+    process_inventory_collection(
+      inventory.cloud_object_store_containers,
+      :cloud_object_store_containers
+    ) { |c| parse_container(c) }
+  end
+
+  def parse_container(bucket)
+    uid = bucket['name']
+    {
+      :ems_ref => uid,
+      :key     => bucket['name']
+    }
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker < ::MiqEmsRefreshWorker
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Amazon::StorageManager::S3
+  end
+
+  def self.settings_name
+    :ems_refresh_worker_amazon_s3
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker/runner.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker::Runner <
+  ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresher.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresher.rb
@@ -1,8 +1,39 @@
-class ManageIQ::Providers::Amazon::StorageManager::S3::Refresher <
-  ManageIQ::Providers::BaseManager::Refresher
+class ManageIQ::Providers::Amazon::StorageManager::S3::Refresher < ManageIQ::Providers::BaseManager::Refresher
   include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-  def parse_legacy_inventory(ems)
-    ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+  def collect_inventory_for_targets(ems, targets)
+    targets_with_data = targets.collect do |target|
+      target_name = target.try(:name) || target.try(:event_type)
+
+      _log.info "Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]..."
+
+      if refresher_options.try(:[], :inventory_object_refresh)
+        inventory = ManageIQ::Providers::Amazon::Inventory::Factory.inventory(ems, target)
+      end
+
+      _log.info "Filtering inventory...Complete"
+      [target, inventory]
+    end
+
+    targets_with_data
+  end
+
+  def parse_targeted_inventory(ems, _target, inventory)
+    log_header = format_ems_for_logging(ems)
+    _log.debug "#{log_header} Parsing inventory..."
+    hashes, = Benchmark.realtime_block(:parse_inventory) do
+      if refresher_options.try(:[], :inventory_object_refresh)
+        ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParserInventoryObject.new(inventory).populate_inventory_collections
+      else
+        ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+      end
+    end
+    _log.debug "#{log_header} Parsing inventory...Complete"
+
+    hashes
+  end
+
+  def post_process_refresh_classes
+    []
   end
 end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresher.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresher.rb
@@ -1,0 +1,8 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::Refresher <
+  ManageIQ::Providers::BaseManager::Refresher
+  include ::EmsRefresh::Refreshers::EmsRefresherMixin
+
+  def parse_legacy_inventory(ems)
+    ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,3 +44,4 @@
         :ems_refresh_worker_amazon: {}
         :ems_refresh_worker_amazon_network: {}
         :ems_refresh_worker_amazon_ebs_storage: {}
+        :ems_refresh_worker_amazon_s3: {}

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -33,7 +33,7 @@ module AwsRefresherSpecCommon
       :cloud_subnet                  => 10,
       :custom_attribute              => 0,
       :disk                          => 10,
-      :ext_management_system         => 3,
+      :ext_management_system         => 4,
       :firewall_rule                 => 119,
       :flavor                        => 56,
       :floating_ip                   => 12,

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -32,6 +32,7 @@ module AwsStubs
       :outbound_firewall_rule_per_security_group_count => scaling * 5,
       :cloud_volume_count                              => scaling * 5,
       :cloud_volume_snapshot_count                     => scaling * 5,
+      :s3_buckets_count                                => scaling * 5
     }
   end
 
@@ -344,6 +345,17 @@ module AwsStubs
       mocked_lbs << lb.to_h
     end
     mocked_lbs
+  end
+
+  def mocked_s3_buckets
+    mocked_s3_buckets = []
+    test_counts[:s3_buckets_count].times do |i|
+      mocked_s3_buckets << {
+        :name          => "bucket_id_#{i}",
+        :creation_date => Time.now.utc
+      }
+    end
+    mocked_s3_buckets
   end
 
   def mocked_instance_health

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   end
 
   def assert_table_counts
-    expect(ExtManagementSystem.count).to eq(3)
+    expect(ExtManagementSystem.count).to eq(4)
     expect(Flavor.count).to eq(56)
     expect(AvailabilityZone.count).to eq(3)
     expect(FloatingIp.count).to eq(3)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -132,7 +132,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
     {
       :auth_private_key                  => test_counts[:key_pair_count],
-      :ext_management_system             => 3,
+      :ext_management_system             => 4,
       # TODO(lsmola) collect all flavors for original refresh
       :flavor                            => @inventory_object_settings[:inventory_object_refresh] ? 57 : 56,
       :availability_zone                 => 5,

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
@@ -86,7 +86,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
   def expected_table_counts
     {
       :auth_private_key                  => 0,
-      :ext_management_system             => 3,
+      :ext_management_system             => 4,
       :flavor                            => 0,
       :availability_zone                 => 0,
       :vm_or_template                    => 0,

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -12,13 +12,13 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)
     end
 
-    # Test all kinds of refreshes, DTO refresh, DTO with batch saving and the original refresh
-    [{:dto_refresh => true},
-     {:dto_saving_strategy => :recursive, :dto_refresh => true},
-     {:dto_refresh => false}].each do |settings|
+    # Test all kinds of refreshes
+    [{:inventory_object_refresh => true},
+     {:inventory_object_saving_strategy => :recursive, :inventory_object_refresh => true},
+     {:inventory_object_refresh => false}].each do |settings|
       context "with settings #{settings}" do
         before :each do
-          allow(Settings.ems_refresh).to receive(:s3_bucket).and_return(settings)
+          allow(Settings.ems_refresh).to receive(:s3).and_return(settings)
         end
 
         it "2 refreshes, first creates all entities, second updates all entitites" do

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -1,7 +1,7 @@
-require_relative '../aws_helper'
-require_relative '../aws_stubs'
+require_relative '../../aws_helper'
+require_relative '../../aws_stubs'
 
-describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
+describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
   include AwsStubs
 
   describe "refresh" do
@@ -13,13 +13,12 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
     end
 
     # Test all kinds of refreshes, DTO refresh, DTO with batch saving and the original refresh
-    [{:inventory_object_refresh => true},
-     {:inventory_object_saving_strategy => :recursive, :inventory_object_refresh => true},
-     {:inventory_object_refresh => false}
-    ].each do |settings|
+    [{:dto_refresh => true},
+     {:dto_saving_strategy => :recursive, :dto_refresh => true},
+     {:dto_refresh => false}].each do |settings|
       context "with settings #{settings}" do
         before :each do
-          allow(Settings.ems_refresh).to receive(:ec2_network).and_return(settings)
+          allow(Settings.ems_refresh).to receive(:s3_bucket).and_return(settings)
         end
 
         it "2 refreshes, first creates all entities, second updates all entitites" do
@@ -65,9 +64,8 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
     @ems.reload
 
     with_aws_stubbed(stub_responses) do
-      EmsRefresh.refresh(@ems.network_manager)
+      EmsRefresh.refresh(@ems.s3_storage_manager)
     end
-
     @ems.reload
 
     assert_table_counts
@@ -76,39 +74,15 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
   def stub_responses
     {
-      :elasticloadbalancing => {
-        :describe_load_balancers  => {
-          :load_balancer_descriptions => mocked_load_balancers
-        },
-        :describe_instance_health => {
-          :instance_states => mocked_instance_health
+      :s3 => {
+        :list_buckets => {
+          :buckets => mocked_s3_buckets
         }
-      },
-      :ec2                  => {
-        :describe_regions            => {
-          :regions => [
-            {:region_name => 'us-east-1'},
-            {:region_name => 'us-west-1'},
-          ]
-        },
-        :describe_instances          => mocked_instances,
-        :describe_vpcs               => mocked_vpcs,
-        :describe_subnets            => mocked_subnets,
-        :describe_security_groups    => mocked_security_groups,
-        :describe_network_interfaces => mocked_network_ports,
-        :describe_addresses          => mocked_floating_ips
       }
     }
   end
 
   def expected_table_counts
-    firewall_rule_count = test_counts[:security_group_count] *
-      (test_counts[:outbound_firewall_rule_per_security_group_count] +
-        test_counts[:outbound_firewall_rule_per_security_group_count])
-
-    floating_ip_count = test_counts[:floating_ip_count] + test_counts[:network_port_count] +
-      test_counts[:instance_ec2_count]
-
     {
       :auth_private_key                  => 0,
       :ext_management_system             => 4,
@@ -131,24 +105,23 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
       :orchestration_stack_parameter     => 0,
       :orchestration_stack_output        => 0,
       :orchestration_stack_resource      => 0,
-      :security_group                    => test_counts[:security_group_count],
-      :firewall_rule                     => firewall_rule_count,
-      :network_port                      => test_counts[:instance_ec2_count] + test_counts[:network_port_count],
-      :cloud_network                     => test_counts[:vpc_count],
-      :floating_ip                       => floating_ip_count,
+      :security_group                    => 0,
+      :firewall_rule                     => 0,
+      :network_port                      => 0,
+      :cloud_network                     => 0,
+      :floating_ip                       => 0,
       :network_router                    => 0,
-      :cloud_subnet                      => test_counts[:subnet_count],
+      :cloud_subnet                      => 0,
       :custom_attribute                  => 0,
-      :load_balancer                     => test_counts[:load_balancer_count],
-      :load_balancer_pool                => test_counts[:load_balancer_count],
-      :load_balancer_pool_member         => test_counts[:load_balancer_instances_count],
-      :load_balancer_pool_member_pool    => test_counts[:load_balancer_count] * test_counts[:load_balancer_instances_count],
-      :load_balancer_listener            => test_counts[:load_balancer_count],
-      :load_balancer_listener_pool       => test_counts[:load_balancer_count],
-      :load_balancer_health_check        => test_counts[:load_balancer_count],
-      :load_balancer_health_check_member => test_counts[:load_balancer_count] * test_counts[:load_balancer_instances_count],
-      :cloud_volume                      => 0,
-      :cloud_volume_snapshot             => 0,
+      :load_balancer                     => 0,
+      :load_balancer_pool                => 0,
+      :load_balancer_pool_member         => 0,
+      :load_balancer_pool_member_pool    => 0,
+      :load_balancer_listener            => 0,
+      :load_balancer_listener_pool       => 0,
+      :load_balancer_health_check        => 0,
+      :load_balancer_health_check_member => 0,
+      :cloud_object_store_containers     => test_counts[:s3_buckets_count]
     }
   end
 
@@ -191,34 +164,17 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
       :load_balancer_listener_pool       => LoadBalancerListenerPool.count,
       :load_balancer_health_check        => LoadBalancerHealthCheck.count,
       :load_balancer_health_check_member => LoadBalancerHealthCheckMember.count,
-      :cloud_volume                      => CloudVolume.count,
-      :cloud_volume_snapshot             => CloudVolumeSnapshot.count,
+      :cloud_object_store_containers     => CloudObjectStoreContainer.count
     }
 
     expect(actual).to eq expected_table_counts
   end
 
   def assert_ems
-    ems = @ems.network_manager
+    ems = @ems.s3_storage_manager
+    expect(ems).to have_attributes(:api_version => nil,
+                                   :uid_ems     => nil)
 
-    expect(ems).to have_attributes(
-                     :api_version => nil, # TODO: Should be 3.0
-                     :uid_ems     => nil
-                   )
-
-    expect(ems.flavors.size).to eql(expected_table_counts[:flavor])
-    expect(ems.availability_zones.size).to eql(expected_table_counts[:availability_zone])
-    expect(ems.vms_and_templates.size).to eql(expected_table_counts[:vm_or_template])
-    expect(ems.security_groups.size).to eql(expected_table_counts[:security_group])
-    expect(ems.network_ports.size).to eql(expected_table_counts[:network_port])
-    expect(ems.cloud_networks.size).to eql(expected_table_counts[:cloud_network])
-    expect(ems.floating_ips.size).to eql(expected_table_counts[:floating_ip])
-    expect(ems.network_routers.size).to eql(expected_table_counts[:network_router])
-    expect(ems.cloud_subnets.size).to eql(expected_table_counts[:cloud_subnet])
-    expect(ems.miq_templates.size).to eq(expected_table_counts[:miq_template])
-
-    expect(ems.orchestration_stacks.size).to eql(expected_table_counts[:orchestration_stack])
-
-    expect(ems.load_balancers.size).to eql(expected_table_counts[:load_balancer])
+    expect(ems.cloud_object_store_containers.size).to eql(expected_table_counts[:cloud_object_store_containers])
   end
 end


### PR DESCRIPTION
Similarly to #101 this commit sets up the core structure of the new AWS S3 manager. 
It provides just the basic stubs and tests that are to be extended.

The refresher collects data about existing buckets.

@miq-bot add_label enhancement