### PR TITLE
Relative path for the VCRs is allowing to run specs from the core

### DIFF
--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -1,4 +1,13 @@
 module AwsRefresherSpecCommon
+  extend ActiveSupport::Concern
+
+  included do
+    # We need a relative path so the specs are executable from the core
+    VCR.configure do |c|
+      c.cassette_library_dir = File.join(File.dirname(__FILE__), "../" * 4 + "vcr_cassettes")
+    end
+  end
+
   def assert_common
     assert_table_counts
     assert_ems


### PR DESCRIPTION
Relative path for the VCRs is allowing to run specs from the core