### PR TITLE
Collect encryption status of cloud volume snapshot

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
@@ -36,7 +36,8 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
         :creation_time => snap['start_time'],
         :description   => snap['description'],
         :size          => snap['volume_size'].to_i.gigabytes,
-        :cloud_volume  => persister.cloud_volumes.lazy_find(snap['volume_id'])
+        :cloud_volume  => persister.cloud_volumes.lazy_find(snap['volume_id']),
+        :encrypted     => snap['encrypted'],
       )
     end
   end

--- a/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory_collection_default/storage_manager.rb
@@ -38,6 +38,7 @@ class ManageIQ::Providers::Amazon::InventoryCollectionDefault::StorageManager < 
           :description,
           :size,
           :cloud_volume,
+          :encrypted,
         ],
         :builder_params              => {
           :ems_id => ->(persister) { persister.manager.try(:ebs_storage_manager).try(:id) || persister.manager.id },

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_parser.rb
@@ -67,7 +67,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshParser
       :creation_time => snap.start_time,
       :description   => snap.description,
       :size          => snap.volume_size.to_i.gigabytes,
-      :volume        => @data_index.fetch_path(:cloud_volumes, snap.volume_id)
+      :volume        => @data_index.fetch_path(:cloud_volumes, snap.volume_id),
+      :encrypted     => snap.encrypted,
     }
 
     return uid, new_result

--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -477,7 +477,8 @@ module AwsStubs
         :volume_size => 1,
         :state       => "completed",
         :volume_id   => "volume_id_#{i}",
-        :tags        => [{ :key => "name", :value => "snapshot_#{i}" }]
+        :tags        => [{ :key => "name", :value => "snapshot_#{i}" }],
+        :encrypted   => (i == 0 ? true : false),
       }
     end
 


### PR DESCRIPTION
UI has encrypted attribute included, but it is rendered empty for the user.

Depends on: https://github.com/ManageIQ/manageiq/pull/15352