### PR TITLE
Queue EBS storage refresh after cloud inventory is saved

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresher.rb
@@ -40,6 +40,7 @@ class ManageIQ::Providers::Amazon::CloudManager::Refresher < ManageIQ::Providers
   def save_inventory(ems, target, inventory_collections)
     EmsRefresh.save_ems_inventory(ems, inventory_collections)
     EmsRefresh.queue_refresh(ems.network_manager) if target.kind_of?(ManageIQ::Providers::BaseManager)
+    EmsRefresh.queue_refresh(ems.ebs_storage_manager) if target.kind_of?(ManageIQ::Providers::BaseManager)
   end
 
   def post_process_refresh_classes

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -39,7 +39,7 @@ module AwsRefresherSpecCommon
       :floating_ip                   => 12,
       :guest_device                  => 0,
       :hardware                      => 46,
-      :miq_queue                     => 49,
+      :miq_queue                     => 50,
       :miq_template                  => 20,
       :network                       => 14,
       :network_port                  => 32,

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -55,7 +55,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(2)
-    expect(MiqQueue.count).to eq(6)
+    expect(MiqQueue.count).to eq(7)
   end
 
   def assert_ems


### PR DESCRIPTION
While parsing volumes immediately after new AWS manager is created, EBS
manager failed to get proper links to availability zones, because it was
parsing data in parallel to the cloud manager. This patch queues the EBS
storage manager parse in the same way as the network manager, i.e.
immediately after the cloud inventory is saved, EBS refreshes the data
once more.

@miq-bot assign @Ladas 

@Ladas I assigned you because there is a todo for you and would like to check if this is still valid way to go.