### PR TITLE
add amazon events to settings to display them in timelines

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,18 @@
 ---
 :ems:
   :ems_amazon:
+    :event_handling:
+      :event_groups:
+        :addition:
+          :critical:
+          - AWS_EC2_Instance_CREATE
+          - AWS_EC2_Instance_UPDATE
+          - AWS_EC2_Instance_DELETE
+        :power:
+          :critical:
+          - AWS_EC2_Instance_running
+          - AWS_EC2_Instance_shutting-down
+          - AWS_EC2_Instance_stopped
     :blacklisted_event_names:
       - ConfigurationSnapshotDeliveryCompleted
       - ConfigurationSnapshotDeliveryStarted


### PR DESCRIPTION
timelines have been enabled for aws for a long time
and we have been collecting events for some time.
We just did not display any events by default.
Display those 6 EC2 events because we already have them
in [automate](https://github.com/ManageIQ/manageiq-content/tree/6be7ec14216da302f9fc3f805670c8ac340211e4/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class) triggering a refresh

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1392391

since https://github.com/ManageIQ/manageiq/pull/13942 has been merged, I can add those events here 😋 

@blomquisg @bronaghs please review
