### PR TITLE
Remove `require_nested :Runner` from NetworkManager::EventCatcher and NetworkManager::MetricsCollectorWorker

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/event_catcher.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Amazon::NetworkManager::EventCatcher < ::MiqEventCatcher
-  require_nested :Runner
 
   def self.ems_class
     ManageIQ::Providers::Amazon::NetworkManager

--- a/app/models/manageiq/providers/amazon/network_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/metrics_collector_worker.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Amazon::NetworkManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
-  require_nested :Runner
 
   self.default_queue_name = "amazon_network"
 


### PR DESCRIPTION
Purpose
-------
Avoid issues in development mode when eager loading, since this doesn't work.


Background
----------
As part of https://github.com/ManageIQ/manageiq/pull/14261 I am trying to get `eager_loading` fuctioning properly with `manageiq`.  When doing eager loading in development mode, things bust because `require_nested` on these two models is invalid because there isn't a corresponding nested directory available for these two models.

Not sure the status of these models, because they aren't included in the main `NetworkManager` in this provider, so they might be incomplete or not used.  Only eager loading without cached classes seems to cause this error to, so I will let the reviewer be the judge of whether this fix is sufficient, or we should consider removing these models entirely.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/14261