### PR TITLE
Collect block device mappings in AWS cloud manager

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -271,6 +271,12 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       end
     end
 
+    instance.block_device_mappings.each do |blk_map|
+      disks = new_result[:hardware][:disks]
+      device = File.basename(blk_map.device_name)
+      add_block_device_disk(disks, device, device)
+    end
+
     return uid, new_result
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser_inventory_object.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser_inventory_object.rb
@@ -135,6 +135,13 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParserInventoryObject < 
       end
     end
 
+    if instance.key?("block_device_mappings")
+      instance["block_device_mappings"].each do |blk_map|
+        device = File.basename(blk_map["device_name"])
+        add_block_device_disk(disks, device, device)
+      end
+    end
+
     disks.each do |d|
       d[:hardware] = inventory_collections[:hardwares].lazy_find(instance['instance_id'])
     end

--- a/app/models/manageiq/providers/amazon/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/amazon/refresh_helper_methods.rb
@@ -41,6 +41,17 @@ module ManageIQ::Providers::Amazon::RefreshHelperMethods
     super(disks, size, name, location, "amazon")
   end
 
+  def add_block_device_disk(disks, name, location)
+    disk = {
+      :device_name     => name,
+      :device_type     => "disk",
+      :controller_type => "amazon",
+      :location        => location,
+    }
+    disks << disk
+    disk
+  end
+
   # Compose an ems_ref combining some existing keys
   def compose_ems_ref(*keys)
     keys.join('_')

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -32,7 +32,7 @@ module AwsRefresherSpecCommon
       :cloud_network                 => 5,
       :cloud_subnet                  => 10,
       :custom_attribute              => 0,
-      :disk                          => 10,
+      :disk                          => 44,
       :ext_management_system         => 4,
       :firewall_rule                 => 119,
       :flavor                        => 56,
@@ -373,7 +373,7 @@ module AwsRefresherSpecCommon
       :virtualization_type => "paravirtual"
     )
 
-    expect(v.hardware.disks.size).to eq(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.disks.size).to eq(1) # TODO: Change to a flavor that has disks
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
 
@@ -477,7 +477,7 @@ module AwsRefresherSpecCommon
       :root_device_type     => "ebs",
     )
 
-    expect(v.hardware.disks.size).to eq(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.disks.size).to eq(1) # TODO: Change to a flavor that has disks
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
     expect(v.hardware.networks.size).to eq(0)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -46,7 +46,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(MiqTemplate.count).to eq(1)
 
     expect(CustomAttribute.count).to eq(0)
-    expect(Disk.count).to eq(1)
+    expect(Disk.count).to eq(3)
     expect(GuestDevice.count).to eq(0)
     expect(Hardware.count).to eq(3)
     expect(Network.count).to eq(4)
@@ -242,7 +242,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :bitness            => 64
     )
 
-    expect(v.hardware.disks.size).to eq(0) # TODO: Change to a flavor that has disks
+    expect(v.hardware.disks.size).to eq(1) # TODO: Change to a flavor that has disks
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
 


### PR DESCRIPTION
Besides collecting ephemeral storage in the AWS cloud manager refresh
parser, we are adding inventory of attached block devices. This is
necessary because with the introduction of the EBS manager we are adding
disks there as well. If the cloud manager does not collect attached
block devices, those disks collected by the EBS manager will be removed
from the inventory.

The suggested change does not require any change in the core repository.