### PR TITLE
Prevent volume update with no modifications

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -100,8 +100,9 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
 
   def modify_volume_options(options = {})
     modify_opts = {}
+
     if volume_type != 'standard'
-      modify_opts[:volume_type] = options[:volume_type] if options[:volume_type] && options[:volume_type] != 'standard'
+      modify_opts[:volume_type] = options[:volume_type] if options[:volume_type] && options[:volume_type] != volume_type
       modify_opts[:size]        = Integer(options[:size]) if options[:size] && Integer(options[:size]).gigabytes != size
       modify_opts[:iops]        = options[:iops] if (options[:volume_type] == "io1" || volume_type == 'io1') && options[:iops]
     end

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
@@ -75,7 +75,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume do
 
         with_aws_stubbed(stubbed_responses) do
           expect do
-            cloud_volume.update_volume(:volume_type => 'gp2')
+            cloud_volume.update_volume(:volume_type => 'gp2', :size => 4)
           end.to raise_error(MiqException::MiqVolumeUpdateError)
         end
       end
@@ -117,10 +117,16 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume do
           include_examples "#modify_volume is not allowed"
         end
 
+        context "volume configuration does not change" do
+          let(:options) { { :volume_type => "gp2", :size => 1 } }
+
+          include_examples "#modify_volume is not allowed"
+        end
+
         context "volume type to gp2" do
           let(:options) { { :volume_type => "gp2", :iops => 200, :size => 4 } }
           # It must ignore IOPS param.
-          let(:modify_volume_options) { { :volume_id => "vol_1", :volume_type => "gp2", :size => 4 } }
+          let(:modify_volume_options) { { :volume_id => "vol_1", :size => 4 } }
 
           include_examples "#modify_volume is allowed"
         end


### PR DESCRIPTION
Amazon EBS API will throw an error in case `modify_volume` is called
with the options that do not differ from the current volume
configuration. This patch ensures that data is properly tested before
it's submitted to the API (if at all). Specs needed minor changes due to
this change; one more test was added to ensure that "no modifications
update" do not invoke the API.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1449237

@miq-bot add_label bug