### PR TITLE
Remove not needed type from a parser

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -53,7 +53,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
 
       persister_image = persister.miq_templates.find_or_build(uid)
       persister_image.assign_attributes(
-        :type                  => ManageIQ::Providers::Amazon::CloudManager::Template.name,
         :ext_management_system => ems,
         :uid_ems               => uid,
         :ems_ref               => uid,
@@ -106,7 +105,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
 
       persister_orchestration_stack = persister.orchestration_stacks.find_or_build(uid)
       persister_orchestration_stack.assign_attributes(
-        :type                   => ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack.name,
         :ext_management_system  => ems,
         :ems_ref                => uid,
         :name                   => stack['stack_name'],
@@ -204,7 +202,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
 
       persister_instance = persister.vms.find_or_build(uid)
       persister_instance.assign_attributes(
-        :type                  => ManageIQ::Providers::Amazon::CloudManager::Vm.name,
         :ext_management_system => ems,
         :uid_ems               => uid,
         :ems_ref               => uid,
@@ -303,7 +300,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       persister_flavor = persister.flavors.find_or_build(uid)
 
       persister_flavor.assign_attributes(
-        :type                     => ManageIQ::Providers::Amazon::CloudManager::Flavor.name,
         :ext_management_system    => ems,
         :ems_ref                  => uid,
         :name                     => name,
@@ -330,7 +326,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       persister_availability_zone = persister.availability_zones.find_or_build(uid)
 
       persister_availability_zone.assign_attributes(
-        :type                  => ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => name,
@@ -344,7 +339,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
 
       persister_key_pair = persister.key_pairs.find_or_build(name)
       persister_key_pair.assign_attributes(
-        :type        => self.class.key_pair_type,
         :resource    => ems,
         :name        => name,
         :fingerprint => kp['key_fingerprint']
@@ -355,11 +349,5 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   # Overridden helper methods, we should put them in helper once we get rid of old refresh
   def get_from_tags(resource, item)
     (resource['tags'] || []).detect { |tag, _| tag['key'].downcase == item.to_s.downcase }.try(:[], 'value')
-  end
-
-  class << self
-    def key_pair_type
-      ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair.name
-    end
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -29,7 +29,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_network = persister.cloud_networks.find_or_build(uid)
       persister_network.assign_attributes(
-        :type                  => self.class.cloud_network_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => name,
@@ -51,7 +50,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_subnet = persister.cloud_subnets.find_or_build(uid)
       persister_subnet.assign_attributes(
-        :type                  => self.class.cloud_subnet_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => name,
@@ -69,7 +67,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_security_group = persister.security_groups.find_or_build(uid)
       persister_security_group.assign_attributes(
-        :type                  => self.class.security_group_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => sg['group_name'],
@@ -115,7 +112,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_load_balancer = persister.load_balancers.find_or_build(uid)
       persister_load_balancer.assign_attributes(
-        :type                  => self.class.load_balancer_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => uid,
@@ -123,7 +119,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_load_balancer_pool = persister.load_balancer_pools.find_or_build(uid)
       persister_load_balancer_pool.assign_attributes(
-        :type                  => self.class.load_balancer_pool_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => uid,
@@ -141,7 +136,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_load_balancer_pool_member = persister.load_balancer_pool_members.find_or_build(uid)
       persister_load_balancer_pool_member.assign_attributes(
-        :type                  => self.class.load_balancer_pool_member_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         # TODO(lsmola) AWS always associates to eth0 of the instances, we do not collect that info now, we need to do that
@@ -164,7 +158,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_load_balancer_listener = persister.load_balancer_listeners.find_or_build(uid)
       persister_load_balancer_listener.assign_attributes(
-        :type                     => self.class.load_balancer_listener_type.name,
         :ext_management_system    => ems,
         :ems_ref                  => uid,
         :load_balancer_protocol   => listener['protocol'],
@@ -189,7 +182,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
     persister_load_balancer_health_check = persister.load_balancer_health_checks.find_or_build(uid)
     persister_load_balancer_health_check.assign_attributes(
-      :type                  => self.class.load_balancer_health_check_type.name,
       :ext_management_system => ems,
       :ems_ref               => uid,
       :protocol              => protocol,
@@ -234,7 +226,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_floating_ip = persister.floating_ips.find_or_build(uid)
       persister_floating_ip.assign_attributes(
-        :type                  => self.class.floating_ip_type.name,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :address               => address,
@@ -255,7 +246,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_network_port = persister.network_ports.find_or_build(uid)
       persister_network_port.assign_attributes(
-        :type                  => self.class.network_port_type.name,
         :ext_management_system => ems,
         :name                  => uid,
         :ems_ref               => uid,
@@ -287,7 +277,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
         persister_floating_ip = persister.floating_ips.find_or_build(public_ip)
         persister_floating_ip.assign_attributes(
-          :type                  => self.class.floating_ip_type.name,
           :ext_management_system => ems,
           :ems_ref               => public_ip,
           :address               => public_ip,
@@ -311,7 +300,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
       persister_network_port = persister.network_ports.find_or_build(uid)
       persister_network_port.assign_attributes(
-        :type                  => self.class.network_port_type.name,
         :ext_management_system => ems,
         :name                  => name,
         :ems_ref               => uid,
@@ -341,7 +329,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
     persister_floating_ip = persister.floating_ips.find_or_build(uid)
     persister_floating_ip.assign_attributes(
-      :type                  => self.class.floating_ip_type.name,
       :ext_management_system => ems,
       :ems_ref               => uid,
       :address               => uid,
@@ -355,51 +342,5 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
   # Overridden helper methods, we should put them in helper once we get rid of old refresh
   def get_from_tags(resource, item)
     (resource['tags'] || []).detect { |tag, _| tag['key'].downcase == item.to_s.downcase }.try(:[], 'value')
-  end
-
-  class << self
-    def load_balancer_type
-      ManageIQ::Providers::Amazon::NetworkManager::LoadBalancer
-    end
-
-    def load_balancer_listener_type
-      ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerListener
-    end
-
-    def load_balancer_health_check_type
-      ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerHealthCheck
-    end
-
-    def load_balancer_pool_type
-      ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPool
-    end
-
-    def load_balancer_pool_member_type
-      ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPoolMember
-    end
-
-    def security_group_type
-      ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup
-    end
-
-    def network_router_type
-      ManageIQ::Providers::Amazon::NetworkManager::NetworkRouter
-    end
-
-    def cloud_network_type
-      ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork
-    end
-
-    def cloud_subnet_type
-      ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet
-    end
-
-    def floating_ip_type
-      ManageIQ::Providers::Amazon::NetworkManager::FloatingIp
-    end
-
-    def network_port_type
-      ManageIQ::Providers::Amazon::NetworkManager::NetworkPort
-    end
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
@@ -20,7 +20,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
 
       persister_volume = persister.cloud_volumes.find_or_build(uid)
       persister_volume.assign_attributes(
-        :type                  => self.class.volume_type,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => get_from_tags(volume, :name) || uid,
@@ -42,7 +41,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
 
       persister_snapshot = persister.cloud_volume_snapshots.find_or_build(uid)
       persister_snapshot.assign_attributes(
-        :type                  => self.class.volume_snapshot_type,
         :ext_management_system => ems,
         :ems_ref               => uid,
         :name                  => get_from_tags(snap, :name) || uid,
@@ -76,16 +74,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
       disk.location = dev
       disk.size     = persister_volume.size
       disk.backing  = persister_volume
-    end
-  end
-
-  class << self
-    def volume_type
-      "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume"
-    end
-
-    def volume_snapshot_type
-      "ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot"
     end
   end
 end

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -107,7 +107,7 @@ module AwsRefresherSpecCommon
   end
 
   def assert_vpc
-    @cn = CloudNetwork.where(:name => "EmsRefreshSpec-VPC").first
+    @cn = ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork.where(:name => "EmsRefreshSpec-VPC").first
     expect(@cn).to(
       have_attributes(
         :name    => "EmsRefreshSpec-VPC",
@@ -123,6 +123,7 @@ module AwsRefresherSpecCommon
     @subnet = @cn.cloud_subnets.where(:name => "EmsRefreshSpec-Subnet1").first
     expect(@subnet).to(
       have_attributes(
+        :type    => "ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet",
         :name    => "EmsRefreshSpec-Subnet1",
         :ems_ref => "subnet-f849ff96",
         :cidr    => "10.0.0.0/24"
@@ -136,6 +137,7 @@ module AwsRefresherSpecCommon
     subnet2 = @cn.cloud_subnets.where(:name => "EmsRefreshSpec-Subnet2").first
     expect(subnet2).to(
       have_attributes(
+        :type    => "ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet",
         :name    => "EmsRefreshSpec-Subnet2",
         :ems_ref => "subnet-16c70477",
         :cidr    => "10.0.1.0/24"
@@ -1040,6 +1042,10 @@ module AwsRefresherSpecCommon
       "type"                     => "ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerListener"
     )
     expect(@listener_2.ext_management_system).to eq(@ems.network_manager)
+    expect(@listener_2.load_balancer_pools.count).to eq 1
+    expect(@listener_2.load_balancer_pools.first.type).to(
+      eq("ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPool")
+    )
 
     @listener_3 = @elb2.load_balancer_listeners.first
     expect(@listener_3).to have_attributes(
@@ -1119,6 +1125,12 @@ module AwsRefresherSpecCommon
 
     expect(health_check_1.load_balancer_pool_members.count).to eq 2
     expect(health_check_1.load_balancer_pool_members).to match_array health_check_2.load_balancer_pool_members
+
+    expect(health_check_1.load_balancer_pool_members.collect(&:type)).to(
+      match_array(
+        ["ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPoolMember"] * 2
+      )
+    )
     expect(health_check_1.vms).to match_array health_check_2.vms
   end
 


### PR DESCRIPTION
Remove not needed :type from the parser, which is needed only
if we are storing sub STI classes under 1 InventoryCollection
definition. Otherwise the :type is taken from the
InventoryCollection of a Persister.

And test that we refresh the right STI classes.