### PR TITLE
Amazon event parser for CloudWatch events

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -163,16 +163,16 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
     if event["messageType"] == "ConfigurationItemChangeNotification"
       # Aws Config Events
       event["eventType"]   = parse_event_type(event)
-      event[:event_source] = :config
+      event["event_source"] = :config
     elsif event.fetch_path("detail", "eventType") == "AwsApiCall"
       # CloudWatch with CloudTrail for API requests Events
       event["eventType"]   = event.fetch_path("detail", "eventName")
-      event[:event_source] = :cloud_watch_api
+      event["event_source"] = :cloud_watch_api
     elsif event["detail-type"] == "EC2 Instance State-change Notification"
       # CloudWatch EC2 Events
       state                = "_#{event.fetch_path("detail", "state")}" if event.fetch_path("detail", "state")
       event["eventType"]   = "#{event["detail-type"].gsub(" ", "_").gsub("-", "_")}#{state}"
-      event[:event_source] = :cloud_watch_ec2
+      event["event_source"] = :cloud_watch_ec2
     else
       # Not recognized event, ignoring...
       return

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -163,16 +163,16 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
 
     if event["messageType"] == "ConfigurationItemChangeNotification"
       # Aws Config Events
-      event["eventType"]   = parse_event_type(event)
+      event["eventType"]    = parse_event_type(event)
       event["event_source"] = :config
     elsif event.fetch_path("detail", "eventType") == "AwsApiCall"
       # CloudWatch with CloudTrail for API requests Events
-      event["eventType"]   = event.fetch_path("detail", "eventName")
+      event["eventType"]    = event.fetch_path("detail", "eventName")
       event["event_source"] = :cloud_watch_api
     elsif event["detail-type"] == "EC2 Instance State-change Notification"
       # CloudWatch EC2 Events
-      state                = "_#{event.fetch_path("detail", "state")}" if event.fetch_path("detail", "state")
-      event["eventType"]   = "#{event["detail-type"].gsub(" ", "_").gsub("-", "_")}#{state}"
+      state                 = "_#{event.fetch_path("detail", "state")}" if event.fetch_path("detail", "state")
+      event["eventType"]    = "#{event["detail-type"].tr(" ", "_").tr("-", "_")}#{state}"
       event["event_source"] = :cloud_watch_ec2
     else
       # Not recognized event, ignoring...

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -1,10 +1,11 @@
 #
-# Uses the AWS Config service to monitor for events.
+# Uses the AWS Config or CloudWatch service to monitor for events.
 #
-# AWS Config events are collected in an SNS Topic.  Each appliance uses a unique
+# AWS Config or CloudWatch events are collected in an SNS Topic.  Each appliance uses a unique
 # SQS queue subscribed to the AWS Config topic.  If the appliance-specific queue
 # doesn't exist, this event monitor will create the queue and subscribe the
 # queue to the AWS Config topic.
+
 #
 class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
   class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
@@ -31,7 +31,11 @@ module ManageIQ::Providers::Amazon::CloudManager::EventParser
       :ems_id     => ems_id
     }
 
-    send("parse_#{event[:event_source]}_event!", event, event_hash)
+    unless %i(config cloud_watch_api cloud_watch_ec2).include?(event["event_source"])
+      raise "Unsupported event source #{event["event_source"]}"
+    end
+
+    send("parse_#{event["event_source"]}_event!", event, event_hash)
 
     log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
     _log.debug("#{log_header}event: [#{event[:message]}]")

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
@@ -11,8 +11,8 @@ module ManageIQ::Providers::Amazon::CloudManager::EventParser
                                              "response: #{event.fetch_path("detail", "responseElements")}"
     event_hash[:timestamp]                 = event["time"]
     # TODO(lsmola) so Event can be tied to more Vms, we will need to change the modeling
