### PR TITLE
upgrade aws-sdk to 2.9.7

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config.lib}/**/*"]
 
-  s.add_dependency("aws-sdk", ["~>2.8.7"])
+  s.add_dependency("aws-sdk", ["~>2.9.7"])
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/ManageIQ/manageiq-providers-amazon/pull/251
and https://github.com/ManageIQ/manageiq/pull/15107

Order of merge should be this one, then the core PR, then the next manageiq-providers-amazon PR listed above.

@bdunne @yrudman @bronaghs @roliveri @hsong-rh  Please review and merge asap.  Thanks.