### PR TITLE
Moving to use only kwargs for InventoryCollection init

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
+++ b/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
     }
 
     init_data.merge!(attributes).merge!(extra_attributes)
-    return init_data
+    init_data
   end
 
   def vms_init_data(extra_attributes = {})
@@ -353,8 +353,8 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
       end
 
       stacks_parents_indexed = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack
-                                 .select([:id, :ancestry])
-                                 .where(:id => stacks_parents.values).find_each.index_by(&:id)
+                               .select([:id, :ancestry])
+                               .where(:id => stacks_parents.values).find_each.index_by(&:id)
 
       ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack
         .select([:id, :ancestry])
@@ -383,8 +383,8 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
       end
 
       miq_templates = ManageIQ::Providers::Amazon::CloudManager::Template
-                        .select([:id])
-                        .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
+                      .select([:id])
+                      .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
 
       ManageIQ::Providers::Amazon::CloudManager::Vm
         .select([:id])

--- a/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
+++ b/app/models/manageiq/providers/amazon/inventory/inventory_collection_default_init_data.rb
@@ -1,57 +1,63 @@
 module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitData
-  def init_data(model_class, attributes, extra_attributes)
+  def init_data(attributes, extra_attributes)
     init_data = {
-      :delete_method => model_class.new.respond_to?(:disconnect_inv) ? :disconnect_inv : nil
+      :delete_method => attributes[:model_class].new.respond_to?(:disconnect_inv) ? :disconnect_inv : nil
     }
 
     init_data.merge!(attributes).merge!(extra_attributes)
-    return model_class, init_data
+    return init_data
   end
 
   def vms_init_data(extra_attributes = {})
     attributes = {
+      :model_class          => ::ManageIQ::Providers::Amazon::CloudManager::Vm,
       :association          => :vms,
       :attributes_blacklist => [:genealogy_parent]
     }
 
-    init_data(::ManageIQ::Providers::Amazon::CloudManager::Vm, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def miq_templates_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::CloudManager::Template,
       :association => :miq_templates,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::CloudManager::Template, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def availability_zones_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone,
       :association => :availability_zones,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def flavors_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::CloudManager::Flavor,
       :association => :flavors,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::CloudManager::Flavor, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def key_pairs_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair,
       :manager_ref => [:name],
       :association => :key_pairs
     }
 
-    init_data(::ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def hardwares_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::Hardware,
       :manager_ref => [:vm_or_template],
       :association => :hardwares
     }
@@ -69,11 +75,12 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
       end
     end
 
-    init_data(::Hardware, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def disks_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::Disk,
       :manager_ref => [:hardware, :device_name],
       :association => :disks
     }
@@ -84,11 +91,12 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
       end
     end
 
-    init_data(::Disk, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def networks_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::Network,
       :manager_ref => [:hardware, :description],
       :association => :networks
     }
@@ -99,40 +107,44 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
       end
     end
 
