### PR TITLE
Filter events using eventType instead of MessageType

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Runner < ManageIQ
   private
 
   def filtered?(event)
-    filtered_events.include?(event["messageType"])
+    filtered_events.include?(event["eventType"])
   end
 
   def event_monitor_handle


### PR DESCRIPTION
The [```filtered?```](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb#L30..32) event uses the event ```MessageType``` property to determine if an event is on the blacklist of events that should be filtered out. Prior to adding support for CloudWatch events, there was always a MessageType property but that is no longer the case.

The ```filtered?``` method receives the event after it has already been partially parsed and the event name has already been normalized. This allows us to use the event name regardless of the AWS service it came from.