### PR TITLE
Leverage builder params to provide ems id and defaults

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -1,10 +1,6 @@
 # TODO: Separate collection from parsing (perhaps collecting in parallel a la RHEVM)
 
 class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::Providers::Amazon::Inventory::Parser
-  def ems
-    collector.manager
-  end
-
   def parse
     log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{collector.manager.name}] id: [#{collector.manager.id}]"
     $aws_log.info("#{log_header}...")
@@ -52,14 +48,13 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       name     ||= uid
 
       persister_image = persister.miq_templates.find_or_build(uid).assign_attributes(
-        :ext_management_system => ems,
-        :uid_ems               => uid,
-        :name                  => name,
-        :location              => location,
-        :vendor                => "amazon",
-        :raw_power_state       => "never",
-        :template              => true,
-        :publicly_available    => image['public'],
+        :uid_ems            => uid,
+        :name               => name,
+        :location           => location,
+        :vendor             => "amazon",
+        :raw_power_state    => "never",
+        :template           => true,
+        :publicly_available => image['public'],
       )
 
       image_hardware(persister_image, image)
@@ -85,9 +80,9 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def vm_and_template_labels(resource, tags)
     tags.each do |tag|
       persister.vm_and_template_labels.find_or_build_by(:resource => resource, :name => tag["key"]).assign_attributes(
-        :section  => 'labels',
-        :value    => tag["value"],
-        :source   => 'amazon'
+        :section => 'labels',
+        :value   => tag["value"],
+        :source  => 'amazon'
       )
     end
   end
@@ -97,7 +92,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       uid = stack['stack_id'].to_s
 
       persister_orchestration_stack = persister.orchestration_stacks.find_or_build(uid).assign_attributes(
-        :ext_management_system  => ems,
         :name                   => stack['stack_name'],
         :description            => stack['description'],
         :status                 => stack['stack_status'],
@@ -178,18 +172,17 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       name = name.blank? ? uid : name
 
       persister_instance = persister.vms.find_or_build(uid).assign_attributes(
-        :ext_management_system => ems,
-        :uid_ems               => uid,
-        :name                  => name,
-        :vendor                => "amazon",
-        :raw_power_state       => status,
-        :boot_time             => instance['launch_time'],
-        :availability_zone     => persister.availability_zones.lazy_find(instance.fetch_path('placement', 'availability_zone')),
-        :flavor                => flavor,
-        :genealogy_parent      => persister.miq_templates.lazy_find(instance['image_id']),
-        :key_pairs             => [persister.key_pairs.lazy_find(instance['key_name'])].compact,
-        :location              => persister.networks.lazy_find("#{uid}__public", :key => :hostname, :default => 'unknown'),
-        :orchestration_stack   => persister.orchestration_stacks.lazy_find(
+        :uid_ems             => uid,
+        :name                => name,
+        :vendor              => "amazon",
+        :raw_power_state     => status,
+        :boot_time           => instance['launch_time'],
+        :availability_zone   => persister.availability_zones.lazy_find(instance.fetch_path('placement', 'availability_zone')),
+        :flavor              => flavor,
+        :genealogy_parent    => persister.miq_templates.lazy_find(instance['image_id']),
+        :key_pairs           => [persister.key_pairs.lazy_find(instance['key_name'])].compact,
+        :location            => persister.networks.lazy_find("#{uid}__public", :key => :hostname, :default => 'unknown'),
+        :orchestration_stack => persister.orchestration_stacks.lazy_find(
           get_from_tags(instance, "aws:cloudformation:stack-id")
         ),
       )
@@ -234,8 +227,8 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
         :hardware    => persister_hardware,
         :description => description
       ).assign_attributes(
-        :ipaddress   => ip_address,
-        :hostname    => hostname,
+        :ipaddress => ip_address,
+        :hostname  => hostname,
       )
     end
   end
@@ -270,7 +263,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def flavors
     collector.flavors.each do |flavor|
       persister.flavors.find_or_build(flavor[:name]).assign_attributes(
-        :ext_management_system    => ems,
         :name                     => flavor[:name],
         :description              => flavor[:description],
         :enabled                  => !flavor[:disabled],
@@ -292,8 +284,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def availability_zones
     collector.availability_zones.each do |az|
       persister.availability_zones.find_or_build(az['zone_name']).assign_attributes(
-        :ext_management_system => ems,
-        :name                  => az['zone_name'],
+        :name => az['zone_name'],
       )
     end
   end
@@ -301,7 +292,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def key_pairs
     collector.key_pairs.each do |kp|
       persister.key_pairs.find_or_build(kp['key_name']).assign_attributes(
-        :resource    => ems,
         :fingerprint => kp['key_fingerprint']
       )
     end

--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/s3.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < ManageIQ::Providers::Amazon::Inventory::Parser
-  def ems
-    collector.manager.respond_to?(:s3_storage_manager) ? collector.manager.s3_storage_manager : collector.manager
-  end
-
   def parse
     log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{collector.manager.name}] id: [#{collector.manager.id}]"
 
@@ -18,9 +14,8 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
       container_id = container['name']
 
       persister_container = persister.cloud_object_store_containers.find_or_build(container_id).assign_attributes(
-        :ext_management_system => ems,
-        :ems_ref               => container_id,
-        :key                   => container['name']
+        :ems_ref => container_id,
+        :key     => container['name']
       )
 
       # Assign number of objects and size in KB of the all container objects
@@ -30,9 +25,9 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
 
   def container_objects(container_id, persister_container)
     # S3 bucket accessible only for API client with same region
-    region  = collector.aws_s3.client.get_bucket_location(:bucket => container_id).location_constraint
-    region  = "us-east-1" if region.empty? # SDK returns empty string for default region
-    options = {:region => region, :bucket => container_id}
+    region       = collector.aws_s3.client.get_bucket_location(:bucket => container_id).location_constraint
+    region       = "us-east-1" if region.empty? # SDK returns empty string for default region
+    options      = {:region => region, :bucket => container_id}
 
     # AWS SDK doesn't show information about overall size and object count.
     # We need to collect it manually.
@@ -59,7 +54,6 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::S3 < Manag
     ems_ref = "#{container_id}_#{uid}"
 
     persister.cloud_object_store_objects.find_or_build(ems_ref).assign_attributes(
-      :ext_management_system        => ems,
       :etag                         => container_object['etag'],
       :last_modified                => container_object['last_modified'],
       :content_length               => container_object['size'],

--- a/app/models/manageiq/providers/amazon/inventory/persister.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Amazon::Inventory::Persister < ManagerRefresh::Invent
   # @param manager [ManageIQ::Providers::BaseManager] A manager object
   # @param target [Object] A refresh Target object
   # @param target [ManagerRefresh::Inventory::Collector] A Collector object
-  def initialize(manager, target, collector)
+  def initialize(manager, target = nil, collector = nil)
     @manager   = manager
     @target    = target
     @collector = collector

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/cloud_manager.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
         :model_class                 => ::ManageIQ::Providers::Amazon::CloudManager::Vm,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :uid_ems,
           :ems_ref,
           :name,
@@ -18,7 +18,11 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
           :key_pairs,
           :location,
           :orchestration_stack,
-        ]
+        ],
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.id },
+          :vendor => "amazon",
+        }
       }
       super(attributes.merge!(extra_attributes))
     end