-    init_data(::Network, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def orchestration_stacks_init_data(extra_attributes = {})
     attributes = {
+      :model_class          => ::ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack,
       :association          => :orchestration_stacks,
       :attributes_blacklist => [:parent]
     }
 
-    init_data(::ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def orchestration_stacks_resources_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::OrchestrationStackResource,
       :association => :orchestration_stacks_resources,
     }
 
-    init_data(::OrchestrationStackResource, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def orchestration_stacks_outputs_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::OrchestrationStackOutput,
       :association => :orchestration_stacks_outputs,
     }
 
-    init_data(::OrchestrationStackOutput, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def orchestration_stacks_parameters_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::OrchestrationStackParameter,
       :association => :orchestration_stacks_parameters,
     }
 
-    init_data(::OrchestrationStackParameter, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def orchestration_templates_init_data(extra_attributes = {})
@@ -147,167 +159,246 @@ module ManageIQ::Providers::Amazon::Inventory::InventoryCollectionDefaultInitDat
     end
 
     attributes = {
+      :model_class       => ::OrchestrationTemplateCfn,
       :association       => :orchestration_templates,
       :custom_save_block => orchestration_template_save_block
     }
 
-    init_data(::OrchestrationTemplateCfn, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_subnet_network_ports_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::CloudSubnetNetworkPort,
       :manager_ref => [:address, :cloud_subnet, :network_port],
       :association => :cloud_subnet_network_ports,
     }
 
-    init_data(::CloudSubnetNetworkPort, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def network_ports_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::NetworkPort,
       :association => :network_ports,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::NetworkPort, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def floating_ips_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::FloatingIp,
       :association => :floating_ips,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::FloatingIp, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_subnets_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet,
       :association => :cloud_subnets,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_networks_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork,
       :association => :cloud_networks,
     }
 
-    init_data(ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def security_groups_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup,
       :association => :security_groups,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def firewall_rules_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::FirewallRule,
       :manager_ref => [:resource, :source_security_group, :direction, :host_protocol, :port, :end_port, :source_ip_range],
       :association => :firewall_rules,
     }
 
-    init_data(::FirewallRule, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancers_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancer,
       :association => :load_balancers,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancer, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_pools_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPool,
       :association => :load_balancer_pools,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPool, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_pool_members_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPoolMember,
       :association => :load_balancer_pool_members,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPoolMember, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_pool_member_pools_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::LoadBalancerPoolMemberPool,
       :manager_ref => [:load_balancer_pool, :load_balancer_pool_member],
       :association => :load_balancer_pool_member_pools,
     }
 
-    init_data(::LoadBalancerPoolMemberPool, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_listeners_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerListener,
       :association => :load_balancer_listeners,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerListener, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_listener_pools_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::LoadBalancerListenerPool,
       :manager_ref => [:load_balancer_listener, :load_balancer_pool],
       :association => :load_balancer_listener_pools,
     }
 
-    init_data(::LoadBalancerListenerPool, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_health_checks_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerHealthCheck,
       :association => :load_balancer_health_checks,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerHealthCheck, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def load_balancer_health_check_members_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::LoadBalancerHealthCheckMember,
       :manager_ref => [:load_balancer_health_check, :load_balancer_pool_member],
       :association => :load_balancer_health_check_members,
     }
 
-    init_data(::LoadBalancerHealthCheckMember, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_volumes_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume,
       :association => :cloud_volumes,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_volume_snapshots_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot,
       :association => :cloud_volume_snapshots,
     }
 
-    init_data(::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_object_store_containers_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::CloudObjectStoreContainer,
       :association => :cloud_object_store_containers,
     }
 
-    init_data(::CloudObjectStoreContainer, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
   end
 
   def cloud_object_store_objects_init_data(extra_attributes = {})
     attributes = {
+      :model_class => ::CloudObjectStoreObject,
       :association => :cloud_object_store_objects,
     }
 
-    init_data(::CloudObjectStoreObject, attributes, extra_attributes)
+    init_data(attributes, extra_attributes)
+  end
+
+  def orchestration_stack_ancestry_init_data(extra_attributes = {})
+    orchestration_stack_ancestry_save_block = lambda do |_ems, inventory_collection|
+      return if inventory_collection.dependency_attributes[:orchestration_stacks].blank?
+
+      stacks_parents = inventory_collection.dependency_attributes[:orchestration_stacks].first.data.each_with_object({}) do |x, obj|
+        parent_id = x.data[:parent].load.try(:id)
+        obj[x.id] = parent_id if parent_id
+      end
+
+      stacks_parents_indexed = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack
+                                 .select([:id, :ancestry])
+                                 .where(:id => stacks_parents.values).find_each.index_by(&:id)
+
+      ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack
+        .select([:id, :ancestry])
+        .where(:id => stacks_parents.keys).find_each do |stack|
+        parent = stacks_parents_indexed[stacks_parents[stack.id]]
+        stack.update_attribute(:parent, parent)
+      end
+    end
+
+    attributes = {
+      :association       => :orchestration_stack_ancestry,
+      :custom_save_block => orchestration_stack_ancestry_save_block
+    }
+    attributes.merge!(extra_attributes)
+    attributes
+  end
+
+  def vm_and_miq_template_ancestry_init_data(extra_attributes = {})
+    vm_and_miq_template_ancestry_save_block = lambda do |_ems, inventory_collection|
+      return if inventory_collection.dependency_attributes[:vms].blank?
+
+      # Fetch IDs of all vms and genealogy_parents, only if genealogy_parent is present
+      vms_genealogy_parents = inventory_collection.dependency_attributes[:vms].first.data.each_with_object({}) do |x, obj|
+        genealogy_parent_id = x.data[:genealogy_parent].load.try(:id)
+        obj[x.id]           = genealogy_parent_id if genealogy_parent_id
+      end
+
+      miq_templates = ManageIQ::Providers::Amazon::CloudManager::Template
+                        .select([:id])
+                        .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
+
+      ManageIQ::Providers::Amazon::CloudManager::Vm
+        .select([:id])
+        .where(:id => vms_genealogy_parents.keys).find_each do |vm|
+        parent = miq_templates[vms_genealogy_parents[vm.id]]
+        parent.with_relationship_type('genealogy') { parent.set_child(vm) }
+      end
+    end
+
+    attributes = {
+      :association       => :vm_and_miq_template_ancestry,
+      :custom_save_block => vm_and_miq_template_ancestry_save_block,
+    }
+    attributes.merge!(extra_attributes)
+    attributes
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/target.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target.rb
@@ -23,11 +23,11 @@ class ManageIQ::Providers::Amazon::Inventory::Target
   end
 
   def add_inventory_collection(inventory_collection_data, key = nil)
-    model_class, data = inventory_collection_data
-    data[:parent]     ||= ems
-    key               ||= data[:association]
+    data          = inventory_collection_data
+    data[:parent] ||= ems
+    key           ||= data[:association]
 
-    inventory_collections[key] = ::ManagerRefresh::InventoryCollection.new(model_class, data)
+    inventory_collections[key] = ::ManagerRefresh::InventoryCollection.new(data)
   end
 
   def add_inventory_collections(inventory_collections, inventory_collections_data = {})

--- a/app/models/manageiq/providers/amazon/inventory/target.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target.rb
@@ -23,7 +23,7 @@ class ManageIQ::Providers::Amazon::Inventory::Target
   end
 
   def add_inventory_collection(inventory_collection_data, key = nil)
-    data          = inventory_collection_data
+    data = inventory_collection_data
     data[:parent] ||= ems
     key           ||= data[:association]
 

--- a/app/models/manageiq/providers/amazon/inventory/target/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target/cloud_manager.rb
@@ -8,12 +8,18 @@ class ManageIQ::Providers::Amazon::Inventory::Target::CloudManager < ManageIQ::P
       vm_and_miq_template_ancestry_init_data(
         :dependency_attributes => {
           :vms           => [inventory_collections[:vms]],
-          :miq_templates => [inventory_collections[:miq_templates]]}))
+          :miq_templates => [inventory_collections[:miq_templates]]
+        }
+      )
+    )
 
     add_inventory_collection(
       orchestration_stack_ancestry_init_data(
         :dependency_attributes => {
           :orchestration_stacks           => [inventory_collections[:orchestration_stacks]],
-          :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]}))
+          :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]
+        }
+      )
+    )
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/target/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target/cloud_manager.rb
@@ -4,57 +4,16 @@ class ManageIQ::Providers::Amazon::Inventory::Target::CloudManager < ManageIQ::P
                                  flavors key_pairs orchestration_stacks orchestration_stacks_resources
                                  orchestration_stacks_outputs orchestration_stacks_parameters orchestration_templates))
 
