### PR TITLE
Set default Container and Object class when collecting inventory for the 1st time

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
@@ -28,7 +28,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
   def parse_container(bucket)
     uid = bucket['name']
     {
-      :type                  => self.class.container_type,
       :ext_management_system => ems,
       :ems_ref               => uid,
       :key                   => bucket['name']
@@ -65,7 +64,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
   def parse_object(object, bucket)
     uid = object['key']
     {
-      :type                         => self.class.object_type,
       :ext_management_system        => ems,
       :ems_ref                      => "#{bucket.ems_ref}_#{uid}",
       :etag                         => object['etag'],
@@ -74,15 +72,5 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
       :key                          => uid,
       :cloud_object_store_container => bucket
     }
-  end
-
-  class << self
-    def container_type
-      ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name
-    end
-
-    def object_type
-      ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject.name
-    end
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
@@ -15,5 +15,21 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
 
       super(attributes.merge!(extra_attributes))
     end
+
+    def cloud_object_store_containers(extra_attributes = {})
+      attributes = {
+        :model_class => ::ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer,
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def cloud_object_store_objects(extra_attributes = {})
+      attributes = {
+        :model_class => ::ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject,
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
   end
 end


### PR DESCRIPTION
When user adds AWS cloud manager S3 storage manager is added as well and refresh is triggered for it. However, during this first refresh, CloudObjectStoreContainers and CloudObjectStoreObjects were assigned empty type. This prevented S3 storage manager from showing them as its children. When user triggered refresh on S3 manually, S3 manager assumed that no object is in database yet resulting in every object
being fetched once again while keeping orphaned ones in database. And again. And again... The database was getting bigger and bigger with every new refresh.

Fixed with this commit - turns out we have to specify default class for Containers and Objects and the orphaned database entries wont appear.

@miq-bot add_label bug
@miq-bot assign @Ladas 