### PR TITLE
Reenable specs as an issue in core creating zombies was fixed

### DIFF
--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -131,9 +131,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
       :load_balancer_health_check        => 0,
       :load_balancer_health_check_member => 0,
       :cloud_object_store_containers     => test_counts[:s3_buckets_count],
-      # TODO(lsmola) old refresh is broken here, association.delete does not delete when we removed the cascade delete
-      # in https://github.com/ManageIQ/manageiq/pull/14009
-      # :cloud_object_store_objects        => test_counts[:s3_buckets_count] * test_counts[:s3_objects_per_bucket_count]
+      :cloud_object_store_objects        => test_counts[:s3_buckets_count] * test_counts[:s3_objects_per_bucket_count]
     }
   end
 
@@ -177,9 +175,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
       :load_balancer_health_check        => LoadBalancerHealthCheck.count,
       :load_balancer_health_check_member => LoadBalancerHealthCheckMember.count,
       :cloud_object_store_containers     => CloudObjectStoreContainer.count,
-      # TODO(lsmola) old refresh is broken here, association.delete does not delete when we removed the cascade delete
-      # in https://github.com/ManageIQ/manageiq/pull/14009
-      # :cloud_object_store_objects        => CloudObjectStoreObject.count
+      :cloud_object_store_objects        => CloudObjectStoreObject.count
     }
 
     expect(actual).to eq expected_table_counts


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/14038

Reenable specs as an issue in core creating zombies was fixed