### PR TITLE
Initial Changes to Amazon Provider for SSA Support

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
   include_concern 'Operations'
+  include_concern 'ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared'
 
   POWER_STATES = {
     "running"       => "on",
@@ -30,13 +31,6 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
     # Mark all instances no longer found as unknown
     self.raw_power_state = "unknown"
     save
-  end
-
-  def proxies4job(_job = nil)
-    {
-      :proxies => [MiqServer.my_server],
-      :message => 'Perform SmartState Analysis on this VM'
-    }
   end
 
   def disconnected

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared
+  extend ActiveSupport::Concern
+  include_concern 'Scanning'
+end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -1,0 +1,63 @@
+module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
+  extend ActiveSupport::Concern
+  require 'amazon_ssa_support'
+
+  included do
+    supports :smartstate_analysis do
+      feature_supported, reason = check_feature_support('smartstate_analysis')
+      unless feature_supported
+        unsupported_reason_add(:smartstate_analysis, reason)
+      end
+    end
+  end
+
+  def scan_via_ems?
+    true
+  end
+
+  def perform_metadata_scan(ost)
+    connect_args           = {}
+    connect_args[:service] = :SQS
+    @sqs = ext_management_system.connect(connect_args)
+    raise "Unable to obtain a new SQS resource" unless @sqs
+    connect_args[:service] = :S3
+    @s3                    = ext_management_system.connect(connect_args)
+    raise "Unable to obtain a new S3 resource" unless @s3
+    ssaq_args                 = {}
+    ssaq_args[:ssa_bucket]    = name
+    ssaq_args[:region]        = ext_management_system.provider_region
+    ssaq_args[:sqs]           = @sqs
+    ssaq_args[:s3]            = @s3
+
+    begin
+      ssaq = AmazonSsaSupport::SsaQueue.new(ssaq_args)
+      raise "Error creating SsaQueue for #{ems_ref}" unless ssaq
+      ssaq.send_extract_request(ems_ref, ost.jobid, AmazonSsaSupport::SsaQueueExtractor::CATEGORIES)
+    rescue => err
+      raise "Unable to send extract request #{err}"
+    end
+  end
+
+  def perform_metadata_sync(ost)
+    sync_stashed_metadata(ost)
+  end
+
+  def proxies4job(job)
+    {
+      :proxies => [MiqServer.my_server],
+      :message => 'Perform SmartState Analysis on this Instance'
+    }
+  end
+
+  def has_active_proxy?
+    true
+  end
+
+  def has_proxy?
+    true
+  end
+
+  def requires_storage_for_scan?
+    false
+  end
+end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -42,7 +42,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     sync_stashed_metadata(ost)
   end
 
-  def proxies4job(_job)
+  def proxies4job(_job = nil)
     {
       :proxies => [MiqServer.my_server],
       :message => 'Perform SmartState Analysis on this Instance'

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -42,7 +42,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     sync_stashed_metadata(ost)
   end
 
-  def proxies4job(job)
+  def proxies4job(_job)
     {
       :proxies => [MiqServer.my_server],
       :message => 'Perform SmartState Analysis on this Instance'

--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency("aws-sdk", ["~>2.9.7"])
+  s.add_dependency("aws-sdk", ["~>2.8.7"])
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency("aws-sdk", ["~>2.8.7"])
+  s.add_dependency("aws-sdk", ["~>2.9.7"])
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/models/manageiq/providers/amazon/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/vm_spec.rb
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Vm do
       allow(MiqServer).to receive(:my_server).and_return("default")
       @proxies = vm.proxies4job
     end
-    
+
     it "has the correct message" do
       expect(@proxies[:message]).to eq('Perform SmartState Analysis on this Instance')
     end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/vm_spec.rb
@@ -4,6 +4,45 @@ describe ManageIQ::Providers::Amazon::CloudManager::Vm do
   let(:ems) { FactoryGirl.create(:ems_amazon_with_authentication) }
   let(:vm)  { FactoryGirl.create(:vm_amazon, :ems_ref => "amazon-perf-vm", :ext_management_system => ems) }
 
+  context "#active_proxy?" do
+    it "returns true" do
+      expect(vm.has_active_proxy?).to eq(true)
+    end
+  end
+
+  context "#has_proxy?" do
+    it "returns true" do
+      expect(vm.has_proxy?).to eq(true)
+    end
+  end
+
+  context "#scan_via_ems?" do
+    it "returns true" do
+      expect(vm.scan_via_ems?).to eq(true)
+    end
+  end
+
+  context "#requires_storage_for_scan??" do
+    it "returns false" do
+      expect(vm.requires_storage_for_scan?).to eq(false)
+    end
+  end
+
+  context "#proxies4job" do
+    before do
+      allow(MiqServer).to receive(:my_server).and_return("default")
+      @proxies = vm.proxies4job
+    end
+    
+    it "has the correct message" do
+      expect(@proxies[:message]).to eq('Perform SmartState Analysis on this Instance')
+    end
+
+    it "returns the default proxy" do
+      expect(@proxies[:proxies].first).to eq('default')
+    end
+  end
+
   context "#is_available?" do
     let(:power_state_on)        { "running" }
     let(:power_state_suspended) { "pending" }


### PR DESCRIPTION
Add initial code to queue a scan request for instances and images by
via the amazon_ssa_support gem.   Update the
version of aws-sdk required for SSA requests.

This PR is dependent upon https://github.com/ManageIQ/amazon_ssa_support/pull/7 so that the requirement for an "extractor_id" when queuing a request will no longer be there.

It is also dependent upon https://github.com/ManageIQ/manageiq-providers-amazon/pull/252 which
upgrades the aws-sdk version to 2.9.7

It is also a dependent upon https://github.com/ManageIQ/manageiq/pull/15107.
because the Gemfile changes adding the amazon_ssa_support gem cannot be added in this Gem - they must be added in the core Gemfile.

@roliveri @hsong-rh @bronaghs please review.

Note this is WIP because I am still adding tests.