### PR TITLE
Support operation `create` for CloudObjectStoreContainer

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -5,6 +5,8 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
   require_nested :RefreshWorker
   require_nested :Refresher
 
+  supports :cloud_object_store_container_create
+
   include ManageIQ::Providers::Amazon::ManagerMixin
   include ManageIQ::Providers::StorageManager::ObjectMixin
 


### PR DESCRIPTION
Support operation `create` for CloudObjectStoreContainer

Depends on:
* https://github.com/ManageIQ/manageiq/pull/14269 (merged)

@miq-bot add_label enhancement
@miq-bot assign @bronaghs 