### PR TITLE
Require rails/engine and action_controller/railtie

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
-require 'manageiq-providers-amazon'
 
 begin
   require 'rspec/core/rake_task'

--- a/lib/manageiq/providers/amazon/engine.rb
+++ b/lib/manageiq/providers/amazon/engine.rb
@@ -1,5 +1,3 @@
-require 'rails/all'
-
 module ManageIQ
   module Providers
     module Amazon


### PR DESCRIPTION
Now, we don't require anything and I get to delete code.


~~Because we use isolate_namespace, we need to require action_controller/railtie. A blank rails engine generated by rails doesn't require anything...[1] Other engines do the sensible thing: require what they need [2] We shouldn't make assumptions about the rails features the application using the engine will want to use.~~

~~[1]
https://github.com/rails/rails/blob/0e453e9150f0ac9fa2bdff4511c3c806a3e45f49/railties/lib/rails/generators/rails/plugin/templates/lib/%25namespaced_name%25/engine.rb~~

~~[2] https://github.com/rails/coffee-rails/blob/db0659924c82f24e2665d799b1ab342078f2501d/lib/coffee/rails/engine.rb#L1~~

Note, I tested this by running the following:
```
05:50:14 ~/Code/manageiq-providers-amazon (dont_require_all_of_rails) (2.4.1) - be rake -T | grep instance_types
rake instance_types                                              # Create new instance_types.rb
```

I tested this before this change, dropped the rails/all and added back things until I could load the rake task.

EDIT: MORE 🔥 🚽 ✂️ 
