### PR TITLE
remove validate_timeline

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -69,9 +69,4 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
     # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceState.html
     POWER_STATES[raw_power_state.to_s] || "terminated"
   end
-
-  def validate_timeline
-    {:available => false,
-     :message   => _("Timeline is not available for %{model}") % {:model => ui_lookup(:model => self.class.to_s)}}
-  end
 end

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -61,11 +61,6 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     true
   end
 
-  def validate_timeline
-    {:available => false,
-     :message   => _("Timeline is not available for %{model}") % {:model => ui_lookup(:model => self.class.to_s)}}
-  end
-
   module ClassMethods
     #
     # Connections


### PR DESCRIPTION
since https://github.com/ManageIQ/manageiq/pull/10588 got merged (a long time ago) these methods are no more called anyway - remove cruft