-    event_hash[:vm_ems_ref]                = event.fetch_path("detail", "responseElements", "instancesSet", "items").
-      try(:first).try(:[], "instanceId")
+    event_hash[:vm_ems_ref]                = event.fetch_path("detail", "responseElements", "instancesSet", "items")
+                                               .try(:first).try(:[], "instanceId")
     event_hash[:availability_zone_ems_ref] = nil # Can't get it, needs to go through VM
   end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/EC2_Instance_State_change_Notification_pending.json
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/EC2_Instance_State_change_Notification_pending.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "4dafbb73-41f9-53a9-b455-ea79f4678cdb",
+  "TopicArn" : "arn:aws:sns:us-east-1:200278856672:AWSConfig_topic",
+  "Message" : "{\"version\":\"0\",\"id\":\"f6d70449-ef3a-4276-8af4-f324e2aaf808\",\"detail-type\":\"EC2 Instance State-change Notification\",\"source\":\"aws.ec2\",\"account\":\"200278856672\",\"time\":\"2017-01-31T15:55:09Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:ec2:us-east-1:200278856672:instance/i-0aeefa44d61669849\"],\"detail\":{\"instance-id\":\"i-0aeefa44d61669849\",\"state\":\"pending\"}}",
+  "Timestamp" : "2017-01-31T15:55:10.938Z",
+  "SignatureVersion" : "1",
+  "Signature" : "cPngeMxZUzp5IHPoCzMxf+iaFXt/r/lcmGgEwD0bEwWT4+J1iezE79ZH6+ZXNTWHk8A11yAp8Rt9qBKeAh+MJgIwGpRQ+hmvzxvvQ+AnJn6m+H5KEO9mI1hOQgrIQishZaIUx3qexnf9R0cx7I4pqbc0w3plgr/5kvzgaVxOq6L4ZlNnf0f539iHFv0lcX4UFOhEAF6nJOhKCQ8L7OYBRO/n0vOQ3jJa5vqEAssncrLNcs0PJXfJQjEF576xMcrLIals3JQ3aoP2z8Y6HgZo/ZIvkTb6kkBXnd8S+hRYBIzf1V9a53049f2yzSIPnGp8qFmpp1dWUdYzY241DayG0g==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:200278856672:AWSConfig_topic:001cf2a7-34a1-4ec0-b52f-e443bc5f52f8"
+}

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/EC2_Instance_State_change_Notification_running.json
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/EC2_Instance_State_change_Notification_running.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "3ddd299e-6d76-51f5-bd11-7894d8cde926",
+  "TopicArn" : "arn:aws:sns:us-east-1:200278856672:AWSConfig_topic",
+  "Message" : "{\"version\":\"0\",\"id\":\"65670a99-8d49-4031-9973-00efd2bc5557\",\"detail-type\":\"EC2 Instance State-change Notification\",\"source\":\"aws.ec2\",\"account\":\"200278856672\",\"time\":\"2017-01-31T15:55:38Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:ec2:us-east-1:200278856672:instance/i-0aeefa44d61669849\"],\"detail\":{\"instance-id\":\"i-0aeefa44d61669849\",\"state\":\"running\"}}",
+  "Timestamp" : "2017-01-31T15:55:39.260Z",
+  "SignatureVersion" : "1",
+  "Signature" : "Ua49CTNIBx3gntLCwTMWD5ZmXbrVDyvQwrZbDlcda6/Frt4JKY6pvdfvETEsT6r0kS8nAoL+mHwmcNqKln3I85u52H1A0Z952piP67FvIaIiPMPXSg4oRvRfiDDS4JJNhbsxCG6+haYwG/fAJFdHfWgW6QYJKwDqTop9+D779ETHjGCLfoQOxWA3cKunm2Nu1FZPpxPY4CLaO+7TBzMtI8LiXP0MNNodHiFGRDEFZ90G+tcF2oVnAqOGSkEIW0PBJuSeb1FK6nRKy3h97zpT9qXMYtDYluySaBF4NOr51eK+Ds6+Au9Zb2xPZFsWNUdsLN0p0TnxVAzcuB4hNBJ58w==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:200278856672:AWSConfig_topic:001cf2a7-34a1-4ec0-b52f-e443bc5f52f8"
+}

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/EC2_Instance_State_change_Notification_stopped.json
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/EC2_Instance_State_change_Notification_stopped.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "12e08214-c0ce-53bd-a025-d31e75cc86a6",
+  "TopicArn" : "arn:aws:sns:us-east-1:200278856672:AWSConfig_topic",
+  "Message" : "{\"version\":\"0\",\"id\":\"33a2f598-657d-4e11-bd94-c45de5eaa626\",\"detail-type\":\"EC2 Instance State-change Notification\",\"source\":\"aws.ec2\",\"account\":\"200278856672\",\"time\":\"2017-01-31T15:52:32Z\",\"region\":\"us-east-1\",\"resources\":[\"arn:aws:ec2:us-east-1:200278856672:instance/i-0aeefa44d61669849\"],\"detail\":{\"instance-id\":\"i-0aeefa44d61669849\",\"state\":\"stopped\"}}",
+  "Timestamp" : "2017-01-31T15:52:34.208Z",
+  "SignatureVersion" : "1",
+  "Signature" : "JmPsgmLwdyZ9RxKX88bZUwk8kTLJTzpR99VNiznHe9QWsxEmnR+vCyo+Mwh02BESpUfZkuqnYbL2jdftqLhZuPL+go/2/u9S7Qo4szXpxOZZilxq/ZjCsWXl8oODGplEGTQiIUjzrHDCnICy5j8koBQFaIwRsCZ5OYd/31pV5YNsEL5j+rHmPS8YHYv2npgoo0ckNsqBuQaUeiFaV0c3GWwMsIy+udR17SPIGaGrWsNA1tnrAnW1vSi9BE4zpjSdza/qAfQW4o6pc+nbeTJNMFpOe4P/0NV4sxED3j3qNveRuzcY73ZSODY5887ZN/Xwr0ErJ2beifKrE0EEB/4m9w==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:200278856672:AWSConfig_topic:001cf2a7-34a1-4ec0-b52f-e443bc5f52f8"
+}

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/StartInstances.json
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/StartInstances.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "14aead3e-1346-5225-93f1-fc34a69eb2d3",
+  "TopicArn" : "arn:aws:sns:us-east-1:200278856672:AWSConfig_topic",
+  "Message" : "{\"version\":\"0\",\"id\":\"f3ae091a-6fb6-45bd-88ee-1942217478e3\",\"detail-type\":\"AWS API Call via CloudTrail\",\"source\":\"aws.ec2\",\"account\":\"200278856672\",\"time\":\"2017-01-31T15:55:09Z\",\"region\":\"us-east-1\",\"resources\":[],\"detail\":{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDAI37PIOA5B6VMIJRUU\",\"arn\":\"arn:aws:iam::200278856672:user/ladas\",\"accountId\":\"200278856672\",\"accessKeyId\":\"ASIAICT2T47U5KIQEUTQ\",\"userName\":\"ladas\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2017-01-31T07:48:19Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2017-01-31T15:55:09Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"StartInstances\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"78.102.117.102\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"instancesSet\":{\"items\":[{\"instanceId\":\"i-0aeefa44d61669849\"}]}},\"responseElements\":{\"instancesSet\":{\"items\":[{\"instanceId\":\"i-0aeefa44d61669849\",\"currentState\":{\"code\":0,\"name\":\"pending\"},\"previousState\":{\"code\":80,\"name\":\"stopped\"}}]}},\"requestID\":\"adf70539-d8d3-4b68-b7d2-ff34bb3769ba\",\"eventID\":\"6afc9bbe-3a12-42be-a489-82db28274163\",\"eventType\":\"AwsApiCall\"}}",
+  "Timestamp" : "2017-01-31T15:56:08.102Z",
+  "SignatureVersion" : "1",
+  "Signature" : "GIcoGX/JzHaIzZHOjNNmO7PfWUfSLfaNzqiZCMRbFx+tezKEgWJjor1fxzt5VE+Q87W4qEUK45aF+Il8jd5VpyEWgr+WADRbzlMUAsvuE6HnHsrMtWMI7u306CwOmsq0TpnZPlr0QjBArEuyQAqmE5cKBImn8ZgSC2cffwmDiiJcvP99/WnA/2SmwZvtfnhWXYuGOvThb93gEiw37M5TtH3SQl7mgznPnvr8tlnJJ9fGw4Tj0kJ7GORnAKWKgGxUeczUoJ4cfLIR93IMWVSpXtgLpGwYBGHc1ikNHFQQixYv/XT7UxIVWb0n3RupLS8rlHuZnaqMMp3guYDyRpR79A==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:200278856672:AWSConfig_topic:001cf2a7-34a1-4ec0-b52f-e443bc5f52f8"
+}

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/StopInstances.json
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/cloud_watch/StopInstances.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "8e22fbde-75e1-52d6-9102-aad4c1191884",
+  "TopicArn" : "arn:aws:sns:us-east-1:200278856672:AWSConfig_topic",
+  "Message" : "{\"version\":\"0\",\"id\":\"e177dd0b-26f7-423a-9645-d49a68b7e58d\",\"detail-type\":\"AWS API Call via CloudTrail\",\"source\":\"aws.ec2\",\"account\":\"200278856672\",\"time\":\"2017-01-31T15:51:23Z\",\"region\":\"us-east-1\",\"resources\":[],\"detail\":{\"eventVersion\":\"1.05\",\"userIdentity\":{\"type\":\"IAMUser\",\"principalId\":\"AIDAI37PIOA5B6VMIJRUU\",\"arn\":\"arn:aws:iam::200278856672:user/ladas\",\"accountId\":\"200278856672\",\"accessKeyId\":\"ASIAICT2T47U5KIQEUTQ\",\"userName\":\"ladas\",\"sessionContext\":{\"attributes\":{\"mfaAuthenticated\":\"false\",\"creationDate\":\"2017-01-31T07:48:19Z\"}},\"invokedBy\":\"signin.amazonaws.com\"},\"eventTime\":\"2017-01-31T15:51:23Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"StopInstances\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"78.102.117.102\",\"userAgent\":\"signin.amazonaws.com\",\"requestParameters\":{\"instancesSet\":{\"items\":[{\"instanceId\":\"i-0aeefa44d61669849\"}]},\"force\":false},\"responseElements\":{\"instancesSet\":{\"items\":[{\"instanceId\":\"i-0aeefa44d61669849\",\"currentState\":{\"code\":64,\"name\":\"stopping\"},\"previousState\":{\"code\":16,\"name\":\"running\"}}]}},\"requestID\":\"a07b3996-e2c1-4a49-8466-43f1badcf340\",\"eventID\":\"4ae6cc29-5b3a-41f4-b3d8-964b38dc9568\",\"eventType\":\"AwsApiCall\"}}",
+  "Timestamp" : "2017-01-31T15:52:24.021Z",
+  "SignatureVersion" : "1",
+  "Signature" : "fOvRAXYLu6BdIx2cvFLYMJPoKT0UPyN3K6QDQGRyVu0OepxwdfblMCbQ0vqIMOCoOBEG4T4t0G9JwJ359TNSXhkoEs5JOJp2oS0G8YJQ17aDQ7+WzyXb+PhX0I54HIm0W+sfphx3MiUwNKkMALGh5gkbIVPlHQ/00lQf2pht5GlYdiSf8vGRV9O79PjEPXSR5cRLnGLnl7KaqCax3NFhHX5wiwIV0OPMThNWyu25LuvkLT0ePPDi+8+F4eSKBmV/ulXicYcxhhrN6oYsd4nZcp4YqgbwQarD8tDnuUctx9tg0cWZ9SJw7tW4t2sJZciNJkF/LTBZNBMOi773VXIJNA==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:200278856672:AWSConfig_topic:001cf2a7-34a1-4ec0-b52f-e443bc5f52f8"
+}

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
@@ -1,10 +1,67 @@
 describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
   context ".event_to_hash" do
     it "parses vm_ems_ref into event" do
