### PR TITLE
Remove duplicate for `storage_manager` association

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -23,12 +23,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   include ManageIQ::Providers::Amazon::ManagerMixin
 
-  has_many :storage_managers,
-           :foreign_key => :parent_ems_id,
-           :class_name  => "ManageIQ::Providers::StorageManager",
-           :autosave    => true,
-           :dependent   => :destroy
-
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::Amazon::NetworkManager",


### PR DESCRIPTION
It appears we made a mistake while adding eBS and S3 providers adding
the same `has_many :storage_managers` twice. Patch is removing this.

@miq-bot assign @bronaghs 