@@ -28,7 +32,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
         :model_class                 => ::ManageIQ::Providers::Amazon::CloudManager::Template,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :uid_ems,
           :ems_ref,
           :name,
@@ -37,7 +41,12 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
           :raw_power_state,
           :template,
           :publicly_available,
-        ]
+        ],
+        :builder_params              => {
+          :ems_id   => ->(persister) { persister.manager.id },
+          :vendor   => "amazon",
+          :template => true
+        }
       }
 
       super(attributes.merge!(extra_attributes))
@@ -81,7 +90,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
         :model_class                 => ::ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
         ]
@@ -95,7 +104,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
         :model_class                 => ::ManageIQ::Providers::Amazon::CloudManager::Flavor,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :description,
@@ -153,7 +162,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::CloudManager < Ma
         :model_class                 => ::ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :description,

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/network_manager.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::NetworkPort,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :name,
           :ems_ref,
           :status,
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::FloatingIp,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :address,
           :fixed_ip_address,
@@ -57,7 +57,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :cidr,
@@ -75,7 +75,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :cidr,
@@ -93,7 +93,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :description,
@@ -126,7 +126,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancer,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
         ]
@@ -140,7 +140,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPool,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
         ]
@@ -154,7 +154,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerPoolMember,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :vm,
         ]
@@ -179,7 +179,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerListener,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :load_balancer_protocol,
           :load_balancer_port_range,
@@ -208,7 +208,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::NetworkManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::NetworkManager::LoadBalancerHealthCheck,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :protocol,
           :port,

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :status,
@@ -14,7 +14,10 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
           :size,
           :base_snapshot,
           :availability_zone,
-        ]
+        ],
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.try(:ebs_storage_manager).try(:id) || persister.manager.id },
+        }
       }
 
       super(attributes.merge!(extra_attributes))
@@ -25,7 +28,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
         :model_class                 => ::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot,
         :inventory_object_attributes => [
           :type,
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :name,
           :status,
@@ -33,7 +36,10 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
           :description,
           :size,
           :cloud_volume,
-        ]
+        ],
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.try(:ebs_storage_manager).try(:id) || persister.manager.id },
+        }
       }
 
       super(attributes.merge!(extra_attributes))
@@ -43,12 +49,15 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
       attributes = {
         :model_class                 => ::ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer,
         :inventory_object_attributes => [
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :key,
           :bytes,
           :object_count,
-        ]
+        ],
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.try(:s3_storage_manager).try(:id) || persister.manager.id },
+        }
       }
 
       super(attributes.merge!(extra_attributes))
@@ -58,14 +67,17 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
       attributes = {
         :model_class                 => ::ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject,
         :inventory_object_attributes => [
-          :ext_management_system,
+          :ems_id,
           :ems_ref,
           :etag,
           :last_modified,
           :content_length,
           :key,
           :cloud_object_store_container,
-        ]
+        ],
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.try(:s3_storage_manager).try(:id) || persister.manager.id },
+        }
       }
 
       super(attributes.merge!(extra_attributes))


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/15142

Leverage builder params to provide ems_id and the defaults. That will simplify parsers logic and allow us to create placeholder objects using just ems_ref.