### PR TITLE
Support deletion of CloudObjectStoreObject

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
@@ -65,6 +65,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
   def parse_object(object, bucket)
     uid = object['key']
     {
+      :type                         => self.class.object_type,
       :ext_management_system        => ems,
       :ems_ref                      => "#{bucket.ems_ref}_#{uid}",
       :etag                         => object['etag'],
@@ -78,6 +79,10 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
   class << self
     def container_type
       ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name
+    end
+
+    def object_type
+      ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject.name
     end
   end
 end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
@@ -1,0 +1,24 @@
+class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject < ::CloudObjectStoreObject
+  supports :delete do
+    unless ext_management_system
+      unsupported_reason_add(:delete, _("The Storage Object is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+
+    unless cloud_object_store_container
+      unsupported_reason_add(:delete, _("The Storage Object is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "cloud_object_store_containers")
+      })
+    end
+  end
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    connection.bucket(cloud_object_store_container.ems_ref).object(key)
+  end
+
+  def raw_delete
+    with_provider_object(&:delete)
+  end
+end

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
@@ -94,6 +94,7 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
     uid = object.key
 
     new_result = {
+      :type                            => self.class.object_type,
       :ems_ref                         => "#{bucket_id}_#{uid}",
       :etag                            => object.etag,
       :last_modified                   => object.last_modified,
@@ -107,6 +108,10 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
   class << self
     def container_type
       ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name
+    end
+
+    def object_type
+      ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject.name
     end
   end
 end


### PR DESCRIPTION
Support deletion of CloudObjectStoreObject for Amazon provider.

Depends on (from other repos):
* https://github.com/ManageIQ/manageiq/pull/14080 (merged)
* https://github.com/ManageIQ/manageiq/pull/14189 (must be merged in one take with this PR) 👈 ‼️ 

Will enable merge of:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/497