### PR TITLE
[WIP] Specs to test the cleanup of labels deleted on AWS

### DIFF
--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -33,7 +33,8 @@ module AwsStubs
       :cloud_volume_count                              => scaling * 5,
       :cloud_volume_snapshot_count                     => scaling * 5,
       :s3_buckets_count                                => scaling * 5,
-      :s3_objects_per_bucket_count                     => scaling * 5
+      :s3_objects_per_bucket_count                     => scaling * 5,
+      :custom_attribute_count                          => scaling * 20,
     }
   end
 
@@ -153,7 +154,12 @@ module AwsStubs
           {
             :network_interface_id => "interface_#{i}"
           }
-        ]
+        ],
+        :tags               => [{
+          :key   => "tag_name_#{i}",
+          :value => "tag_value_#{i}",
+        }],
+
       }
     end
 


### PR DESCRIPTION
These specs accompany a PR on the main repo: https://github.com/ManageIQ/manageiq/pull/14388. 

In summary, when labels were deleted on the AWS provider, they persisted in the ManageIQ database. The above referenced PR fixes this by deleting them from ManageIQ database. These specs test this cleanup.

Depends on: https://github.com/ManageIQ/manageiq/pull/14388