### PR TITLE
dont run bundle twice on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '9.4'
-before_install: bin/setup
+install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:


### PR DESCRIPTION
without an install script travis defaults to bundle install
because there is a Gemfile in the project root.
This effectively runs bundle twice, because we also run it from
bin/setup