### PR TITLE
Enable SSA for AWS Images

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/template.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Amazon::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
+  include_concern 'ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared'
+
   supports :provisioning do
     if ext_management_system
       unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?


### PR DESCRIPTION
Previously SSA was enabled for AWS Instances but not for Images.
This (extremely) simple change will turn on the support for Images as well.
@roliveri please review and approve.
@blomquisg @bronaghs please review and merge when appropriate.