### PR TITLE
Parse timestamp for aws alarm events

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_parser.rb
@@ -25,7 +25,7 @@ module ManageIQ::Providers::Amazon::CloudManager::EventParser
 
   def self.parse_cloud_watch_alarm_event!(event, event_hash)
     event_hash[:message]                   = event["AlarmName"]
-    event_hash[:timestamp]                 = event["time"]
+    event_hash[:timestamp]                 = event["StateChangeTime"]
     event_hash[:vm_ems_ref]                = nil # Can't get it
     event_hash[:availability_zone_ems_ref] = nil # Can't get it
   end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_parser_spec.rb
@@ -13,7 +13,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
     it "parses vm_ems_ref into event" do
       event = parse_event("sqs_message.json")
 
-      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-06199fba')
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :vm_ems_ref => 'i-06199fba',
+          :timestamp  => "2016-01-29T08:09:24.720Z"
+        )
+      )
     end
   end
 
@@ -21,13 +26,23 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
     it "parses StartInstances event" do
       event = parse_event("cloud_watch/StartInstances.json")
 
-      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :vm_ems_ref => 'i-0aeefa44d61669849',
+          :timestamp  => "2017-01-31T15:55:09Z"
+        )
+      )
     end
 
     it "parses StopInstances" do
       event = parse_event("cloud_watch/StopInstances.json")
 
-      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :vm_ems_ref => 'i-0aeefa44d61669849',
+          :timestamp  => "2017-01-31T15:51:23Z"
+        )
+      )
     end
   end
 
@@ -35,19 +50,34 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
     it "parses EC2_Instance_State_change_Notification_pending event" do
       event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_pending.json")
 
-      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :vm_ems_ref => 'i-0aeefa44d61669849',
+          :timestamp  => "2017-01-31T15:55:09Z"
+        )
+      )
     end
 
     it "parses EC2_Instance_State_change_Notification_running event" do
       event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_running.json")
 
-      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :vm_ems_ref => 'i-0aeefa44d61669849',
+          :timestamp  => "2017-01-31T15:55:38Z"
+        )
+      )
     end
 
     it "parses EC2_Instance_State_change_Notification_stopped event" do
       event = parse_event("cloud_watch/EC2_Instance_State_change_Notification_stopped.json")
 
-      expect(described_class.event_to_hash(event, nil)).to include(:vm_ems_ref => 'i-0aeefa44d61669849')
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :vm_ems_ref => 'i-0aeefa44d61669849',
+          :timestamp  => "2017-01-31T15:52:32Z"
+        )
+      )
     end
   end
 
@@ -56,7 +86,11 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventParser do
       event = parse_event("cloud_watch/AWS_ALARM_awselb-EmSRefreshSpecVPCELB-Unhealthy-Hosts.json")
 
       expect(described_class.event_to_hash(event, nil)).to(
-        include(:vm_ems_ref => nil, :message => "awselb-EmSRefreshSpecVPCELB-Unhealthy-Hosts")
+        include(
+          :vm_ems_ref => nil,
+          :message    => "awselb-EmSRefreshSpecVPCELB-Unhealthy-Hosts",
+          :timestamp  => "2017-02-22T09:18:26.916+0000"
+        )
       )
     end
   end


### PR DESCRIPTION
Parse correct timestamp for AWS Alarm event

Test that we parse a timestamp for each event type, timestamp is needed for being able to display event in the timelines, also an event without timestamp can break timelines, if it's first or last event of the provider.
