### PR TITLE
Enable dynamic cloud volume modifications

### DIFF
--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -1,4 +1,24 @@
 FactoryGirl.define do
   factory :cloud_volume_amazon, :parent => :cloud_volume,
                                 :class  => "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume"
+  factory :cloud_volume_amazon_standard,
+          :parent => :cloud_volume,
+          :class  => "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume" do
+    size 1.gigabyte
+    volume_type 'standard'
+  end
+
+  factory :cloud_volume_amazon_gp2,
+          :parent => :cloud_volume,
+          :class  => "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume" do
+    size 1.gigabyte
+    volume_type 'gp2'
+  end
+
+  factory :cloud_volume_amazon_io1,
+          :parent => :cloud_volume,
+          :class  => "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume" do
+    size 4.gigabytes
+    volume_type 'io1'
+  end
 end

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume do
   let(:ems_cloud) { FactoryGirl.create(:ems_amazon_with_authentication) }
   let(:ebs) { FactoryGirl.create(:ems_amazon_ebs, :parent_ems_id => ems_cloud.id) }
   let(:availability_zone) { FactoryGirl.create(:availability_zone_amazon) }
-  let(:cloud_volume) { FactoryGirl.create(:cloud_volume_amazon, :ext_management_system => ebs, :ems_ref => "vol_1", :availability_zone => availability_zone) }
+  let(:cloud_volume) { FactoryGirl.create(:cloud_volume_amazon_gp2, :ext_management_system => ebs, :ems_ref => "vol_1", :availability_zone => availability_zone) }
 
   describe "cloud volume operations" do
     context ".raw_create_volume" do
@@ -31,6 +31,157 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume do
 
         with_aws_stubbed(stubbed_responses) do
           expect(CloudVolume.create_volume(ebs, options)).to be_truthy