-    vm_and_miq_template_ancestry_save_block = lambda do |_ems, inventory_collection|
-      # Fetch IDs of all vms and genealogy_parents, only if genealogy_parent is present
-      vms_genealogy_parents = inventory_collection.dependency_attributes[:vms].first.data.each_with_object({}) do |x, obj|
-        genealogy_parent_id = x.data[:genealogy_parent].load.try(:id)
-        obj[x.id]           = genealogy_parent_id if genealogy_parent_id
-      end
-
-      miq_templates = ManageIQ::Providers::Amazon::CloudManager::Template.select([:id])
-                                                                         .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
-
-      ManageIQ::Providers::Amazon::CloudManager::Vm.select([:id])
-                                                   .where(:id => vms_genealogy_parents.keys).find_each do |vm|
-        parent = miq_templates[vms_genealogy_parents[vm.id]]
-        parent.with_relationship_type('genealogy') { parent.set_child(vm) }
-      end
-    end
+    add_inventory_collection(
+      vm_and_miq_template_ancestry_init_data(
+        :dependency_attributes => {
+          :vms           => [inventory_collections[:vms]],
+          :miq_templates => [inventory_collections[:miq_templates]]}))
 
     add_inventory_collection(
-      [
-        ManageIQ::Providers::Amazon::CloudManager::Vm,
-        :custom_save_block     => vm_and_miq_template_ancestry_save_block,
-        :dependency_attributes => {:vms           => [inventory_collections[:vms]],
-                                   :miq_templates => [inventory_collections[:miq_templates]]}
-      ],
-      :vm_and_miq_template_ancestry
-    )
-
-    orchestration_stack_ancestry_save_block = lambda do |_ems, inventory_collection|
-      stacks_parents = inventory_collection.dependency_attributes[:orchestration_stacks].first.data.each_with_object({}) do |x, obj|
-        parent_id = x.data[:parent].load.try(:id)
-        obj[x.id] = parent_id if parent_id
-      end
-
-      stacks_parents_indexed = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.select([:id, :ancestry])
-                                                                                            .where(:id => stacks_parents.values).find_each.index_by(&:id)
-
-      ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.select([:id, :ancestry])
-                                                                   .where(:id => stacks_parents.keys).find_each do |stack|
-        parent = stacks_parents_indexed[stacks_parents[stack.id]]
-        stack.update_attribute(:parent, parent)
-      end
-    end
-
-    add_inventory_collection(
-      [
-        ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack,
-        :custom_save_block     => orchestration_stack_ancestry_save_block,
-        :dependency_attributes => {:orchestration_stacks           => [inventory_collections[:orchestration_stacks]],
-                                   :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]}
-      ],
-      :orchestration_stack_ancestry
-    )
+      orchestration_stack_ancestry_init_data(
+        :dependency_attributes => {
+          :orchestration_stacks           => [inventory_collections[:orchestration_stacks]],
+          :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]}))
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/target/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target/target_collection.rb
@@ -7,13 +7,19 @@ class ManageIQ::Providers::Amazon::Inventory::Target::TargetCollection < ManageI
       vm_and_miq_template_ancestry_init_data(
         :dependency_attributes => {
           :vms           => [inventory_collections[:vms]],
-          :miq_templates => [inventory_collections[:miq_templates]]}))
+          :miq_templates => [inventory_collections[:miq_templates]]
+        }
+      )
+    )
 
     add_inventory_collection(
       orchestration_stack_ancestry_init_data(
         :dependency_attributes => {
           :orchestration_stacks           => [inventory_collections[:orchestration_stacks]],
-          :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]}))
+          :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]
+        }
+      )
+    )
   end
 
   private

