### PR TITLE
List VMs from the same availability zone as volume

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -1,6 +1,10 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVolume
   supports :create
 
+  def available_vms
+    availability_zone.vms
+  end
+
   def self.validate_create_volume(ext_management_system)
     validate_volume(ext_management_system)
   end


### PR DESCRIPTION
This patch implements a method from the base cloud volume that provides
the list of VMs (instances) that the volume can be attached to. In case
of Amazon, the volume can be attached to any instance residing in the
same availability zone as the volume itself.

Depends on: ManageIQ/manageiq#14058

@miq-bot add_label enhancement,pending core