### PR TITLE
Parse availability zone of an EBS volume

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/targets/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/targets/storage_manager/ebs.rb
@@ -1,6 +1,10 @@
 class ManageIQ::Providers::Amazon::Inventory::Targets::StorageManager::Ebs < ManageIQ::Providers::Amazon::Inventory::Targets
   def initialize_inventory_collections
     add_inventory_collections(%i(cloud_volumes cloud_volume_snapshots))
+
+    add_inventory_collections(%i(availability_zones),
+                              :parent   => ems.parent_manager,
+                              :strategy => :local_db_cache_all)
   end
 
   def cloud_volumes

--- a/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
@@ -35,16 +35,6 @@ class ManageIQ::Providers::Amazon::NetworkManager::RefreshParser
 
   private
 
-  def parent_manager_fetch_path(collection, ems_ref)
-    @parent_manager_data ||= {}
-    return @parent_manager_data.fetch_path(collection, ems_ref) if @parent_manager_data.has_key_path?(collection,
-                                                                                                      ems_ref)
-
-    @parent_manager_data.store_path(collection,
-                                    ems_ref,
-                                    @ems.public_send(collection).try(:where, :ems_ref => ems_ref).try(:first))
-  end
-
   def security_groups
     @security_groups ||= @aws_ec2.security_groups
   end

--- a/app/models/manageiq/providers/amazon/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/amazon/refresh_helper_methods.rb
@@ -46,6 +46,16 @@ module ManageIQ::Providers::Amazon::RefreshHelperMethods
     keys.join('_')
   end
 
+  def parent_manager_fetch_path(collection, ems_ref)
+    @parent_manager_data ||= {}
+    return @parent_manager_data.fetch_path(collection, ems_ref) if @parent_manager_data.has_key_path?(collection,
+                                                                                                      ems_ref)
+
+    @parent_manager_data.store_path(collection,
+                                    ems_ref,
+                                    @ems.public_send(collection).try(:where, :ems_ref => ems_ref).try(:first))
+  end
+
   module ClassMethods
     def ems_inv_to_hashes(ems, options = nil)
       new(ems, options).ems_inv_to_hashes

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
@@ -24,16 +24,6 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
 
   private
 
-  def parent_manager_fetch_path(collection, ems_ref)
-    @parent_manager_data ||= {}
-    return @parent_manager_data.fetch_path(collection, ems_ref) if @parent_manager_data.has_key_path?(collection,
-                                                                                                      ems_ref)
-
-    @parent_manager_data.store_path(collection,
-                                    ems_ref,
-                                    @ems.public_send(collection).try(:where, :ems_ref => ems_ref).try(:first))
-  end
-
   def get_volumes
     volumes = @aws_ec2.client.describe_volumes[:volumes]
     process_collection(volumes, :cloud_volumes) { |volume| parse_volume(volume) }

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
@@ -22,6 +22,18 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
     @data
   end
 
+  private
+
+  def parent_manager_fetch_path(collection, ems_ref)
+    @parent_manager_data ||= {}
+    return @parent_manager_data.fetch_path(collection, ems_ref) if @parent_manager_data.has_key_path?(collection,
+                                                                                                      ems_ref)
+
+    @parent_manager_data.store_path(collection,
+                                    ems_ref,
+                                    @ems.public_send(collection).try(:where, :ems_ref => ems_ref).try(:first))
+  end
+
   def get_volumes
     volumes = @aws_ec2.client.describe_volumes[:volumes]
     process_collection(volumes, :cloud_volumes) { |volume| parse_volume(volume) }
@@ -36,14 +48,15 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
     uid = volume.volume_id
 
     new_result = {
-      :type          => self.class.volume_type,
-      :ems_ref       => uid,
-      :name          => uid,
-      :status        => volume.state,
-      :creation_time => volume.create_time,
-      :volume_type   => volume.volume_type,
-      :size          => volume.size.to_i.gigabytes,
-      :snapshot_uid  => volume.snapshot_id
+      :type              => self.class.volume_type,
+      :ems_ref           => uid,
+      :name              => uid,
+      :status            => volume.state,
+      :creation_time     => volume.create_time,
+      :volume_type       => volume.volume_type,
+      :size              => volume.size.to_i.gigabytes,
+      :snapshot_uid      => volume.snapshot_id,
+      :availability_zone => parent_manager_fetch_path(:availability_zones, volume.availability_zone),
     }
 
     return uid, new_result

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser_inventory_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser_inventory_object.rb
@@ -38,7 +38,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParserInventoryOb
       :creation_time         => volume['create_time'],
       :volume_type           => volume['volume_type'],
       :size                  => volume['size'].to_i.gigabytes,
-      :base_snapshot         => inventory_collections[:cloud_volume_snapshots].lazy_find(volume['snapshot_id'])
+      :base_snapshot         => inventory_collections[:cloud_volume_snapshots].lazy_find(volume['snapshot_id']),
+      :availability_zone     => inventory_collections[:availability_zones].lazy_find(volume['availability_zone'])
     }
   end
 


### PR DESCRIPTION
Refresh parser and inventory object will retrieve the availability zone from the parent manager or inventory and save it into the cloud volume hash.

Depends-On: https://github.com/ManageIQ/manageiq/pull/13654

@miq-bot add_label enhancement
@miq-bot assign @Ladas 