### PR TITLE
Add support snapshot_create to EBS cloud volume

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVolume
   supports :create
+  supports :snapshot_create
 
   def available_vms
     availability_zone.vms


### PR DESCRIPTION
The support in the backend was already there but the missing `supports`
prevented UI from showing the corresponding menu item.

This screen shows the menu item for EBS volume

![screen shot 2017-03-23 at 17 30 02](https://cloud.githubusercontent.com/assets/1437960/24258647/b3fb6aea-0fee-11e7-8189-d20c929e21e9.png)

@miq-bot add_label bug