### PR TITLE
allow raw_connect to validate the connection and decrypt the password

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -1,6 +1,24 @@
 require_relative 'aws_helper'
 
 describe ManageIQ::Providers::Amazon::CloudManager do
+  context ".raw_connect" do
+    it "decrypts the secret access key" do
+      expect(MiqPassword).to receive(:try_decrypt).with('secret_access_key')
+
+      described_class.raw_connect('access_key', 'secret_access_key', :EC2, 'region')
+    end
+
+    it "validates credentials if specified" do
+      expect(described_class).to receive(:validate_connection)
+
+      described_class.raw_connect('access_key', 'secret_access_key', :EC2, 'region', 'uri', true)
+    end
+
+    it "returns the connection if not specified" do
+      expect(described_class.raw_connect('access_key', 'secret_access_key', :EC2, 'region', 'uri')).to be_a_kind_of(Aws::EC2::Resource)
+    end
+  end
+
   it ".ems_type" do
     expect(described_class.ems_type).to eq('ec2')
   end


### PR DESCRIPTION
The UI is moving towards validating credentials on the queue to allow for validating credentials in separate zones utilizing the `raw_connect` class method, rather than needing to create a temporary EMS for validation.

 For many of the providers, `raw_connect` ensures the credentials are correct. This updates `raw_connect` to not only return a connection but also be able to validate (it will *not* validate by default).

Because credentials are going to be stored on the queue, it also needs to be able to decrypt them. This uses `MiqPassword.try_decrypt` so that it can accept both unencrypted and encrypted credentials.

PR with greater detail: https://github.com/ManageIQ/manageiq-ui-classic/pull/1580