### PR TITLE
Link volumes to corresponding VM disks

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/target/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target/storage_manager/ebs.rb
@@ -2,8 +2,12 @@ class ManageIQ::Providers::Amazon::Inventory::Target::StorageManager::Ebs < Mana
   def initialize_inventory_collections
     add_inventory_collections(%i(cloud_volumes cloud_volume_snapshots))
 
-    add_inventory_collections(%i(availability_zones),
+    add_inventory_collections(%i(availability_zones hardwares),
                               :parent   => ems.parent_manager,
                               :strategy => :local_db_cache_all)
+
+    add_inventory_collections(%i(disks),
+                              :parent      => ems.parent_manager,
+                              :update_only => true)
   end
 end

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -377,13 +377,26 @@ module AwsStubs
       mocked_cloud_volumes << {
         :availability_zone => "us-east-1e",
         :create_time       => Time.now,
-        :size              => i,
+        :size              => 1,
         :state             => "in-use",
         :volume_id         => "volume_id_#{i}",
         :volume_type       => "standard",
         :snapshot_id       => "snapshot_id_#{i}",
         :tags              => [{ :key => "name", :value => "volume_#{i}" }]
       }
+    end
+
+    unless mocked_cloud_volumes.blank?
+      # Attach the first cloud volume to a specific instance.
+      volume_with_attachment = mocked_cloud_volumes[0]
+      volume_with_attachment[:attachments] = [{
+        :volume_id             => "volume_id_0",
+        :instance_id           => "instance_0",
+        :device                => "/dev/sda1",
+        :state                 => "attached",
+        :attach_time           => Time.now,
+        :delete_on_termination => true
+      }]
     end
 
     { :volumes => mocked_cloud_volumes }
@@ -396,7 +409,7 @@ module AwsStubs
         :snapshot_id => "snapshot_id_#{i}",
         :description => "snapshot_desc_#{i}",
         :start_time  => Time.now,
-        :volume_size => i,
+        :volume_size => 1,
         :state       => "completed",
         :volume_id   => "volume_id_#{i}",
         :tags        => [{ :key => "name", :value => "snapshot_#{i}" }]


### PR DESCRIPTION
This patch currently works only for the legacy refresh parser. It will look for the instance (VM) referenced in the attachment section of the volume data and create a backing link between the volume and instance's disk. Linking is done similar to the OpenStack (Cinder) provider.

Inventory object doesn't work yet as I can't figure out how to properly get the hardware and disks from the corresponding `:vm` inventory object.

Specs will also fail because I am using local VCR with our own account. They are nevertheless provided for inspection.

@miq-bot add_label wip, enhancement
@miq-bot assign @Ladas 

Depends on: #122. The spec will be updated with the data from the VCR received from this PR.