### PR TITLE
Gather AWS labels and create CustomAttributes

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -185,6 +185,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :vendor             => "amazon",
       :raw_power_state    => "never",
       :template           => true,
+      :labels             => parse_labels(image.tags),
       # the is_public flag here avoids having to make an additional API call
       # per image, since we already know whether it's a public image
       :publicly_available => is_public,
@@ -231,7 +232,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :vendor              => "amazon",
       :raw_power_state     => status,
       :boot_time           => instance.launch_time,
-
+      :labels              => parse_labels(instance.tags),
       :hardware            => {
         :bitness              => architecture_to_bitness(instance.architecture),
         :virtualization_type  => instance.virtualization_type,
@@ -386,5 +387,21 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :last_updated           => resource.last_updated_timestamp
     }
     return uid, new_result
+  end
+
+  def parse_labels(tags)
+    result = []
+    return result if tags.empty?
+    tags.each do |tag|
+      custom_attr = {
+        :section => 'labels',
+        :name    => tag[:key],
+        :value   => tag[:value],
+        :source  => 'amazon'
+      }
+      result << custom_attr
+    end
+
+    result
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/persister/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/cloud_manager.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Amazon::Inventory::Persister::CloudManager < ManageIQ
   def initialize_inventory_collections
     add_inventory_collections(
       cloud,
-      %i(vms miq_templates hardwares networks disks availability_zones
+      %i(vms miq_templates hardwares networks disks availability_zones vm_and_template_labels
          flavors key_pairs orchestration_stacks orchestration_stacks_resources
          orchestration_stacks_outputs orchestration_stacks_parameters orchestration_templates)
     )

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/cloud_manager.rb
@@ -39,6 +39,16 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
       super(attributes.merge!(extra_attributes))
     end
 
+    def vm_and_template_labels(extra_attributes = {})
+      attributes = {
+        :model_class => CustomAttribute,
+        :association => :vm_and_template_labels,
+        :manager_ref => [:resource, :name]
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
     def orchestration_stacks(extra_attributes = {})
       attributes = {
         :model_class => ::ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack,

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -31,7 +31,7 @@ module AwsRefresherSpecCommon
       :availability_zone             => 5,
       :cloud_network                 => 5,
       :cloud_subnet                  => 10,
-      :custom_attribute              => 0,
+      :custom_attribute              => 43,
       :disk                          => 44,
       :ext_management_system         => 4,
       :firewall_rule                 => 119,
@@ -336,7 +336,7 @@ module AwsRefresherSpecCommon
       :cpu_reserve_expand    => nil,
       :cpu_limit             => nil,
       :cpu_shares            => nil,
-      :cpu_shares_level      => nil
+      :cpu_shares_level      => nil,
     )
 
     expect(v.ext_management_system).to eq(@ems)
@@ -358,7 +358,7 @@ module AwsRefresherSpecCommon
       .to match_array [sg_2, @sg]
 
     expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
-    expect(v.custom_attributes.size).to eq(0)
+    expect(v.custom_attributes.size).to eq(1)
     expect(v.snapshots.size).to eq(0)
 
     expect(v.hardware).to have_attributes(
@@ -403,6 +403,7 @@ module AwsRefresherSpecCommon
     v.with_relationship_type("genealogy") do
       expect(v.parent).to eq(@template)
     end
+    expect(v.custom_attributes.find_by(:name => "Name").value).to eq("EmsRefreshSpec-PoweredOn-Basic3")
   end
 
   def assert_specific_vm_powered_off
@@ -443,7 +444,7 @@ module AwsRefresherSpecCommon
     expect(v.cloud_subnet).to be_nil
     expect(v.security_groups).to match_array([@sg])
     expect(v.operating_system).to be_nil # TODO: This should probably not be nil
-    expect(v.custom_attributes.size).to eq(0)
+    expect(v.custom_attributes.size).to eq(1)
     expect(v.snapshots.size).to eq(0)
 
     expect(v.hardware).to have_attributes(

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -44,8 +44,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(VmOrTemplate.count).to eq(3)
     expect(Vm.count).to eq(2)
     expect(MiqTemplate.count).to eq(1)
-
-    expect(CustomAttribute.count).to eq(0)
+    expect(CustomAttribute.count).to eq(1)
     expect(Disk.count).to eq(3)
     expect(GuestDevice.count).to eq(0)
     expect(Hardware.count).to eq(3)
@@ -228,7 +227,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(v.security_groups).to eq([@sg])
     expect(v.key_pairs).to eq([@kp])
     expect(v.operating_system).to       be_nil # TODO: This should probably not be nil
-    expect(v.custom_attributes.size).to eq(0)
+    expect(v.custom_attributes.size).to eq(1)
     expect(v.snapshots.size).to eq(0)
 
     expect(v.hardware).to have_attributes(


### PR DESCRIPTION
This PR parses AWS Tags which are saved in the database as custom attributes.
Currently AWS only supports tagging VMs and Images.

This PR takes care of the parsing and depends on the model and post processing logic getting merged first:
https://github.com/ManageIQ/manageiq/pull/14202 (Status: merged)

A UI PR will be made separately to display the custom attributes in the Labels table of the VMs and Images.


Steps to test:
 
1. Add tags to a VM or image through the AWS console.
2. Add an AWS provider to the MIQ UI
3. Open the Summary page for the VM selected in 1) and make sure a "Labels" table exists and displays the tags configured in 1)


https://www.pivotaltracker.com/story/show/139414085