-      message = JSON.parse(File.read(File.join(File.dirname(__FILE__), "/event_catcher/sqs_message.json")))
-      event   = JSON.parse(message['Message'])
-      event["eventType"] = 'AWS_EC2_Instance_UPDATE'
+      message               = JSON.parse(File.read(File.join(File.dirname(__FILE__), "/event_catcher/sqs_message.json")))
+      event                 = JSON.parse(message['Message'])
+      event["eventType"]    = 'AWS_EC2_Instance_UPDATE'
+      event["event_source"] = :config
       expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-06199fba')
     end
+  end
+
+  context "AWS Config Event" do
+    it "parses vm_ems_ref into event" do
+      event = parse_event("sqs_message.json")
+
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-06199fba')
+    end
+  end
+
+  context "AWS CloudWatch with CloudTrail API" do
+    it "parses StartInstances event" do
+      event = parse_event("cloud_watch/StartInstances.json")
+
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+    end
+
+    it "parses StopInstances" do
+      event = parse_event("cloud_watch/StopInstances.json")
+
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+    end
+  end
+
+  context "AWS CloudWatch EC2" do
+    it "parses EC2_Instance_State_change_Notification_pending event" do
+      event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_pending.json")
+
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+    end
+    
+    it "parses EC2_Instance_State_change_Notification_running event" do
+      event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_running.json")
+
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+    end
+
+    it "parses EC2_Instance_State_change_Notification_stopped event" do
+      event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_stopped.json")
+
+      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+    end
+  end
+
+  def response(path)
+    response = double
+    allow(response).to receive(:body).and_return(
+      File.read(File.join(File.dirname(__FILE__), "/event_catcher/#{path}")))
+
+    allow(response).to receive(:message_id).and_return("mocked_message_id")
+
+    response
+  end
+
+  def parse_event(path)
+    ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream.new(double).send(:parse_event, response(path))
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
 
       expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
     end
-    
+
     it "parses EC2_Instance_State_change_Notification_running event" do
       event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_running.json")
 


### PR DESCRIPTION
Amazon event parser for CloudWatch events. The parser is able
to recognize CloudWatch ec2 events and CloudWatch API events
collected via CloudTrail.