### PR TITLE
set power state to shutting_down when rebooting an instance

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/guest.rb
@@ -11,6 +11,6 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations::Guest
   def raw_reboot_guest
     with_provider_object(&:reboot)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "pending") # show state as suspended
+    self.update_attributes!(:raw_power_state => "shutting_down")
   end
 end


### PR DESCRIPTION
Sets the same power state `shutting_down` when rebooting an instance as in the [stop operation](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/power.rb#L20)

`pending` is basically an intermediate state ([aws api](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceState.html)) - which we translate to [suspended](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager/vm.rb#L10). But we want to show it in the UI as `shutting down`

In case the operation was not carried out correct via aws, then the next refresh will set it to the real state.

@mkanoor I'm not sure if this has an impact on automate. See this PR https://github.com/ManageIQ/manageiq/pull/7477 - do you now if clicking a power button in the UI triggers a statemachine that could depend on the `pending` / `suspended` power state?



fixes https://bugzilla.redhat.com/show_bug.cgi?id=1401487