### PR TITLE
Increase minimum AWS version for modify_volume

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency("aws-sdk", ["~>2.6.14"])
+  s.add_dependency("aws-sdk", ["~>2.8.7"])
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
In order to enable updating EBS volumes on the fly, the SDK needs to support the [#modify_volume](http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#modify_volume-instance_method). This has been introduced in version [2.7.8](https://github.com/aws/aws-sdk-ruby/commit/9e0558fdfb0eec9ed03f500d552edd3b36cdaa9f#diff-be5c280d1f1bc5bd07cf35078448e1caR1668) of aws-sdk gem.

This patch thus increases the minimum supported version to v2.7.8.