### PR TITLE
[WIP] Decouple S3 Storage Manager from Amazon CloudProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /config/environments/*.local.yml
 
 /spec/manageiq
+.idea/*

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -22,6 +22,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   OrchestrationTemplateCfn.register_eligible_manager(self)
 
   include ManageIQ::Providers::Amazon::ManagerMixin
+  include ManageIQ::Providers::Amazon::StandaloneS3Mixin
 
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
@@ -58,12 +59,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
            :to        => :ebs_storage_manager,
            :allow_nil => true
 
-  has_one :s3_storage_manager,
-          :foreign_key => :parent_ems_id,
-          :class_name  => "ManageIQ::Providers::Amazon::StorageManager::S3",
-          :autosave    => true,
-          :dependent   => :destroy
-
   delegate :cloud_object_store_containers,
            :cloud_object_store_objects,
            :to        => :s3_storage_manager,
@@ -85,11 +80,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     ebs_storage_manager.name            = "#{name} EBS Storage Manager"
     ebs_storage_manager.zone_id         = zone_id
     ebs_storage_manager.provider_region = provider_region
-
-    build_s3_storage_manager unless s3_storage_manager
-    s3_storage_manager.name            = "#{name} S3 Storage Manager"
-    s3_storage_manager.zone_id         = zone_id
-    s3_storage_manager.provider_region = provider_region
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/amazon/standalone_s3_mixin.rb
+++ b/app/models/manageiq/providers/amazon/standalone_s3_mixin.rb
@@ -1,0 +1,71 @@
+module ManageIQ::Providers::Amazon::StandaloneS3Mixin
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :match_manager_group
+    after_create :ensure_s3_storage_manager
+    before_destroy :remove_s3_storage_manager
+  end
+
+  # connect clound manager with other cloud managers that use same userid/password
+  # (S3 manager is shared within manager_group)
+  def match_manager_group
+    return unless default_authentication
+
+    matching_manager = ManageIQ::Providers::Amazon::CloudManager.joins(:authentications).find_by(
+      "userid = :id", :id => default_authentication.userid
+    )
+    self.manager_group = matching_manager.manager_group if matching_manager
+  end
+
+  # obtain storage manager that belongs to my manager_group
+  def s3_storage_manager
+    ManageIQ::Providers::Amazon::StorageManager::S3.find_by(:manager_group => manager_group)
+  end
+
+  # create storage manager for this manager_group if not exist
+  def ensure_s3_storage_manager
+    return if s3_storage_manager
+
+    manager = ManageIQ::Providers::Amazon::StorageManager::S3.new(
+      :name            => "S3 Storage Manager (#{manager_group})",
+      :zone_id         => zone_id,
+      :manager_group   => manager_group,
+      :parent_ems_id   => nil,
+      :provider_region => provider_region # TODO: S3 is region agnostic
+    )
+
+    # Duplicate endpoint and authentication from CloudManager
+    manager.endpoints << default_endpoint.dup
+    manager.authentications << default_authentication.dup if default_authentication
+
+    manager.save!
+  end
+
+  # replicate cloud manager authentication updates on S3
+  def after_update_authentication
+    cred = default_authentication
+    manager = s3_storage_manager
+    manager.update_authentication(:default => {:userid => cred.userid, :password => cred.password}) if manager
+  end
+
+  # remove S3 manager together with last cloud manager
+  def remove_s3_storage_manager
+    manager = s3_storage_manager
+    return unless manager
+
+    if ManageIQ::Providers::Amazon::CloudManager.where(:manager_group => manager_group).count == 1
+      manager.delete
+    end
+  end
+
+  # manually add s3 manager to list of storage managers
+  def storage_managers
+    manager = s3_storage_manager
+    if manager
+      super << manager
+    else
+      super
+    end
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -6,22 +6,6 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
   include ManageIQ::Providers::Amazon::ManagerMixin
   include ManageIQ::Providers::StorageManager::ObjectMixin
 
-  delegate :authentication_check,
-           :authentication_status,
-           :authentications,
-           :authentication_for_summary,
-           :zone,
-           :connect,
-           :verify_credentials,
-           :with_provider_connection,
-           :address,
-           :ip_address,
-           :hostname,
-           :default_endpoint,
-           :endpoints,
-           :to        => :parent_manager,
-           :allow_nil => true
-
   def self.ems_type
     @ems_type ||= "s3".freeze
   end


### PR DESCRIPTION
This commit introduces S3 Storage Manager as a standalone management system so that multiple CloudManagers can share it.

When first Amazon Cloud Manager is created, it creates a new S3 Manager giving it a copy of its own authentication data. Then when another Amazon Cloud Manager is created using same WS_ACCESS_KEY_ID, no new S3 Manager is created - the existing one is shared.

At the moment there is no GUI for manually editing S3 credentials, but when credentials for Amazon Cloud Manager are updated, change is reflected to S3 as well. When all Amazon Cloud Managers are removed,
the S3 manager is also removed.

How does MIQ know which S3 manager belongs to a given Cloud Manager?
-> A new field `manager_group` is added to the ExtManagementSystem model. Cloud Managers with identic AWS_ACCESS_KEY_ID are given equal manager_group. S3 Manager is given same manager_group.

This commit depends on [introduction of `manager_group` field](https://github.com/ManageIQ/manageiq/pull/13771) in the main repo.
