### PR TITLE
Hook CloudManager to Provider

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -33,6 +33,20 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
            :autosave    => true,
            :dependent   => :destroy
 
+  delegate :authentication_check,
+           :authentication_status,
+           :authentications,
+           :authentication_for_summary,
+           :raw_connect,
+           :verify_credentials,
+           :translate_exception,
+           :with_provider_connection,
+           :default_endpoint,
+           :endpoints,
+           :s3_storage_manager,
+           :to        => :provider,
+           :allow_nil => false
+
   delegate :floating_ips,
            :security_groups,
            :cloud_networks,
@@ -56,12 +70,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
            :to        => :ebs_storage_manager,
            :allow_nil => true
 
-  has_one :s3_storage_manager,
-          :foreign_key => :parent_ems_id,
-          :class_name  => "ManageIQ::Providers::Amazon::StorageManager::S3",
-          :autosave    => true,
-          :dependent   => :destroy
-
   delegate :cloud_object_store_containers,
            :cloud_object_store_objects,
            :to        => :s3_storage_manager,
@@ -83,11 +91,10 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     ebs_storage_manager.name            = "#{name} EBS Storage Manager"
     ebs_storage_manager.zone_id         = zone_id
     ebs_storage_manager.provider_region = provider_region
+  end
 
-    build_s3_storage_manager unless s3_storage_manager
-    s3_storage_manager.name            = "#{name} S3 Storage Manager"
-    s3_storage_manager.zone_id         = zone_id
-    s3_storage_manager.provider_region = provider_region
+  def provider_class
+    ManageIQ::Providers::Amazon::Provider
   end
 
   def self.ems_type

--- a/app/models/manageiq/providers/amazon/provider.rb
+++ b/app/models/manageiq/providers/amazon/provider.rb
@@ -1,0 +1,66 @@
+class ManageIQ::Providers::Amazon::Provider < ::Provider
+  include ConnectionConfigurationMixin
+  include ManageIQ::Providers::Amazon::ProviderMixin
+
+  has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
+
+  has_many :cloud_managers,
+           :foreign_key => :provider_id,
+           :class_name  => "ManageIQ::Providers::Amazon::CloudManager",
+           :autosave    => true,
+           :dependent   => :destroy
+
+  has_one :s3_storage_manager,
+          :foreign_key => :provider_id,
+          :class_name  => "ManageIQ::Providers::Amazon::StorageManager::S3",
+          :autosave    => true,
+          :dependent   => :destroy
+
+  before_create :ensure_managers
+
+  def ensure_managers
+    build_s3_storage_manager unless s3_storage_manager
+    s3_storage_manager.name            = "S3 Storage Manager for #{name}"
+    s3_storage_manager.zone_id         = zone_id
+    s3_storage_manager.provider_region = "us-east-1" # TODO: S3 is region agnostic
+  end
+
+  def cloud_manager_for_region(provider_region)
+    cloud_managers.find{|el| el.provider_region == provider_region}
+  end
+
+  def provider_regions=(x)
+    ensure_managers_for_regions x
+  end
+
+  def provider_regions
+    cloud_managers.pluck(:provider_region)
+  end
+
+  def ensure_managers_for_regions(provider_regions)
+    provider_regions.each do |provider_region|
+      ensure_managers_for_region(provider_region)
+    end
+
+    # remove managers for other regions
+    obsolete_managers = cloud_managers.select{|el| !provider_regions.include? el.provider_region}
+    obsolete_managers.each do |el|
+      cloud_managers.delete(el)
+      el.destroy
+    end
+  end
+
+  def ensure_managers_for_region(provider_region)
+    if cloud_manager_for_region(provider_region).nil?
+      cloud_manager = ManageIQ::Providers::Amazon::CloudManager.new
+      cloud_manager.name            = "#{name} - EC2 (#{provider_region})"
+      cloud_manager.zone_id         = zone_id
+      cloud_manager.provider_region = provider_region
+      cloud_managers << cloud_manager
+    end
+  end
+
+  def supports_authentication?(authtype)
+    authtype.to_s == "default"
+  end
+end

