### PR TITLE
Return instead of next is causing unwanted break of Vm parsing

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -107,7 +107,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def get_instances
     process_inventory_collection(collector.instances, :vms) do |instance|
       status = instance.fetch_path('state', 'name')
-      return if collector.options.ignore_terminated_instances && status.to_sym == :terminated
+      next if collector.options.ignore_terminated_instances && status.to_sym == :terminated
 
       # TODO(lsmola) we have a non lazy dependency, can we remove that?
       flavor = persister.flavors.find(instance['instance_type']) || persister.flavors.find("unknown")


### PR DESCRIPTION
Return instead of next is causing unwanted break of Vm parsing