### PR TITLE
Creates the AWS SNS topic if one isn't already present.

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -110,6 +110,8 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
     end
   end
 
+  # @return [Aws::SNS::Topic] the found topic
+  # @raise [ProviderUnreachable] in case the topic is not found
   def sns_topic
     @ems.with_provider_connection(:service => :SNS) do |sns|
       get_topic(sns) || create_topic(sns)
@@ -124,7 +126,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
     sns.create_topic(:name => @topic_name)
     $aws_log.info("Created SNS topic #{@topic_name}")
   rescue Aws::SNS::Errors::ServiceError => err
-    $aws_log.error("Cannot create SNS topic #{@topic_name}, #{err.class.name}, Message=#{err.message}")
+    raise ProviderUnreachable, "Cannot create SNS topic #{@topic_name}, #{err.class.name}, Message=#{err.message}"
   end
 
   # @param [Aws::SNS::Topic] topic


### PR DESCRIPTION
Currently, if the AWS_Config SNS topic does not exist on AWS a warning is written to the aws.log file and events are not collected.
This PR will first try to get the AWS_Config topic, and if it does not exist one will be created.

https://github.com/ManageIQ/manageiq-providers-amazon/issues/126
https://www.pivotaltracker.com/story/show/138951121