### PR TITLE
Collect IOPS and encryption status of cloud volume

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
@@ -19,13 +19,14 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
         :volume_type       => volume['volume_type'],
         :size              => volume['size'].to_i.gigabytes,
         :base_snapshot     => persister.cloud_volume_snapshots.lazy_find(volume['snapshot_id']),
-        :availability_zone => persister.availability_zones.lazy_find(volume['availability_zone'])
+        :availability_zone => persister.availability_zones.lazy_find(volume['availability_zone']),
+        :iops              => volume['iops'],
+        :encrypted         => volume['encrypted'],
       )
 
       volume_attachments(persister_volume, volume['attachments'])
     end
   end
-
 
   def snapshots
     collector.cloud_volume_snapshots.each do |snap|

--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
@@ -26,6 +26,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
     end
   end
 
+
   def snapshots
     collector.cloud_volume_snapshots.each do |snap|
       persister.cloud_volume_snapshots.find_or_build(snap['snapshot_id']).assign_attributes(

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
@@ -14,6 +14,8 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
           :size,
           :base_snapshot,
           :availability_zone,
+          :iops,
+          :encrypted,
         ],
         :builder_params              => {
           :ems_id => ->(persister) { persister.manager.try(:ebs_storage_manager).try(:id) || persister.manager.id },

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
@@ -47,6 +47,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
       :size              => volume.size.to_i.gigabytes,
       :snapshot_uid      => volume.snapshot_id,
       :availability_zone => parent_manager_fetch_path(:availability_zones, volume.availability_zone),
+      :encrypted         => volume.encrypted,
+      :iops              => volume.iops
     }
 
     link_volume_to_disk(new_result, volume.attachments)

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -445,7 +445,9 @@ module AwsStubs
         :volume_id         => "volume_id_#{i}",
         :volume_type       => "standard",
         :snapshot_id       => "snapshot_id_#{i}",
-        :tags              => [{ :key => "name", :value => "volume_#{i}" }]
+        :tags              => [{ :key => "name", :value => "volume_#{i}" }],
+        :iops              => (i == 0 ? 100 : nil),
+        :encrypted         => (i == 0 ? true : false),
       }
     end
 

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
@@ -82,6 +82,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
 
     assert_specific_snapshot
     assert_specific_volume
+    assert_unencrypted_volume
   end
 
   def stub_responses
@@ -218,7 +219,9 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
       :name        => "volume_0",
       :status      => "in-use",
       :volume_type => "standard",
-      :size        => 1.gigabyte
+      :size        => 1.gigabyte,
+      :encrypted   => true,
+      :iops        => 100
     )
 
     expect(@volume.ext_management_system).to eq(@ems.ebs_storage_manager)
@@ -229,5 +232,20 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
     @disk.reload
     expect(@disk.backing).to eq(@volume)
     expect(@disk.size).to eq(@volume.size)
+  end
+
+  def assert_unencrypted_volume
+    @volume = ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume.where(:ems_ref => "volume_id_1").first
+
+    expect(@volume).not_to be_nil
+    expect(@volume).to have_attributes(
+      :ems_ref     => "volume_id_1",
+      :name        => "volume_1",
+      :status      => "in-use",
+      :volume_type => "standard",
+      :size        => 1.gigabyte,
+      :encrypted   => false,
+      :iops        => nil
+    )
   end
 end


### PR DESCRIPTION
Since they were not used in the UI, these two attributes were previously
not collected. Latest UI changes have introduced changes that show all
fields while editing existing cloud volumes, rendering them empty for
the users.

Depends on: https://github.com/ManageIQ/manageiq/pull/14704

@miq-bot add_label enhancement,pending core