### PR TITLE
Remove not needed type from an orch template parser

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -158,7 +158,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
 
   def stack_template(stack)
     persister.orchestration_templates.find_or_build(stack['stack_id']).assign_attributes(
-      :type        => "OrchestrationTemplateCfn",
       :name        => stack['stack_name'],
       :description => stack['description'],
       :content     => collector.stack_template(stack['stack_name']),


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/14894 

Remove not needed type from an orch template parser