### PR TITLE
Connect to correct region with S3

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
@@ -23,8 +23,14 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer
   end
 
   def provider_object(connection = nil)
+    connect(connection).bucket(ems_ref)
+  end
+
+  def connect(connection = nil)
     connection ||= ext_management_system.connect
-    connection.bucket(ems_ref)
+    region = connection.client.get_bucket_location(:bucket => ems_ref).location_constraint
+    region = "us-east-1" if region.empty? # SDK returns empty string for default region
+    ext_management_system.connect(:region => region)
   end
 
   def raw_delete

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
@@ -14,8 +14,7 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject < 
   end
 
   def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
-    connection.bucket(cloud_object_store_container.ems_ref).object(key)
+    cloud_object_store_container.provider_object(connection).object(key)
   end
 
   def raw_delete

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -85,10 +85,12 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
     end
 
     it "bucket's provider_object is of expected type" do
-      provider_obj = bucket.provider_object
+      with_aws_stubbed(stub_responses) do
+        provider_obj = bucket.provider_object
 
-      expect(provider_obj).to_not be_nil
-      expect(provider_obj.class).to eq(Aws::S3::Bucket)
+        expect(provider_obj).to_not be_nil
+        expect(provider_obj.class).to eq(Aws::S3::Bucket)
+      end
     end
 
     it "delete_cloud_object_store_container triggers remote action" do


### PR DESCRIPTION
Current code always connects to S3's region that of cloud manager. This works fine when buckets that we're accessing are within that region, but results in error when accessing bucket from any other region.
    
With this commit we update provider_object for CloudObjectStoreContainer and CloudObjectStoreObject so that it now connects to appropriate region.

@miq-bot add_label enhancement
@miq-bot assign @bronaghs 