### PR TITLE
Do vm targeted full refresh by default

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -165,7 +165,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
 
   def infer_related_vm_ems_refs_db!
     changed_vms = manager.vms.where(:ems_ref => references(:vms)).includes(:key_pairs, :network_ports, :floating_ips,
-                                                                        :orchestration_stack, :cloud_subnets)
+                                                                           :orchestration_stack, :cloud_subnets)
     changed_vms.each do |vm|
       stack      = vm.orchestration_stack
       all_stacks = ([stack] + (stack.try(:ancestors) || [])).compact

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
     parse_targets!
     infer_related_ems_refs!
 
+    # Reset the target cache, so we can access new targets inside
     target.manager_refs_by_association_reset
   end
 
@@ -12,7 +13,8 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   end
 
   def instances
-    hash_collection.new(
+    return @instances unless @instances.blank?
+    @instances = hash_collection.new(
       aws_ec2.instances(:filters => [{:name => 'instance-id', :values => references(:vms)}])
     )
   end
@@ -56,7 +58,9 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   end
 
   def network_ports
-    hash_collection.new(aws_ec2.client.describe_network_interfaces(
+    return @network_ports unless @network_ports.blank?
+
+    @network_ports = hash_collection.new(aws_ec2.client.describe_network_interfaces(
       :filters => [{:name => 'network-interface-id', :values => references(:network_ports).to_a}]
     ).network_interfaces)
   end
@@ -153,8 +157,15 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
     # ems_refs of every related object. Now this is not very nice fro ma design point of view, but we really want
     # to see changes in VM's associated objects, so the VM view is always consistent and have fresh data. The partial
     # reason for this is, that AWS doesn't send all the objects state change,
-    changed_vms = manager.vms.where(:ems_ref => references(:vms)).includes(:key_pairs, :network_ports, :floating_ips,
-                                                                           :orchestration_stack)
+    unless references(:vms).blank?
+      infer_related_vm_ems_refs_db!(references(:vms))
+      infer_related_vm_ems_refs_api!(references(:vms))
+    end
+  end
+
+  def infer_related_vm_ems_refs_db!(vm_references)
+    changed_vms = manager.vms.where(:ems_ref => vm_references).includes(:key_pairs, :network_ports, :floating_ips,
+                                                                        :orchestration_stack)
     changed_vms.each do |vm|
       stack      = vm.orchestration_stack
       all_stacks = ([stack] + (stack.try(:ancestors) || [])).compact
@@ -171,9 +182,65 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
         target.add_target(:association => :network_ports, :manager_ref => {:ems_ref => ems_ref})
       end
 
+      vm.cloud_subnets.collect(&:ems_ref).compact.each do |ems_ref|
+        target.add_target(:association => :cloud_subnets, :manager_ref => {:ems_ref => ems_ref})
+      end
+
       vm.floating_ips.collect(&:ems_ref).compact.each do |ems_ref|
         target.add_target(:association => :floating_ips, :manager_ref => {:ems_ref => ems_ref})
       end
     end
+  end
+
+  def infer_related_vm_ems_refs_api!(_vm_references)
+    # TODO(lsmola) should we filter them by only VMs we want to do full refresh for?
+    instances.each do |vm|
+      target.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => vm["image_id"]})
+      target.add_target(:association => :key_pairs, :manager_ref => {:ems_ref => vm["key_name"]})
+      orchestration_stack_id = get_from_tags(vm, "aws:cloudformation:stack-id")
+      if orchestration_stack_id
+        target.add_target(:association => :security_groups, :manager_ref => {:ems_ref => orchestration_stack_id})
+      end
+
+      vm["network_interfaces"].each do |network_interface|
+        target.add_target(:association => :network_ports, :manager_ref => {:ems_ref => network_interface["network_interface_id"]})
+        target.add_target(:association => :cloud_subnet, :manager_ref => {:ems_ref => network_interface["subnet_id"]})
+        target.add_target(:association => :cloud_network, :manager_ref => {:ems_ref => network_interface["vpc_id"]})
+      end
+
+      vm["security_groups"].each do |security_group|
+        target.add_target(:association => :security_groups, :manager_ref => {:ems_ref => security_group["group_id"]})
+      end
+
+      vm["block_device_mappings"].each do |cloud_volume|
+        next if cloud_volume.fetch_path("ebs", "volume_id").blank?
+        target.add_target(
+          :association => :cloud_volumes,
+          :manager_ref => {:ems_ref => cloud_volume.fetch_path("ebs", "volume_id")})
+      end
+
+      # EC2 classic floating ips
+      if vm["network_interfaces"].blank? && vm['public_ip_address'].present?
+        target.add_target(:association => :floating_ips, :manager_ref => {:ems_ref => vm['public_ip_address']})
+      end
+    end
+
+    # Reset target cache, so we can get a fresh list of network_ports ids
+    target.manager_refs_by_association_reset
+
+    # We need to go through all network ports, to get a correct list of the floating IPs, for some reason, the list
+    # under a vm is missing allocation_ids
+    network_ports.each do |network_port|
+      network_port['private_ip_addresses'].each do |private_ip_address|
+        floating_ip_id = (private_ip_address.fetch_path("association", "allocation_id") ||
+          private_ip_address.fetch_path("association", "public_ip"))
+        next if floating_ip_id.blank?
+        target.add_target(:association => :floating_ips, :manager_ref => {:ems_ref => floating_ip_id})
+      end
+    end
+  end
+
+  def get_from_tags(resource, item)
+    (resource['tags'] || []).detect { |tag, _| tag['key'].downcase == item.to_s.downcase }.try(:[], 'value')
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
@@ -76,14 +76,11 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
 
       dev = File.basename(a['device'])
 
-      disk_hash = {
-        :hardware    => persister.hardwares.lazy_find(a["instance_id"]),
-        :device_name => dev,
-        :location    => dev,
-        :size        => volume_hash[:size],
-        :backing     => persister.cloud_volumes.lazy_find(uid),
-      }
-      persister.disks << persister.disks.new_inventory_object(disk_hash)
+      disk = persister.disks.find_or_build_by(:hardware    => persister.hardwares.lazy_find(a["instance_id"]),
+                                              :device_name => dev)
+      disk.location = dev
+      disk.size     = volume_hash[:size]
+      disk.backing  = persister.cloud_volumes.lazy_find(uid)
     end
   end
 

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/cloud_manager.rb
@@ -54,5 +54,13 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
 
       super(attributes.merge!(extra_attributes))
     end
+
+    def disks(extra_attributes = {})
+      attributes = {
+        :inventory_object_attributes => %i(hardware device_name location size backing),
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
   end
 end


### PR DESCRIPTION
If VM was scheduled for refresh, always refresh the references that
we can obtain by scanning the Vm in the API and our DB. This way, we
should always get a Vm that has all references filled.

The alternative for this would be a multi-phase refresh, where each
refresh can be planning another refresh for missing references.

In this case, we output a fully refreshed Vms in one step, which
will be later configurable, as this is handy for integration
with external tools. E.g. when we need to send refreshed data
to ansible, we need Vm completely refreshed after 1 refresh, not
possible many incremental refreshes.