### PR TITLE
Wrap the validation Settings.ems call in a lambda

### DIFF
--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
   extend ActiveSupport::Concern
 
   included do
-    validates :provider_region, :inclusion => {:in => ManageIQ::Providers::Amazon::Regions.names}
+    validates :provider_region, :inclusion => {:in => ->(_region) { ManageIQ::Providers::Amazon::Regions.names }}
   end
 
   def description


### PR DESCRIPTION
Regions.names calls regions which calls

`Settings.ems.ems_amazon.try!(:additional_regions)).stringify_keys`

This Settings call was occurring at require time. We should not hit
Settings by just requiring files and that is what happens
previously.  This seems to cause a sporadic test failure [1]
perhaps because resetting the global constant Settings is very time
dependent and if we access it at the wrong time, it could be nil/not
initialized.

We can prevent this by delaying the Settings call until the validation
is called by wrapping the code in a lambda.

```
  1) Metric as vmware with enabled and disabled targets executing perf_capture_timer should queue up enabled targets
     Failure/Error: if (_klass = name.safe_constantize) # this triggers the load

     NoMethodError:
       undefined method `ems_amazon' for nil:NilClass
     # ./lib/extensions/descendant_loader.rb:234:in `load_subclasses'
     # ./lib/extensions/descendant_loader.rb:254:in `descendants'
     # ./lib/extensions/ar_virtual.rb:593:in `preloaders_for_one'
     # ./lib/miq_preloader.rb:4:in `preload'
     # ./app/models/metric/targets.rb:68:in `load_infra_targets_data'
     # ./app/models/metric/targets.rb:12:in `capture_infra_targets'
     # ./app/models/metric/targets.rb:135:in `capture_targets'
     # ./app/models/metric/capture.rb:46:in `perf_capture_timer'
     # ./spec/models/metric_spec.rb:61:in `block (5 levels) in <top (required)>'
```