### PR TITLE
Support deletion of S3 folders

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
@@ -18,6 +18,10 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject < 
   end
 
   def raw_delete
-    with_provider_object(&:delete)
+    if key.end_with? "/" # delete object with subobjects (aka. folder)
+      cloud_object_store_container.provider_object.objects(:prefix => key).batch_delete!
+    else # delete single object
+      with_provider_object(&:delete)
+    end
   end
 end

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -255,6 +255,62 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
         expect(object.supports?(:delete)).to be_falsey
       end
     end
+
+    describe "delete folder" do
+      before do
+        allow(object.cloud_object_store_container).to receive(:provider_object)
+          .and_return(provider_object_for_container)
+      end
+
+      let :provider_object_for_container do
+        container = double("provider_object_for_container")
+        allow(container).to receive(:objects).and_return(objects_batch)
+        allow(container).to receive(:object).and_return(single_object)
+        container
+      end
+
+      let :objects_batch do
+        objects_batch = double("objects_batch")
+        allow(objects_batch).to receive(:batch_delete!)
+        objects_batch
+      end
+
+      let :single_object do
+        single_object = double("single_object")
+        allow(single_object).to receive(:delete)
+        single_object
+      end
+
+      it "delete folder #1" do
+        object.key = "myfolder/"
+        expect(objects_batch).to receive(:batch_delete!)
+        expect(single_object).not_to receive(:delete)
+
+        with_aws_stubbed(stub_responses) do
+          object.delete_cloud_object_store_object
+        end
+      end
+
+      it "delete folder #2" do
+        object.key = "myfolder/subfolder/"
+        expect(objects_batch).to receive(:batch_delete!)
+        expect(single_object).not_to receive(:delete)
+
+        with_aws_stubbed(stub_responses) do
+          object.delete_cloud_object_store_object
+        end
+      end
+
+      it "delete regular object" do
+        object.key = "file.txt"
+        expect(objects_batch).not_to receive(:batch_delete!)
+        expect(single_object).to receive(:delete)
+
+        with_aws_stubbed(stub_responses) do
+          object.delete_cloud_object_store_object
+        end
+      end
+    end
   end
 
   def refresh_spec


### PR DESCRIPTION
On S3, folders are nothing but regular objects. However, deleting folder fails silently if there are any objects in it. To resolve this issue, we perform a batch delete of all objects within that folder.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1444079

@miq-bot assign @bronaghs 
@miq-bot add_label bug