+        end
+      end
+    end
+
+    context "#update_volume" do
+      let(:update_volume_name_stub) { { :create_tags => {}, :modify_volume => "failed" } }
+      let(:modify_volume_stub) { { :create_tags => "failed", :modify_volume => {} } }
+      let(:full_update_volume_stub) { { :create_tags => {}, :modify_volume => {} } }
+
+      context "updating volume name" do
+        it "is allowed when :name is provided" do
+          with_aws_stubbed(:ec2 => update_volume_name_stub) do
+            expect do
+              cloud_volume.update_volume(:name => "new_name")
+            end.not_to raise_error
+          end
+        end
+
+        it "is allowed when all data are provided" do
+          with_aws_stubbed(:ec2 => full_update_volume_stub) do
+            expect do
+              cloud_volume.update_volume(:name => "new_name", :size => 10, :volume_type => 'gp2')
+            end.not_to raise_error
+          end
+        end
+
+        it "is not allowed when :name is not provided" do
+          with_aws_stubbed(:ec2 => modify_volume_stub) do
+            expect do
+              cloud_volume.update_volume(:size => 10, :volume_type => 'gp2')
+            end.not_to raise_error
+          end
+        end
+      end
+
+      it "catches error from the provider" do
+        stubbed_responses = {
+          :ec2 => {
+            :modify_volume => "UnauthorizedOperation"
+          }
+        }
+
+        with_aws_stubbed(stubbed_responses) do
+          expect do
+            cloud_volume.update_volume(:volume_type => 'gp2')
+          end.to raise_error(MiqException::MiqVolumeUpdateError)
+        end
+      end
+
+      context "when modifying" do
+        let(:volume) { FactoryGirl.create(:cloud_volume_amazon_gp2, :ext_management_system => ebs, :ems_ref => "vol_1", :availability_zone => availability_zone) }
+        let(:raw_client) { double }
+
+        before do
+          double.tap do |vol|
+            allow(vol).to receive(:client).and_return(raw_client)
+            allow(volume).to receive(:provider_object).and_return(vol)
+          end
+        end
+
+        shared_examples_for "#modify_volume is allowed" do
+          it "are properly set" do
+            expect(raw_client).to receive(:modify_volume).with(modify_volume_options)
+
+            with_aws_stubbed(:ec2 => modify_volume_stub) do
+              volume.update_volume(options)
+            end
+          end
+        end
+
+        shared_examples_for "#modify_volume is not allowed" do
+          it "is not allowed" do
+            expect(raw_client).not_to receive(:modify_volume)
+            with_aws_stubbed(:ec2 => modify_volume_stub) do
+              volume.update_volume(options)
+            end
+          end
+        end
+
+        context "standard volume" do
+          let(:options) { { :volume_type => "gp2", :iops => 200, :size => 4 } }
+          let(:volume) { FactoryGirl.create(:cloud_volume_amazon_standard, :ext_management_system => ebs, :ems_ref => "vol_1", :availability_zone => availability_zone) }
+
+          include_examples "#modify_volume is not allowed"
+        end
+
+        context "volume type to gp2" do
+          let(:options) { { :volume_type => "gp2", :iops => 200, :size => 4 } }
+          # It must ignore IOPS param.
+          let(:modify_volume_options) { { :volume_id => "vol_1", :volume_type => "gp2", :size => 4 } }
+
+          include_examples "#modify_volume is allowed"
+        end
+
+        context "volume type to io1" do
+          let(:options) { { :volume_type => "io1", :iops => 200, :size => 4 } }
+          # It must us all params.
+          let(:modify_volume_options) { { :volume_id => "vol_1", :volume_type => "io1", :iops => 200, :size => 4 } }
+
+          include_examples "#modify_volume is allowed"
+        end
+
+        context "only volume type" do
+          let(:options) { { :volume_type => "io1" } }
+          let(:modify_volume_options) { { :volume_id => "vol_1", :volume_type => "io1" } }
+
+          include_examples "#modify_volume is allowed"
+        end
+
+        context "iops of a 'gp2' volume type" do
+          let(:options) { { :iops => 200 } }
+
+          include_examples "#modify_volume is not allowed"
+        end
+
+        context "iops of an 'io1' volume type" do
+          let(:volume) { FactoryGirl.create(:cloud_volume_amazon_io1, :ext_management_system => ebs, :ems_ref => "vol_1", :availability_zone => availability_zone) }
+          let(:options) { { :iops => 200 } }
+          let(:modify_volume_options) { { :volume_id => "vol_1", :iops => 200 } }
+
+          include_examples "#modify_volume is allowed"
+        end
+
+        context "the size of the volume" do
+          let(:options) { { :size => 4 } }
+          let(:modify_volume_options) { { :volume_id => "vol_1", :size => 4 } }
+
+          include_examples "#modify_volume is allowed"
+        end
+
+        context "the size of the volume with the same value" do
+          let(:options) { { :size => 1 } }
+
+          include_examples "#modify_volume is not allowed"
+        end
+
+        context "the size of the volume is valid string" do
+          let(:options) { { :size => "4" } }
+          let(:modify_volume_options) { { :volume_id => "vol_1", :size => 4 } }
+
+          include_examples "#modify_volume is allowed"
+        end
+
+        context "the size of the volume is invalid string" do
+          it "when invalid it should raise error" do
+            with_aws_stubbed(:ec2 => modify_volume_stub) do
+              expect do
+                cloud_volume.update_volume(:size => "invalid")
+              end.to raise_error(MiqException::MiqVolumeUpdateError)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Recently Amazon introduced a capability to modify existing cloud volumes
on the fly. Depending on the volume type size, volume type and IOPS can
be modified without detaching the volume first.

This patch enhances the existing `update_volume` method that previously
allowed changing only the name of the volume by using the new method
`#modify_volume` from the aws-sdk gem. The patch also adds a set of
tests verifying different possible options passed to the
`update_volume`.

Depends on #176 (requires newer aws-sdk gem).

@miq-bot add_label enhancement