### PR TITLE
Support deletion of CloudObjectStoreContainer

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
@@ -28,6 +28,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
   def parse_container(bucket)
     uid = bucket['name']
     {
+      :type                  => self.class.container_type,
       :ext_management_system => ems,
       :ems_ref               => uid,
       :key                   => bucket['name']
@@ -72,5 +73,11 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
       :key                          => uid,
       :cloud_object_store_container => bucket
     }
+  end
+
+  class << self
+    def container_type
+      ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name
+    end
   end
 end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -11,9 +11,7 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
            :authentications,
            :authentication_for_summary,
            :zone,
-           :connect,
            :verify_credentials,
-           :with_provider_connection,
            :address,
            :ip_address,
            :hostname,
@@ -32,5 +30,10 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
 
   def self.hostname_required?
     false
+  end
+
+  def connect(options = {})
+    options[:service] = :S3
+    parent_manager.connect options
   end
 end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer < ::CloudObjectStoreContainer
+  supports :delete do
+    unless ext_management_system
+      unsupported_reason_add(:delete, _("The Storage Container is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+  end
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    connection.bucket(ems_ref)
+  end
+
+  def raw_delete
+    with_provider_object(&:delete!)
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
@@ -83,6 +83,7 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
     uid = bucket.name
 
     new_result = {
+      :type    => self.class.container_type,
       :ems_ref => uid,
       :key     => bucket.name
     }
@@ -101,5 +102,11 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
       :cloud_object_store_container_id => @data_index.fetch_path(:cloud_object_store_containers, bucket_id)
     }
     return uid, new_result
+  end
+
+  class << self
+    def container_type
+      ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name
+    end
   end
 end

--- a/spec/factories/cloud_object_store.rb
+++ b/spec/factories/cloud_object_store.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  factory :aws_object, :class => ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject.name do |object|
+    object.sequence(:key) { |n| "object-key-#{n}" }
+  end
+
+  factory :aws_bucket_with_objects,
+          :class => ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name do |bucket|
+    bucket.sequence(:name) { |n| "stubbed-name-#{n}" }
+    bucket.sequence(:ems_ref) { |n| "stubbed-ems-ref-#{n}" }
+
+    after(:create) do |bucket|
+      bucket.cloud_object_store_objects = FactoryGirl.create_list(
+        :aws_object, 5, :ext_management_system => bucket.ext_management_system
+      )
+    end
+  end
+end


### PR DESCRIPTION
CloudObjectStoreContainer now supports async task processing
therefore we support the first operation with this commit: destroy.
See video attached to the manage-ui-classic PR (link below).

Links:
* https://github.com/ManageIQ/manageiq/pull/13965 (already merged)
* https://github.com/ManageIQ/manageiq-ui-classic/pull/420 (GUI for this operation)

@miq-bot add_label enhancement
@miq-bot assign @blomquisg