--- a/app/models/manageiq/providers/amazon/inventory/target/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/target/target_collection.rb
@@ -3,62 +3,17 @@ class ManageIQ::Providers::Amazon::Inventory::Target::TargetCollection < ManageI
     add_targeted_inventory_collections
     add_remaining_inventory_collections(:strategy => :local_db_find_one)
 
-    vm_and_miq_template_ancestry_save_block = lambda do |_ems, inventory_collection|
-      # Fetch IDs of all vms and genealogy_parents, only if genealogy_parent is present
-      vms_genealogy_parents = inventory_collection.dependency_attributes[:vms].first.data.each_with_object({}) do |x, obj|
-        genealogy_parent_id = x.data[:genealogy_parent].load.try(:id)
-        obj[x.id]           = genealogy_parent_id if genealogy_parent_id
-      end
-
-      miq_templates = ManageIQ::Providers::Amazon::CloudManager::Template
-                      .select([:id])
-                      .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
-
-      ManageIQ::Providers::Amazon::CloudManager::Vm
-        .select([:id])
-        .where(:id => vms_genealogy_parents.keys).find_each do |vm|
-        parent = miq_templates[vms_genealogy_parents[vm.id]]
-        parent.with_relationship_type('genealogy') { parent.set_child(vm) }
-      end
-    end
+    add_inventory_collection(
+      vm_and_miq_template_ancestry_init_data(
+        :dependency_attributes => {
+          :vms           => [inventory_collections[:vms]],
+          :miq_templates => [inventory_collections[:miq_templates]]}))
 
     add_inventory_collection(
-      [
-        ManageIQ::Providers::Amazon::CloudManager::Vm,
-        :custom_save_block     => vm_and_miq_template_ancestry_save_block,
-        :dependency_attributes => {:vms           => [inventory_collections[:vms]],
-                                   :miq_templates => [inventory_collections[:miq_templates]]}
-      ],
-      :vm_and_miq_template_ancestry
-    )
-
-    orchestration_stack_ancestry_save_block = lambda do |_ems, inventory_collection|
-      stacks_parents = inventory_collection.dependency_attributes[:orchestration_stacks].first.data.each_with_object({}) do |x, obj|
-        parent_id = x.data[:parent].load.try(:id)
-        obj[x.id] = parent_id if parent_id
-      end
-
-      stacks_parents_indexed = ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack
-                               .select([:id, :ancestry])
-                               .where(:id => stacks_parents.values).find_each.index_by(&:id)
-
-      ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack
-        .select([:id, :ancestry])
-        .where(:id => stacks_parents.keys).find_each do |stack|
-        parent = stacks_parents_indexed[stacks_parents[stack.id]]
-        stack.update_attribute(:parent, parent)
-      end
-    end
-
-    add_inventory_collection(
-      [
-        ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack,
-        :custom_save_block     => orchestration_stack_ancestry_save_block,
-        :dependency_attributes => {:orchestration_stacks           => [inventory_collections[:orchestration_stacks]],
-                                   :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]}
-      ],
-      :orchestration_stack_ancestry
-    )
+      orchestration_stack_ancestry_init_data(
+        :dependency_attributes => {
+          :orchestration_stacks           => [inventory_collections[:orchestration_stacks]],
+          :orchestration_stacks_resources => [inventory_collections[:orchestration_stacks_resources]]}))
   end
 
   private


### PR DESCRIPTION
Moving to use only kwargs for InventoryCollection init.
Unifying format, preparing for the abstraction of the
InventoryCollection definitions.

Depends on https://github.com/ManageIQ/manageiq/pull/13739