### PR TITLE
[WIP] Save remote AWS tags locally

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -11,9 +11,6 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     @data_index          = {}
     @known_flavors       = Set.new
     @options             = options
-    @category_name       = "amazon"
-    @category_desc       = "Amazon"
-    @category            = find_or_create_category(@category_name)
   end
 
   def ems_inv_to_hashes
@@ -38,18 +35,6 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
 
   private
 
-  # Define a custom Category (Classification) for tags that are pulled
-  # down from AWS. Those tags will be assigned to this category.
-  #
-  def find_or_create_category(name)
-    tag = Tag.find_or_create_by_classification_name(name)
-
-    Category.find_or_create_by(:description => @category_desc) do |cat|
-      cat.tag          = tag
-      cat.example_text = "Tags for Amazon resources"
-    end
-  end
-
   # Convert the resource.tags into an array of hashes. In addition, reject
   # the key of "name" since that is already being used to establish the
   # resource's name for the UI.
@@ -59,43 +44,11 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
 
     unless resource.tags.blank?
       resource.tags.each do |struct|
-        array << {struct[:key] => struct[:value]} if struct[:key].to_s.downcase != 'name'
+        array << {struct[:key] => struct[:value]}
       end
     end
 
     array
-  end
-
-  # Takes an array of resource objects and creates the necessary entries within
-  # the classifications, tags and taggings database. The +type+ should be the
-  # model type, e.g. VmOrTemplate.
-  #
-  # Note that this method should only be called after process_collection in
-  # order to ensure that the resource already exists in the database locally,
-  # otherwise the Tagging cannot be set.
-  #
-  def create_tags_for_resources(resources, type)
-    resources.each do |resource|
-      tags = parse_tags(resource) # Returns an array of key/value pairs
-      tags.each do |hash|
-        hash.each do |key, value|
-          name = "/managed/#{@category_name}/#{key.downcase}:#{value.downcase}"
-          tag  = Tag.find_or_create_by(:name => name)
-
-          category = Category.find_or_create_by(:description => "#{key.downcase}/#{value.downcase}") do |cat|
-            cat.parent = @category
-            cat.tag    = tag
-          end
-
-          object = Object.const_get(type).find_by(:uid_ems => resource.id)
-
-          Tagging.find_or_create_by(:tag => tag) do |tagging|
-            tagging.taggable_type = type
-            tagging.taggable = object
-          end
-        end
-      end
-    end
   end
 
   def get_flavors
@@ -166,7 +119,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
   def get_instances
     instances = @aws_ec2.instances
     process_collection(instances, :vms) { |instance| parse_instance(instance) }
-    create_tags_for_resources(instances, 'VmOrTemplate')
+    #create_tags_for_resources(instances, 'VmOrTemplate')
   end
 
   def parse_flavor(flavor)
@@ -295,6 +248,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :vendor              => "amazon",
       :raw_power_state     => status,
       :boot_time           => instance.launch_time,
+      :tags                => parse_tags(instance),
       :hardware            => {
         :bitness              => architecture_to_bitness(instance.architecture),
         :virtualization_type  => instance.virtualization_type,

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -11,8 +11,8 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     @data_index          = {}
     @known_flavors       = Set.new
     @options             = options
-    @category_name       = "amazon_provider_tags"
-    @category_desc       = "Amazon Provider Tags"
+    @category_name       = "amazon"
+    @category_desc       = "Amazon"
     @category            = find_or_create_category(@category_name)
   end
 
@@ -79,9 +79,9 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       tags = parse_tags(resource) # Returns an array of key/value pairs
       tags.each do |hash|
         hash.each do |key, value|
-          tag = Tag.find_or_create_by(:name => "/managed/#{@category_name}/#{resource.id}/#{key}")
+          tag = Tag.find_or_create_by(:name => "/managed/#{@category_name}/#{key.downcase}/#{value.downcase}")
 
-          Category.find_or_create_by(:description => "#{resource.id}:#{key}:#{value}") do |cat|
+          category = Category.find_or_create_by(:description => "#{key.downcase}/#{value.downcase}") do |cat|
             cat.parent = @category
             cat.tag    = tag
           end

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -119,7 +119,6 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
   def get_instances
     instances = @aws_ec2.instances
     process_collection(instances, :vms) { |instance| parse_instance(instance) }
-    #create_tags_for_resources(instances, 'VmOrTemplate')
   end
 
   def parse_flavor(flavor)

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -79,7 +79,8 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       tags = parse_tags(resource) # Returns an array of key/value pairs
       tags.each do |hash|
         hash.each do |key, value|
-          tag = Tag.find_or_create_by(:name => "/managed/#{@category_name}/#{key.downcase}/#{value.downcase}")
+          name = "/managed/#{@category_name}/#{key.downcase}/#{value.downcase}"
+          tag  = Tag.find_or_create_by(:name => name)
 
           category = Category.find_or_create_by(:description => "#{key.downcase}/#{value.downcase}") do |cat|
             cat.parent = @category
@@ -88,9 +89,9 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
 
           object = Object.const_get(type).find_by(:uid_ems => resource.id)
 
-          Tagging.find_or_create_by(:tag_id => tag.id) do |tagging|
+          Tagging.find_or_create_by(:tag => tag) do |tagging|
             tagging.taggable_type = type
-            tagging.taggable_id = object.id
+            tagging.taggable = object
           end
         end
       end

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -79,7 +79,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       tags = parse_tags(resource) # Returns an array of key/value pairs
       tags.each do |hash|
         hash.each do |key, value|
-          name = "/managed/#{@category_name}/#{key.downcase}/#{value.downcase}"
+          name = "/managed/#{@category_name}/#{key.downcase}:#{value.downcase}"
           tag  = Tag.find_or_create_by(:name => name)
 
           category = Category.find_or_create_by(:description => "#{key.downcase}/#{value.downcase}") do |cat|


### PR DESCRIPTION
This is a first stab at converting remote key/value pairs on AWS tags into something we can store and re-use locally. This is complicated by the fact that:

* Currently tags, and their values, are split between two tables - classifications and tags.
* The classification description serves as the key's value. But, it must be unique within the table.
* The classification (or category subclass) is a self referential table.
* The tag and parent are then referenced within the classifications table for each value.
* The `taggings` table actually stores the reference to the tagged resource by type, e.g. VmOrTemplate.
* There are custom validations and methods on the `Tag`, `Classification`, `Category tables`.