### PR TITLE
Filter out events in Settings instead of CloudManager

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -103,11 +103,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   end
 
   def self.default_blacklisted_event_names
-    %w(
-      ConfigurationSnapshotDeliveryCompleted
-      ConfigurationSnapshotDeliveryStarted
-      ConfigurationSnapshotDeliveryFailed
-    )
+    Settings.ems.ems_amazon.blacklisted_event_names
   end
 
   #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,10 @@
 ---
 :ems:
   :ems_amazon:
+    :blacklisted_event_names:
+      - ConfigurationSnapshotDeliveryCompleted
+      - ConfigurationSnapshotDeliveryStarted
+      - ConfigurationSnapshotDeliveryFailed
     :disabled_regions: []
     # disable regions by their keys found in app/models/manageiq/providers/amazon/regions.rb e.g.
     # - us-gov-west-1


### PR DESCRIPTION
There is currently no way to filter out events using a configuration setting. There already is a blacklisted_events table but the only way to populate it is through hard coding event names in the provider cloud manager or to create rows through the rails console.

This PR creates a configuration setting for Amazon in the config/settings.yml file where event names to be filtered out can be added.

This change can be applied to each provider individually.

https://www.pivotaltracker.com/story/show/139861047
https://github.com/ManageIQ/manageiq-providers-amazon/issues/140
