### PR TITLE
Remove Virtual Templates

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -14,7 +14,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :RefreshWorker
   require_nested :Refresher
   require_nested :Template
-  require_nested :VirtualTemplate
   require_nested :Vm
 
   OrchestrationTemplateCfn.register_eligible_manager(self)

--- a/app/models/manageiq/providers/amazon/cloud_manager/virtual_template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/virtual_template.rb
@@ -1,8 +1,0 @@
-class ManageIQ::Providers::Amazon::CloudManager::VirtualTemplate < ::ManageIQ::Providers::CloudManager::VirtualTemplate
-  validates :cloud_network, :availability_zone,
-            :ems_ref, :flavor, :presence => true
-
-  belongs_to :cloud_network
-  belongs_to :availability_zone
-  belongs_to :flavor
-end


### PR DESCRIPTION
Removing Virtual Templates which are a part of arbitration which will soon be deleted from the main repo. (first PR for the removal process: https://github.com/ManageIQ/manageiq/pull/14776) 

@miq-bot add_label refactoring 