### PR TITLE
Make S3 a prototype feature

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -80,8 +80,10 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     build_ebs_storage_manager unless ebs_storage_manager
     ebs_storage_manager.name = "#{name} EBS Storage Manager"
 
-    build_s3_storage_manager unless s3_storage_manager
-    s3_storage_manager.name = "#{name} S3 Storage Manager"
+    if ::Settings.prototype.amazon.s3
+      build_s3_storage_manager unless s3_storage_manager
+      s3_storage_manager.name = "#{name} S3 Storage Manager"
+    end
 
     ensure_managers_zone_and_provider_region
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,3 +69,6 @@
         :ems_refresh_worker_amazon_network: {}
         :ems_refresh_worker_amazon_ebs_storage: {}
         :ems_refresh_worker_amazon_s3: {}
+:prototype:
+  :amazon:
+    :s3: false

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -114,7 +114,7 @@ module AwsRefresherSpecCounts
     orchestration_stack_outputs_count    = orchestration_stack_hashes.map { |x| x["outputs"] }.flatten.compact.size
     orchestration_stack_resources_count  = stacks_resources.size
 
-    base_inventory_counts.merge({
+    base_inventory_counts.merge(
       :auth_private_key              => key_pairs.size,
       :availability_zone             => availability_zones.size,
       :cloud_network                 => cloud_networks.size,
@@ -138,7 +138,7 @@ module AwsRefresherSpecCounts
       :security_group                => security_groups_count,
       :vm                            => instances_count,
       :vm_or_template                => instances_and_images_count
-    })
+    )
   end
 
   def assert_table_counts(expected_table_counts)

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -1,9 +1,49 @@
 module AwsRefresherSpecCounts
   extend ActiveSupport::Concern
 
+  def expected_ext_management_systems_count
+    ::Settings.prototype.amazon.s3 ? 4 : 3
+  end
+
+  def base_inventory_counts
+    {
+      :auth_private_key              => 0,
+      :availability_zone             => 0,
+      :cloud_network                 => 0,
+      :cloud_subnet                  => 0,
+      :cloud_volume                  => 0,
+      :cloud_volume_backup           => 0,
+      :cloud_volume_snapshot         => 0,
+      :custom_attribute              => 0,
+      :disk                          => 0,
+      :ext_management_system         => expected_ext_management_systems_count,
+      :firewall_rule                 => 0,
+      :flavor                        => 0,
+      :floating_ip                   => 0,
+      :guest_device                  => 0,
+      :hardware                      => 0,
+      :miq_template                  => 0,
+      :network                       => 0,
+      :network_port                  => 0,
+      :network_router                => 0,
+      :operating_system              => 0,
+      :orchestration_stack           => 0,
+      :orchestration_stack_output    => 0,
+      :orchestration_stack_parameter => 0,
+      :orchestration_stack_resource  => 0,
+      :orchestration_template        => 0,
+      :security_group                => 0,
+      :snapshot                      => 0,
+      :system_service                => 0,
+      :vm                            => 0,
+      :vm_or_template                => 0
+    }
+  end
+
   def assert_counts(expected_table_counts)
-    assert_table_counts(expected_table_counts)
-    assert_ems(expected_table_counts)
+    expected_counts = base_inventory_counts.merge(expected_table_counts)
+    assert_table_counts(expected_counts)
+    assert_ems(expected_counts)
   end
 
   def table_counts_from_api
@@ -74,38 +114,31 @@ module AwsRefresherSpecCounts
     orchestration_stack_outputs_count    = orchestration_stack_hashes.map { |x| x["outputs"] }.flatten.compact.size
     orchestration_stack_resources_count  = stacks_resources.size
 
