### PR TITLE
Cloud volume operations

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -1,2 +1,83 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVolume
+  supports :create
+
+  def self.validate_create_volume(ext_management_system)
+    validate_volume(ext_management_system)
+  end
+
+  def self.raw_create_volume(ext_management_system, options)
+    volume_name = options.delete(:name)
+    volume = nil
+
+    ext_management_system.with_provider_connection do |service|
+      # Create the volume using provided options.
+      volume = service.client.create_volume(options)
+      # Also name the volume using tags.
+      service.client.create_tags(
+        :resources => [volume.volume_id],
+        :tags      => [{ :key => "Name", :value => volume_name }]
+      )
+    end
+    {:ems_ref => volume.volume_id, :status => volume.state, :name => volume_name}
+  rescue => e
+    _log.error "volume=[#{volume_name}], error: #{e}"
+    raise MiqException::MiqVolumeCreateError, e.to_s, e.backtrace
+  end
+
+  def validate_update_volume
+    validate_volume
+  end
+
+  def raw_update_volume(options)
+    # Only name update is currently supported
+    if options.key?(:name)
+      with_provider_object do |volume|
+        volume.create_tags(:tags => [{:key => "Name", :value => options[:name]}])
+      end
+    end
+  rescue => e
+    _log.error "volume=[#{name}], error: #{e}"
+    raise MiqException::MiqVolumeUpdateError, e.to_s, e.backtrace
+  end
+
+  def validate_delete_volume
+    msg = validate_volume
+    return {:available => msg[:available], :message => msg[:message]} unless msg[:available]
+    if with_provider_object(&:state) == "in-use"
+      return validation_failed("Create Volume", "Can't delete volume that is in use.")
+    end
+    {:available => true, :message => nil}
+  end
+
+  def raw_delete_volume
+    with_provider_object(&:delete)
+  rescue => e
+    _log.error "volume=[#{name}], error: #{e}"
+    raise MiqException::MiqVolumeDeleteError, e.to_s, e.backtrace
+  end
+
+  def validate_attach_volume
+    validate_volume_available
+  end
+
+  def raw_attach_volume(server_ems_ref, device = nil)
+    with_provider_object do |vol|
+      vol.attach_to_instance(:instance_id => server_ems_ref, :device => device)
+    end
+  end
+
+  def validate_detach_volume
+    validate_volume_in_use
+  end
+
+  def raw_detach_volume(server_ems_ref)
+    with_provider_object do |vol|
+      vol.detach_from_instance(:instance_id => server_ems_ref)
+    end
+  end
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    connection.volume(ems_ref)
+  end
 end

--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :cloud_volume_amazon, :parent => :cloud_volume,
+                                :class  => "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume"
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :ems_amazon_ebs,
+          :aliases => ["manageiq/providers/amazon/storage_manager/ebs"],
+          :class   => "ManageIQ::Providers::Amazon::StorageManager::Ebs",
+          :parent  => :ems_storage do
+    provider_region "us-east-1"
+  end
+end

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
@@ -1,0 +1,104 @@
+require_relative "../../aws_helper"
+
+describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume do
+  let(:ems_cloud) { FactoryGirl.create(:ems_amazon_with_authentication) }
+  let(:ebs) { FactoryGirl.create(:ems_amazon_ebs, :parent_ems_id => ems_cloud.id) }
+  let(:cloud_volume) { FactoryGirl.create(:cloud_volume_amazon, :ext_management_system => ebs, :ems_ref => "vol_1") }
+
+  describe "cloud volume operations" do
+    context ".raw_create_volume" do
+      it "creates a volume" do
+        stubbed_responses = {
+          :ec2 => {
+            :create_volume => {
+              :volume_id         => "volume_id",
+              :size              => 1,
+              :availability_zone => "az1",
+              :state             => "creating",
+              :volume_type       => "gp2"
+            },
+            :create_tags   => {}
+          }
+        }
+
+        options = {
+          :name              => "volume",
+          :availability_zone => "az1",
+          :size              => 1,
+          :volume_type       => "gp2",
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect(CloudVolume.create_volume(ebs, options)).to be_truthy
+        end
+      end
+    end
+
+    context "#delete_volume" do
+      it "deletes the cloud volume" do
+        stubbed_responses = {
+          :ec2 => {
+            :delete_volume => {}
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect(cloud_volume.delete_volume).to be_truthy
+        end
+      end
+
+      it "catches error from the provider" do
+        stubbed_responses = {
+          :ec2 => {
+            :delete_volume => "UnauthorizedOperation"
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect do
+            cloud_volume.delete_volume
+          end.to raise_error(MiqException::MiqVolumeDeleteError)
+        end
+      end
+    end
+
+    context "#attach_volume" do
+      let(:instance) { FactoryGirl.create(:vm_amazon, :ext_management_system => ems_cloud, :ems_ref => "instance_0") }
+
+      it "attaches the cloud volume" do
+        stubbed_responses = {
+          :ec2 => {
+            :attach_volume => {
+              :volume_id   => cloud_volume.ems_ref,
+              :instance_id => instance.ems_ref,
+              :device      => "/dev/sdm"
+            }
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect(cloud_volume.attach_volume(instance.ems_ref, "/dev/sdm")).to be_truthy
+        end
+      end
+    end
+
+    context "#detach_volume" do
+      # Register the attachment of the volume to an instance.
+      let(:disk) { FactoryGirl.create(:disk, :controller_type => "amazon", :device_type => "disk", :device_name => "sda1", :location => "sda1", :backing_id => cloud_volume.id) }
+      let(:hardware) { FactoryGirl.create(:hardware, :disks => [disk]) }
+      let(:instance) { FactoryGirl.create(:vm_amazon, :ext_management_system => ems_cloud, :ems_ref => "instance_0", :hardware => hardware) }
+
+      it "detaches the cloud volume" do
+        stubbed_responses = {
+          :ec2 => {
+            :detach_volume => {}
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect(cloud_volume.detach_volume(instance.ems_ref)).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds support for the following operations on the cloud volume: create new, attach, detach, delete and update name. Stubbed specs are provided for these operations.

@miq-bot add_label enhancement
@miq-bot assign @blomquisg