--- a/app/models/manageiq/providers/amazon/provider_mixin.rb
+++ b/app/models/manageiq/providers/amazon/provider_mixin.rb
@@ -1,0 +1,67 @@
+module ManageIQ::Providers::Amazon::ProviderMixin
+  extend ActiveSupport::Concern
+
+  def connect(options = {})
+    raise "no credentials defined" if missing_credentials?(options[:auth_type])
+
+    username = options[:user] || authentication_userid(options[:auth_type])
+    password = options[:pass] || authentication_password(options[:auth_type])
+    service  = options[:service] || :EC2
+    proxy    = options[:proxy_uri] || http_proxy_uri
+    region   = options[:provider_region] || "us-east-1"
+
+    self.class.raw_connect(username, password, service, region, proxy)
+  end
+
+  def translate_exception(err)
+    require 'aws-sdk'
+    case err
+    when Aws::EC2::Errors::SignatureDoesNotMatch
+      MiqException::MiqHostError.new "SignatureMismatch - check your AWS Secret Access Key and signing method"
+    when Aws::EC2::Errors::AuthFailure
+      MiqException::MiqHostError.new "Login failed due to a bad username or password."
+    when Aws::Errors::MissingCredentialsError
+      MiqException::MiqHostError.new "Missing credentials"
+    else
+      MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
+    end
+  end
+
+  def verify_credentials(auth_type = nil, options = {})
+    raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
+
+    begin
+      # EC2 does Lazy Connections, so call a cheap function
+      with_provider_connection(options.merge(:auth_type => auth_type)) do |ec2|
+        ec2.client.describe_regions.regions.map(&:region_name)
+      end
+    rescue => err
+      miq_exception = translate_exception(err)
+      raise unless miq_exception
+
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      raise miq_exception
+    end
+
+    true
+  end
+
+  def http_proxy_uri
+    VMDB::Util.http_proxy_uri(emstype.try(:to_sym)) || VMDB::Util.http_proxy_uri
+  end
+
+  module ClassMethods
+    def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri = nil)
+      require 'aws-sdk'
+      Aws.const_get(service)::Resource.new(
+        :access_key_id     => access_key_id,
+        :secret_access_key => secret_access_key,
+        :region            => region,
+        :http_proxy        => proxy_uri,
+        :logger            => $aws_log,
+        :log_level         => :debug,
+        :log_formatter     => Aws::Log::Formatter.new(Aws::Log::Formatter.default.pattern.chomp)
+      )
+    end
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -14,13 +14,10 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
            :connect,
            :verify_credentials,
            :with_provider_connection,
-           :address,
-           :ip_address,
-           :hostname,
            :default_endpoint,
            :endpoints,
