### PR TITLE
Add cloud volume snapshot operations for EBS manager

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -76,6 +76,14 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
     end
   end
 
+  def create_volume_snapshot(options)
+    ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot.create_snapshot(self, options)
+  end
+
+  def create_volume_snapshot_queue(userid, options)
+    ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot.create_snapshot_queue(userid, self, options)
+  end
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.volume(ems_ref)

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
@@ -1,2 +1,98 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot < ::CloudVolumeSnapshot
+  supports :create
+  supports :update
+  supports :delete
+
+  def self.create_snapshot_queue(userid, cloud_volume, options = {})
+    ext_management_system = cloud_volume.try(:ext_management_system)
+    task_opts = {
+      :action => "creating volume snapshot in #{ext_management_system.inspect} for #{cloud_volume.inspect} with #{options.inspect}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => cloud_volume.class.name,
+      :instance_id => cloud_volume.id,
+      :method_name => 'create_volume_snapshot',
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone(ext_management_system),
+      :args        => [options]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def self.create_snapshot(cloud_volume, options = {})
+    raise ArgumentError, _("cloud_volume cannot be nil") if cloud_volume.nil?
+    ext_management_system = cloud_volume.try(:ext_management_system)
+    raise ArgumentError, _("ext_management_system cannot be nil") if ext_management_system.nil?
+
+    snapshot_name = options.delete(:name) if options.key?(:name)
+    snapshot = nil
+
+    ext_management_system.with_provider_connection do |service|
+      # Create the volume using provided options.
+      snapshot = service.client.create_snapshot(
+        :volume_id   => cloud_volume.ems_ref,
+        :description => options[:description]
+      )
+
+      if snapshot_name
+        service.client.create_tags(
+          :resources => [snapshot.snapshot_id],
+          :tags      => [{ :key => "Name", :value => snapshot_name }]
+        )
+      end
+    end
+
+    create(
+      :name                  => snapshot_name,
+      :description           => snapshot.description,
+      :ems_ref               => snapshot.snapshot_id,
+      :status                => snapshot.state,
+      :cloud_volume          => cloud_volume,
+      :ext_management_system => ext_management_system,
+    )
+  rescue => e
+    _log.error "snapshot=[#{options[:name]}], error: #{e}"
+    raise MiqException::MiqVolumeSnapshotCreateError, e.to_s, e.backtrace
+  end
+
+  def delete_snapshot_queue(userid = "system", _options = {})
+    task_opts = {
+      :action => "deleting volume snapshot #{inspect} in #{ext_management_system.inspect}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'delete_snapshot',
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def delete_snapshot(_options = {})
+    with_provider_object do |snapshot|
+      if snapshot
+        snapshot.delete
+      else
+        _log.warn "snapshot=[#{name}] already deleted"
+      end
+    end
+  rescue => e
+    _log.error "volume=[#{name}], error: #{e}"
+    raise MiqException::MiqVolumeSnapshotDeleteError, e.to_s, e.backtrace
+  end
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    connection.snapshot(ems_ref)
+  end
 end

--- a/spec/factories/cloud_volume_snapshot.rb
+++ b/spec/factories/cloud_volume_snapshot.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :cloud_volume_snapshot_amazon, :parent => :cloud_volume_snapshot,
+                                         :class  => "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot"
+end

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot_spec.rb
@@ -1,0 +1,37 @@
+require_relative "../../aws_helper"
+
+describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot do
+  let(:amazon) { FactoryGirl.create(:ems_amazon_with_authentication) }
+  let(:ems) { FactoryGirl.create(:ems_amazon_ebs, :parent_ems_id => amazon.id) }
+  let(:cloud_volume_snapshot) { FactoryGirl.create(:cloud_volume_snapshot_amazon, :ext_management_system => ems, :ems_ref => "snapshot_1") }
+
+  describe "cloud volume operations" do
+    context "#delete_snapshot" do
+      it "deletes the cloud volume snapshot" do
+        stubbed_responses = {
+          :ec2 => {
+            :delete_snapshot => {}
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect(cloud_volume_snapshot.delete_snapshot).to be_truthy
+        end
+      end
+
+      it "catches error from the provider" do
+        stubbed_responses = {
+          :ec2 => {
+            :delete_snapshot => "UnauthorizedOperation"
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect do
+            cloud_volume_snapshot.delete_snapshot
+          end.to raise_error(MiqException::MiqVolumeSnapshotDeleteError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create and delete snapshot operations are added to the cloud volume snapshot. Queued versions of these operations are provided allowing background creation and deletion of volume snapshots.

This currently depends on #151 adding cloud volumes support as it extends the cloud volume with the operation to create a new snapshot from the volume.

@miq-bot add_label enhancement
@miq-bot assign @durandom 