### PR TITLE
Parse the name of EBS volume or snapshot

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
     new_result = {
       :type              => self.class.volume_type,
       :ems_ref           => uid,
-      :name              => uid,
+      :name              => get_from_tags(volume, :name) || uid,
       :status            => volume.state,
       :creation_time     => volume.create_time,
       :volume_type       => volume.volume_type,
@@ -58,7 +58,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
     new_result = {
       :ems_ref       => uid,
       :type          => self.class.volume_snapshot_type,
-      :name          => snap.snapshot_id,
+      :name          => get_from_tags(snap, :name) || uid,
       :status        => snap.state,
       :creation_time => snap.start_time,
       :description   => snap.description,

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser_inventory_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser_inventory_object.rb
@@ -33,7 +33,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParserInventoryOb
       :type                  => self.class.volume_type,
       :ext_management_system => ems,
       :ems_ref               => uid,
-      :name                  => uid,
+      :name                  => get_from_tags(volume, :name) || uid,
       :status                => volume['state'],
       :creation_time         => volume['create_time'],
       :volume_type           => volume['volume_type'],
@@ -50,13 +50,18 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParserInventoryOb
       :type                  => self.class.volume_snapshot_type,
       :ext_management_system => ems,
       :ems_ref               => uid,
-      :name                  => snap['snapshot_id'],
+      :name                  => get_from_tags(snap, :name) || uid,
       :status                => snap['state'],
       :creation_time         => snap['start_time'],
       :description           => snap['description'],
       :size                  => snap['volume_size'].to_i.gigabytes,
       :cloud_volume          => inventory_collections[:cloud_volumes].lazy_find(snap['volume_id'])
     }
+  end
+
+  # Overridden helper methods, we should put them in helper once we get rid of old refresh
+  def get_from_tags(resource, item)
+    (resource['tags'] || []).detect { |tag, _| tag['key'].downcase == item.to_s.downcase }.try(:[], 'value')
   end
 
   class << self

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -381,7 +381,8 @@ module AwsStubs
         :state             => "in-use",
         :volume_id         => "volume_id_#{i}",
         :volume_type       => "standard",
-        :snapshot_id       => "snapshot_id_#{i}"
+        :snapshot_id       => "snapshot_id_#{i}",
+        :tags              => [{ :key => "name", :value => "volume_#{i}" }]
       }
     end
 
@@ -398,6 +399,7 @@ module AwsStubs
         :volume_size => i,
         :state       => "completed",
         :volume_id   => "volume_id_#{i}",
+        :tags        => [{ :key => "name", :value => "snapshot_#{i}" }]
       }
     end
 

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
@@ -197,7 +197,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
     expect(@snapshot).not_to be_nil
     expect(@snapshot).to have_attributes(
       :ems_ref     => "snapshot_id_1",
-      :name        => "snapshot_id_1",
+      :name        => "snapshot_1",
       :description => "snapshot_desc_1",
       :status      => "completed",
       :size        => 1.gigabyte
@@ -212,7 +212,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
     expect(@volume).not_to be_nil
     expect(@volume).to have_attributes(
       :ems_ref     => "volume_id_1",
-      :name        => "volume_id_1",
+      :name        => "volume_1",
       :status      => "in-use",
       :volume_type => "standard",
       :size        => 1.gigabyte


### PR DESCRIPTION
Name is defined as a tag and can be optional. Patch uses the id of
the volume/snapshot if name is not given.
