### PR TITLE
Remap `:name` parameter into `:bucket` parameter when creating new bucket

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
@@ -42,7 +42,9 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer
   end
 
   def self.raw_cloud_object_store_container_create(ext_management_system, options)
-    options.except!(:name) # name is part of general options, but S3 doesn't like it
+    # frontend stores name as :name, but amazon expects it as :bucket
+    options[:bucket] = options.delete(:name) unless options[:name].nil?
+
     region = options[:create_bucket_configuration][:location_constraint]
     connection = ext_management_system.connect(:region => region)
     bucket = connection.create_bucket(options)


### PR DESCRIPTION
Current implementation assumes that frontend composes all the options that backend then just sends to AWS. But there is an exception with :name option. While it is needed on frontend (to display flash), it is rejected by AWS.

Initial idea was to just remove the :name option here in backend, but turns out (see [this conversation](https://github.com/ManageIQ/manageiq-ui-classic/pull/651#discussion_r107285748)) that renaming it to :bucket works better. Hence this commit.

@miq-bot add_label enhancement
@miq-bot assign @Ladas 