### PR TITLE
Support operation "clear" on CloudObjectStoreContainer

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
@@ -7,6 +7,21 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer
     end
   end
 
+  supports :cloud_object_store_container_clear do
+    unless ext_management_system
+      unsupported_reason_add(
+        :cloud_object_store_container_clear,
+        _("The Storage Container is not connected to an active %{table}") % {
+          :table => ui_lookup(:table => "ext_management_systems")
+        }
+      )
+    end
+
+    unless cloud_object_store_objects.count.positive?
+      unsupported_reason_add(:cloud_object_store_container_clear, _("The Storage Container is already empty"))
+    end
+  end
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.bucket(ems_ref)
@@ -14,5 +29,9 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer
 
   def raw_delete
     with_provider_object(&:delete!)
+  end
+
+  def raw_cloud_object_store_container_clear
+    with_provider_object(&:clear!)
   end
 end


### PR DESCRIPTION
With this commit we implement raw method that clears bucket on the S3. We also render it supported so that GUI will display button. To `clear` bucket means to remove all objects within it.

Depends on (from other repos):
* https://github.com/ManageIQ/manageiq/pull/14082 (merged)