-    {
+    base_inventory_counts.merge({
       :auth_private_key              => key_pairs.size,
       :availability_zone             => availability_zones.size,
       :cloud_network                 => cloud_networks.size,
       :cloud_subnet                  => cloud_subnets.size,
       :cloud_volume                  => cloud_volumes.size,
-      :cloud_volume_backup           => 0,
       :cloud_volume_snapshot         => cloud_volume_snapshots.size,
       :custom_attribute              => custom_attributes_count,
       :disk                          => disks_count,
-      :ext_management_system         => 4,
       :firewall_rule                 => firewall_rules_count,
       :flavor                        => 76,
       :floating_ip                   => floating_ips_refs.size,
-      :guest_device                  => 0,
       :hardware                      => instances_and_images_count,
       :miq_template                  => images_count,
       :network                       => networks_count,
       :network_port                  => network_ports_count,
-      :network_router                => 0,
-      :operating_system              => 0,
       :orchestration_stack           => orchestration_stacks_count,
       :orchestration_stack_output    => orchestration_stack_outputs_count,
       :orchestration_stack_parameter => orchestration_stack_parameters_count,
       :orchestration_stack_resource  => orchestration_stack_resources_count,
       :orchestration_template        => orchestration_stacks_count,
       :security_group                => security_groups_count,
-      :snapshot                      => 0,
-      :system_service                => 0,
       :vm                            => instances_count,
       :vm_or_template                => instances_and_images_count
-    }
+    })
   end
 
   def assert_table_counts(expected_table_counts)

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -3,6 +3,10 @@ module AwsStubs
     @data_scaling || try(:data_scaling) || 1
   end
 
+  def expected_ext_management_systems_count
+    ::Settings.prototype.amazon.s3 ? 4 : 3
+  end
+
   def disconnect_inv_factor
     # The entities like VM are disconnected instead of deleted, for comparing, we set how many was disconnected and
     # we add them to the total count

