### PR TITLE
AWS SDK call `get_bucket_location` returns empty string

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
@@ -37,6 +37,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
   def process_objects(bucket_id, bucket_object)
     # S3 bucket accessible only for API client with same region
     region = collector.aws_s3.client.get_bucket_location(:bucket => bucket_id).location_constraint
+    region = "us-east-1" if region.empty? # SDK returns empty string for default region
     options = { :region => region, :bucket => bucket_id }
 
     # AWS SDK doesn't show information about overall size and object count.


### PR DESCRIPTION
For buckets in US East (N. Virginia) region, the SDK returns empty string "" instead of "us-east-1". But when connecting to S3, we need to specify "us-east-1" explicitly. With this commit we map empty string to region name to prevent error.

@miq-bot assign @Ladas 
@miq-bot add_label enhancement