-           :to        => :parent_manager,
-           :allow_nil => true
+           :to        => :provider,
+           :allow_nil => false
 
   def self.ems_type
     @ems_type ||= "s3".freeze

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+
+  factory(:provider_amazon, :class => "ManageIQ::Providers::Amazon::Provider", :parent => :provider) do
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/amazon/provider_spec.rb
+++ b/spec/models/manageiq/providers/amazon/provider_spec.rb
@@ -1,0 +1,85 @@
+require_relative 'aws_helper'
+require_relative 'aws_stubs'
+
+describe ManageIQ::Providers::Amazon::Provider do
+  before do
+    @provider_regions = ['us-east-1', 'us-east-2']
+    _, _, @zone = EvmSpecHelper.create_guid_miq_server_zone
+
+    @provider = FactoryGirl.create(:provider_amazon, :zone => @zone, :provider_regions => @provider_regions)
+
+    @original_ids = extract_ids @provider.cloud_managers
+  end
+
+  it "provider creates managers" do
+    expect(@provider.default_authentication).not_to be_nil
+    expect(@provider.s3_storage_manager).not_to be_nil
+    expect(@provider.cloud_managers.count).to eq(@provider_regions.count)
+    expect(@provider.provider_regions).to eq(@provider_regions)
+  end
+
+  it "provider adds/deletes cloud managers for regions (no intersection)" do
+    # assign same regions
+    @provider.provider_regions = @provider_regions
+
+    expect(@provider.cloud_managers.count).to eq(@provider_regions.count)
+    expect(extract_ids @provider.cloud_managers).to eq(@original_ids)
+    expect(@provider.provider_regions).to eq(@provider_regions)
+
+    # assign other regions (no intersection)
+    provider_regions2 = ['us-west-1', 'us-west-2', 'ap-southeast-1']
+    @provider.provider_regions = provider_regions2
+
+    expect(@provider.cloud_managers.count).to eq(provider_regions2.count)
+    expect(ManageIQ::Providers::Amazon::CloudManager.count).to eq(provider_regions2.count)
+    expect(@provider.provider_regions).to eq(provider_regions2)
+  end
+
+  it "provider adds/deletes cloud managers for regions (with intersection)" do
+    # assign additional region
+    @provider.provider_regions = ['us-east-1', 'us-east-2', 'ap-southeast-1']
+
+    expect(@provider.cloud_managers.count).to eq(3)
+    expect(extract_ids @provider.cloud_managers).to include(*@original_ids)
+  end
+
+  it "managers use provider's authentication" do
+    expect(Authentication.count).to eq(1) # all managers share provider's credentials
+
+    expect(@provider.s3_storage_manager.default_authentication).not_to be_nil
+    expect(@provider.s3_storage_manager.default_authentication.id).to eq(@provider.default_authentication.id)
+
+    @provider.cloud_managers.each do |el|
+      expect(el.default_authentication).not_to be_nil
+      expect(el.default_authentication.id).to eq(@provider.default_authentication.id)
+    end
+  end
+
+  it "cloud manager lists s3 manager as well" do
+    @s3_manager = @provider.s3_storage_manager
+    @provider.cloud_managers.each do |el|
+      expect(el.s3_storage_manager).not_to be_nil
+      expect(el.s3_storage_manager.id).to eq(@provider.s3_storage_manager.id)
+      expect(extract_ids(el.storage_managers)).to include(@s3_manager.id)
+    end
+  end
+
+  it "s3 manager points to no cloud manager" do
+    expect(@provider.s3_storage_manager.parent_manager).to be_nil
+  end
+
+  it "provider regions to string" do
+    expect(@provider.provider_regions.join(",")).to eq("us-east-1,us-east-2")
+
+    @provider.provider_regions = []
+
+    expect(@provider.provider_regions.join(",")).to eq("")
+  end
+
+  private
+
+  def extract_ids(objects)
+    objects.map{|el| el.id}
+  end
+
+end

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -7,8 +7,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
   describe "refresh" do
     before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-      @ems                 = FactoryGirl.create(:ems_amazon, :zone => zone)
-      @ems.update_authentication(:default => {:userid => "0123456789", :password => "ABCDEFGHIJKL345678efghijklmno"})
+      @provider            = FactoryGirl.create(:provider_amazon, :zone => zone, :provider_regions => ['us-west-1'])
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)
     end
 
@@ -61,12 +60,12 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
   end
 
   def refresh_spec
-    @ems.reload
+    @provider.reload
 
     with_aws_stubbed(stub_responses) do
-      EmsRefresh.refresh(@ems.s3_storage_manager)
+      EmsRefresh.refresh(@provider.s3_storage_manager)
     end
-    @ems.reload
+    @provider.reload
 
     assert_table_counts
     assert_ems
@@ -171,7 +170,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
   end
 
   def assert_ems
-    ems = @ems.s3_storage_manager
+    ems = @provider.s3_storage_manager
     expect(ems).to have_attributes(:api_version => nil,
                                    :uid_ems     => nil)
 


### PR DESCRIPTION
This commit addresses a need to group Amazon Managers
that connect with same credentials. Also, with this commit
we make S3 storage manager shared among them.

Before commit:
```
CloudManager (us-west-1) --- auth
|
NetworkManager,EBS,S3
```

After commit:

```
Provider --- auth
|
CloudManager (us-west-1), CloudManager (us-east-1), ...,S3
|
NetworkManager,EBS
```

This PR depends on these two PRs:

* https://github.com/ManageIQ/manageiq/pull/13915
* https://github.com/ManageIQ/manageiq-ui-classic/pull/388