### PR TITLE
[WIP] add amazon events

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,17 @@
 ---
+:amazon:
+  :event_handling:
+    :event_groups:
+      :addition:
+        :critical:
+        - AWS_EC2_Instance_CREATE
+        - AWS_EC2_Instance_UPDATE
+        - AWS_EC2_Instance_DELETE
+      :power:
+        :critical:
+        - AWS_EC2_Instance_running
+        - AWS_EC2_Instance_shutting-down
+        - AWS_EC2_Instance_stopped
 :ems:
   :ems_amazon:
     :disabled_regions: []


### PR DESCRIPTION
I'm trying to add events to be displayed in timelines

If I do it this way, it will overwrite the `:critical` keys from manageiq core settings, because thats how the settings work. They overwrite - they don't merge.

1. Change settings processing to merge arrays instead of overwrite
2. Change [EmsEvent.event_groups](https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_event.rb#L28) to also look at other keys, eg. `:ems -> <provider_name> -> :event_handling ...`
3. Overhaul the event_groups and put them into own files? in `config/settings/events/<any_file>.yml`
4. Overhaul the event_groups and put them into `manageiq-content`
5. make `EmsEvent.event_groups` configurable / injectable from outside. But that would require bootstrapping from the provider. 

I tend to lean towards 3 or 4. While 3 has the benefit of being in the provider repo.
But I guess we also need to able to tune the events via advanced settings in the UI.
This is a plus for 2. But people will probably overlook stuff under different keys than `:event_handling`, so this speaks for 1. 

Well, well.

Maybe move it all out of settings and give it a proper UI and model it in the DB via seeding?

https://bugzilla.redhat.com/show_bug.cgi?id=1392391

@Fryguy @bdunne @blomquisg  ?