### PR TITLE
Adjust attribute set of newly created bucket

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
@@ -45,7 +45,6 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer
       :ems_ref               => bucket.name,
       :bytes                 => 0,
       :object_count          => 0,
-      :provider_region       => region,
       :ext_management_system => ext_management_system
     }
   rescue => e


### PR DESCRIPTION
This PR was originally designed so that CloudObjectStoreContainer model stores `provider_region`. But a decision was made in https://github.com/ManageIQ/manageiq/pull/14242 to omit this field for now and instead query bucket region dynamically when user triggers operation. Hence this tiny adjustment.

@miq-bot add_label enhancement
@miq-bot assign @Ladas 