### PR TITLE
Suppress warning "toplevel constant referenced"

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::StorageManager
+  require_nested :CloudObjectStoreContainer
+  require_nested :CloudObjectStoreObject
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher


### PR DESCRIPTION
As reported in https://github.com/ManageIQ/manageiq-providers-amazon/issues/161, calling
```ruby
ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer.name
```
in refresh parser resulted in warning "warning: toplevel constant CloudObjectStoreContainer referenced by ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer" being printed to evm.log. Fixing this by hard-coding `type` name as string. Other refresh parsers have it hard-coded as well, but I wanted to be smarter... :D

@miq-bot add_label bug
@miq-bot assign @Ladas 