--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -137,7 +137,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
     {
       :auth_private_key                  => test_counts[:key_pair_count],
-      :ext_management_system             => 4,
+      :ext_management_system             => expected_ext_management_systems_count,
       # TODO(lsmola) collect all flavors for original refresh
       :flavor                            => @inventory_object_settings[:inventory_object_refresh] ? 78 : 76,
       :availability_zone                 => 5,

--- a/spec/models/manageiq/providers/amazon/cloud_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/vcr_specs/targeted_refresh_spec.rb
@@ -54,7 +54,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_load_balancer_non_vpc_vms
           assert_specific_vm_powered_on
 
-          assert_counts({
+          assert_counts(
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_volume                  => 1,
@@ -70,7 +70,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
             :security_group                => 2,
             :vm                            => 1,
             :vm_or_template                => 2
-          })
+          )
         end
       end
 
@@ -106,7 +106,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_cloud_volume_vm_on_cloud_network
           assert_specific_vm_on_cloud_network
 
-          assert_counts({
+          assert_counts(
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_network                 => 1,
@@ -124,7 +124,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
             :security_group                => 1,
             :vm                            => 1,
             :vm_or_template                => 2
-          })
+          )
         end
       end
 
@@ -151,7 +151,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_cloud_volume_vm_on_cloud_network_public_ip
           assert_specific_vm_on_cloud_network_public_ip
 
-          assert_counts({
+          assert_counts(
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_network                 => 1,
@@ -169,7 +169,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
             :security_group                => 1,
             :vm                            => 1,
             :vm_or_template                => 2
-          })
+          )
         end
       end
 
@@ -203,15 +203,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           # orchestration stack belongs to an orchestration template
           expect(@orch_stack.orchestration_template).to eq(@orch_template)
 
-
-          assert_counts({
+          assert_counts(
             :flavor                        => 3,
             :orchestration_stack           => 1,
             :orchestration_stack_output    => 1,
             :orchestration_stack_parameter => 6,
             :orchestration_stack_resource  => 2,
             :orchestration_template        => 1
-          })
+          )
         end
       end
 
@@ -259,15 +258,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           expect(@orch_stack.parent).to eq(@parent_stack)
           expect(@parent_stack.children).to match_array([@orch_stack])
 
-
-          assert_counts({
+          assert_counts(
             :flavor                        => 3,
             :orchestration_stack           => 2,
             :orchestration_stack_output    => 2,
             :orchestration_stack_parameter => 10,
             :orchestration_stack_resource  => 19,
             :orchestration_template        => 2
-          })
+          )
         end
       end
 
@@ -307,7 +305,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_orchestration_template
           assert_specific_orchestration_stack
 
-          assert_counts({
+          assert_counts(
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_network                 => 1,
@@ -330,7 +328,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
             :security_group                => 1,
             :vm                            => 1,
             :vm_or_template                => 2
-          })
+          )
         end
       end
 
@@ -369,39 +367,6 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
           assert_specific_cloud_volume_vm_on_cloud_network
           assert_specific_cloud_volume_snapshot
-
-          expected_counts = {
-            :auth_private_key              => 0,
-            :availability_zone             => 0,
-            :cloud_network                 => 0,
-            :cloud_subnet                  => 0,
-            :cloud_volume                  => 2,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 1,
-            :custom_attribute              => 0,
-            :disk                          => 0,
-            :ext_management_system         => 4,
-            :firewall_rule                 => 0,
-            :flavor                        => 3,
-            :floating_ip                   => 0,
-            :guest_device                  => 0,
-            :hardware                      => 0,
-            :miq_template                  => 0,
-            :network                       => 0,
-            :network_port                  => 0,
-            :network_router                => 0,
-            :operating_system              => 0,
-            :orchestration_stack           => 0,
-            :orchestration_stack_output    => 0,
-            :orchestration_stack_parameter => 0,
-            :orchestration_stack_resource  => 0,
-            :orchestration_template        => 0,
-            :security_group                => 0,
-            :snapshot                      => 0,
-            :system_service                => 0,
-            :vm                            => 0,
-            :vm_or_template                => 0
-          }
 
           assert_counts(
             :cloud_volume                  => 2,

--- a/spec/models/manageiq/providers/amazon/cloud_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/vcr_specs/targeted_refresh_spec.rb
@@ -54,40 +54,23 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_load_balancer_non_vpc_vms
           assert_specific_vm_powered_on
 
-          expected_counts = {
+          assert_counts({
             :auth_private_key              => 1,
             :availability_zone             => 1,
-            :cloud_network                 => 0,
-            :cloud_subnet                  => 0,
             :cloud_volume                  => 1,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 0,
             :custom_attribute              => 2,
             :disk                          => 1,
-            :ext_management_system         => 4,
             :firewall_rule                 => 13,
             :flavor                        => 3,
             :floating_ip                   => 1,
-            :guest_device                  => 0,
             :hardware                      => 2,
             :miq_template                  => 1,
             :network                       => 2,
             :network_port                  => 1,
-            :network_router                => 0,
-            :operating_system              => 0,
-            :orchestration_stack           => 0,
-            :orchestration_stack_output    => 0,
-            :orchestration_stack_parameter => 0,
-            :orchestration_stack_resource  => 0,
-            :orchestration_template        => 0,
             :security_group                => 2,
-            :snapshot                      => 0,
-            :system_service                => 0,
             :vm                            => 1,
             :vm_or_template                => 2
-          }
-
-          assert_counts(expected_counts)
+          })
         end
       end
 
@@ -123,40 +106,25 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_cloud_volume_vm_on_cloud_network
           assert_specific_vm_on_cloud_network
 
-          expected_counts = {
+          assert_counts({
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_network                 => 1,
             :cloud_subnet                  => 1,
             :cloud_volume                  => 2,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 0,
             :custom_attribute              => 2,
             :disk                          => 2,
-            :ext_management_system         => 4,
             :firewall_rule                 => 3,
             :flavor                        => 3,
             :floating_ip                   => 1,
-            :guest_device                  => 0,
             :hardware                      => 2,
             :miq_template                  => 1,
             :network                       => 2,
             :network_port                  => 1,
-            :network_router                => 0,
-            :operating_system              => 0,
-            :orchestration_stack           => 0,
-            :orchestration_stack_output    => 0,
-            :orchestration_stack_parameter => 0,
-            :orchestration_stack_resource  => 0,
-            :orchestration_template        => 0,
             :security_group                => 1,
-            :snapshot                      => 0,
-            :system_service                => 0,
             :vm                            => 1,
             :vm_or_template                => 2
-          }
-
-          assert_counts(expected_counts)
+          })
         end
       end
 
@@ -183,40 +151,25 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_cloud_volume_vm_on_cloud_network_public_ip
           assert_specific_vm_on_cloud_network_public_ip
 
-          expected_counts = {
+          assert_counts({
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_network                 => 1,
             :cloud_subnet                  => 1,
             :cloud_volume                  => 2,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 0,
             :custom_attribute              => 2,
             :disk                          => 2,
-            :ext_management_system         => 4,
             :firewall_rule                 => 3,
             :flavor                        => 3,
             :floating_ip                   => 1,
-            :guest_device                  => 0,
             :hardware                      => 2,
             :miq_template                  => 1,
             :network                       => 2,
             :network_port                  => 1,
-            :network_router                => 0,
-            :operating_system              => 0,
-            :orchestration_stack           => 0,
-            :orchestration_stack_output    => 0,
-            :orchestration_stack_parameter => 0,
-            :orchestration_stack_resource  => 0,
-            :orchestration_template        => 0,
             :security_group                => 1,
-            :snapshot                      => 0,
-            :system_service                => 0,
             :vm                            => 1,
             :vm_or_template                => 2
-          }
-
-          assert_counts(expected_counts)
+          })
         end
       end
 
@@ -250,40 +203,15 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           # orchestration stack belongs to an orchestration template
           expect(@orch_stack.orchestration_template).to eq(@orch_template)
 
-          expected_counts = {
-            :auth_private_key              => 0,
-            :availability_zone             => 0,
-            :cloud_network                 => 0,
-            :cloud_subnet                  => 0,
-            :cloud_volume                  => 0,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 0,
-            :custom_attribute              => 0,
-            :disk                          => 0,
-            :ext_management_system         => 4,
-            :firewall_rule                 => 0,
+
+          assert_counts({
             :flavor                        => 3,
-            :floating_ip                   => 0,
-            :guest_device                  => 0,
-            :hardware                      => 0,
-            :miq_template                  => 0,
-            :network                       => 0,
-            :network_port                  => 0,
-            :network_router                => 0,
-            :operating_system              => 0,
             :orchestration_stack           => 1,
             :orchestration_stack_output    => 1,
             :orchestration_stack_parameter => 6,
             :orchestration_stack_resource  => 2,
-            :orchestration_template        => 1,
-            :security_group                => 0,
-            :snapshot                      => 0,
-            :system_service                => 0,
-            :vm                            => 0,
-            :vm_or_template                => 0
-          }
-
-          assert_counts(expected_counts)
+            :orchestration_template        => 1
+          })
         end
       end
 
@@ -331,40 +259,15 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           expect(@orch_stack.parent).to eq(@parent_stack)
           expect(@parent_stack.children).to match_array([@orch_stack])
 
-          expected_counts = {
-            :auth_private_key              => 0,
-            :availability_zone             => 0,
-            :cloud_network                 => 0,
-            :cloud_subnet                  => 0,
-            :cloud_volume                  => 0,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 0,
-            :custom_attribute              => 0,
-            :disk                          => 0,
-            :ext_management_system         => 4,
-            :firewall_rule                 => 0,
+
+          assert_counts({
             :flavor                        => 3,
-            :floating_ip                   => 0,
-            :guest_device                  => 0,
-            :hardware                      => 0,
-            :miq_template                  => 0,
-            :network                       => 0,
-            :network_port                  => 0,
-            :network_router                => 0,
-            :operating_system              => 0,
             :orchestration_stack           => 2,
             :orchestration_stack_output    => 2,
             :orchestration_stack_parameter => 10,
             :orchestration_stack_resource  => 19,
-            :orchestration_template        => 2,
-            :security_group                => 0,
-            :snapshot                      => 0,
-            :system_service                => 0,
-            :vm                            => 0,
-            :vm_or_template                => 0
-          }
-
-          assert_counts(expected_counts)
+            :orchestration_template        => 2
+          })
         end
       end
 
@@ -404,40 +307,30 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
           assert_specific_orchestration_template
           assert_specific_orchestration_stack
 
-          expected_counts = {
+          assert_counts({
             :auth_private_key              => 1,
             :availability_zone             => 1,
             :cloud_network                 => 1,
             :cloud_subnet                  => 1,
             :cloud_volume                  => 1,
-            :cloud_volume_backup           => 0,
-            :cloud_volume_snapshot         => 0,
             :custom_attribute              => 4,
             :disk                          => 1,
-            :ext_management_system         => 4,
             :firewall_rule                 => 3,
             :flavor                        => 3,
             :floating_ip                   => 1,
-            :guest_device                  => 0,
             :hardware                      => 2,
             :miq_template                  => 1,
             :network                       => 2,
             :network_port                  => 1,
-            :network_router                => 0,
-            :operating_system              => 0,
             :orchestration_stack           => 2,
             :orchestration_stack_output    => 2,
             :orchestration_stack_parameter => 10,
             :orchestration_stack_resource  => 19,
             :orchestration_template        => 2,
             :security_group                => 1,
-            :snapshot                      => 0,
-            :system_service                => 0,
             :vm                            => 1,
             :vm_or_template                => 2
-          }
-
-          assert_counts(expected_counts)
+          })
         end
       end
 
@@ -510,7 +403,11 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
             :vm_or_template                => 0
           }
 
-          assert_counts(expected_counts)
+          assert_counts(
+            :cloud_volume                  => 2,
+            :cloud_volume_snapshot         => 1,
+            :flavor                        => 3,
+          )
         end
       end
     end

--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -33,9 +33,11 @@ describe ManageIQ::Providers::Amazon::CloudManager do
     expect(ems.ebs_storage_manager.zone_id).to eq zone1.id
     expect(ems.ebs_storage_manager.provider_region).to eq "us-east-1"
 
-    expect(ems.s3_storage_manager.zone).to eq zone1
-    expect(ems.s3_storage_manager.zone_id).to eq zone1.id
-    expect(ems.s3_storage_manager.provider_region).to eq "us-east-1"
+    if ::Settings.prototype.amazon.s3
+      expect(ems.s3_storage_manager.zone).to eq zone1
+      expect(ems.s3_storage_manager.zone_id).to eq zone1.id
+      expect(ems.s3_storage_manager.provider_region).to eq "us-east-1"
+    end
 
     ems.zone = zone2
     ems.provider_region = "us-west-1"
@@ -50,9 +52,11 @@ describe ManageIQ::Providers::Amazon::CloudManager do
     expect(ems.ebs_storage_manager.zone_id).to eq zone2.id
     expect(ems.ebs_storage_manager.provider_region).to eq "us-west-1"
 
-    expect(ems.s3_storage_manager.zone).to eq zone2
-    expect(ems.s3_storage_manager.zone_id).to eq zone2.id
-    expect(ems.s3_storage_manager.provider_region).to eq "us-west-1"
+    if ::Settings.prototype.amazon.s3
+      expect(ems.s3_storage_manager.zone).to eq zone2
+      expect(ems.s3_storage_manager.zone_id).to eq zone2.id
+      expect(ems.s3_storage_manager.provider_region).to eq "us-west-1"
+    end
   end
 
   describe ".metrics_collector_queue_name" do

--- a/spec/models/manageiq/providers/amazon/network_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/network_manager/stubbed_refresher_spec.rb
@@ -110,7 +110,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
     {
       :auth_private_key                  => 0,
-      :ext_management_system             => 4,
+      :ext_management_system             => expected_ext_management_systems_count,
       :flavor                            => 0,
       :availability_zone                 => 0,
       :vm_or_template                    => 0,

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
@@ -96,7 +96,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
   def expected_table_counts
     {
       :auth_private_key                  => 0,
-      :ext_management_system             => 4,
+      :ext_management_system             => expected_ext_management_systems_count,
       :flavor                            => 0,
       :availability_zone                 => 0,
       :vm_or_template                    => 1,

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -2,9 +2,11 @@ require_relative '../../aws_helper'
 require_relative '../../aws_stubs'
 
 describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
+
   include AwsStubs
 
   before do
+    skip("AWS S3 is disabled") unless ::Settings.prototype.amazon.s3
     EvmSpecHelper.local_miq_server(:zone => Zone.seed)
   end
 
@@ -305,7 +307,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
   def expected_table_counts
     {
       :auth_private_key                  => 0,
-      :ext_management_system             => 4,
+      :ext_management_system             => expected_ext_management_systems_count,
       :flavor                            => 0,
       :availability_zone                 => 0,
       :vm_or_template                    => 0,

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -2,7 +2,6 @@ require_relative '../../aws_helper'
 require_relative '../../aws_stubs'
 
 describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
-
   include AwsStubs
 
   before do


### PR DESCRIPTION
Add a configuration to the Settings.yml file that allows administrators to enable or disable Amazon S3 support.

The feature will be disabled by default.

Disabling S3 will disable the S3 manager, which will prevent the S3 refresh worker from starting.