### PR TITLE
Add links between cloud volumes and base snapshots

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
@@ -15,8 +15,9 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
     $aws_log.info("#{log_header}...")
     get_volumes
     get_snapshots
-
     $aws_log.info("#{log_header}...Complete")
+
+    link_storage_associations
 
     @data
   end
@@ -41,7 +42,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
       :status        => volume.state,
       :creation_time => volume.create_time,
       :volume_type   => volume.volume_type,
-      :size          => volume.size.to_i.gigabytes
+      :size          => volume.size.to_i.gigabytes,
+      :snapshot_uid  => volume.snapshot_id
     }
 
     return uid, new_result
@@ -57,11 +59,19 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
       :status        => snap.state,
       :creation_time => snap.start_time,
       :description   => snap.description,
-      :size          => snap.volume_size,
+      :size          => snap.volume_size.to_i.gigabytes,
       :volume        => @data_index.fetch_path(:cloud_volumes, snap.volume_id)
     }
 
     return uid, new_result
+  end
+
+  def link_storage_associations
+    @data[:cloud_volumes].each do |cv|
+      base_snapshot_uid = cv.delete(:snapshot_uid)
+      base_snapshot = @data_index.fetch_path(:cloud_volume_snapshots, base_snapshot_uid)
+      cv[:base_snapshot] = base_snapshot unless base_snapshot.nil?
+    end if @data[:cloud_volumes]
   end
 
   class << self

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser_inventory_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser_inventory_object.rb
@@ -37,7 +37,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParserInventoryOb
       :status                => volume['state'],
       :creation_time         => volume['create_time'],
       :volume_type           => volume['volume_type'],
-      :size                  => volume['size'].to_i.gigabytes
+      :size                  => volume['size'].to_i.gigabytes,
+      :base_snapshot         => inventory_collections[:cloud_volume_snapshots].lazy_find(volume['snapshot_id'])
     }
   end
 
@@ -52,7 +53,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParserInventoryOb
       :status                => snap['state'],
       :creation_time         => snap['start_time'],
       :description           => snap['description'],
-      :size                  => snap['volume_size'],
+      :size                  => snap['volume_size'].to_i.gigabytes,
       :cloud_volume          => inventory_collections[:cloud_volumes].lazy_find(snap['volume_id'])
     }
   end

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -380,7 +380,8 @@ module AwsStubs
         :size              => i,
         :state             => "in-use",
         :volume_id         => "volume_id_#{i}",
-        :volume_type       => "standard"
+        :volume_type       => "standard",
+        :snapshot_id       => "snapshot_id_#{i}"
       }
     end
 


### PR DESCRIPTION
This patch adds the ability to identify base snapshot, i.e. the snapshot
that was used to create a specific volume. Both legacy parser and
inventory object parser are updated, along with the spec. The latter
adds tests for specific volume and snapshot to make sure proper values
are identified.

@miq-bot add_label enhancement