### PR TITLE
Gracefully ignore and log errors when listing s3 objects

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/collector/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/storage_manager/s3.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::StorageManager::S3 <
     )
     token = response.next_continuation_token if response.is_truncated
     return hash_collection.new(response.contents), token
+  rescue => e
+    _log.warn("Unable to collect S3 objects in a bucket #{options[:bucket]}, Message: #{e.message}")
+    _log.warn(e.backtrace.join("\n"))
+    return [], nil
   end
 
   private

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_parser.rb
@@ -51,10 +51,16 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshParser
       token = nil
       proceed = true
       while proceed
-        response = api_client.list_objects_v2(
-          :bucket             => bucket_id,
-          :continuation_token => token
-        )
+        begin
+          response = api_client.list_objects_v2(
+            :bucket             => bucket_id,
+            :continuation_token => token
+          )
+        rescue => e
+          _log.warn("Unable to collect S3 objects in a bucket #{bucket_id}, Message: #{e.message}")
+          _log.warn(e.backtrace.join("\n"))
+          break
+        end
         process_collection(response.contents, :cloud_object_store_objects) do |o|
           uid, new_result = parse_object(o, bucket_id)
           bytes += new_result[:content_length]


### PR DESCRIPTION
Gracefully ignore and log errors when listing s3 objects and log them as a warning

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1439257