### PR TITLE
Handle SSA Response from AWS Scanning Instance

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -25,11 +25,11 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     connect_args[:service] = :S3
     @s3                    = ext_management_system.connect(connect_args)
     raise "Unable to obtain a new S3 resource" unless @s3
-    ssaq_args                 = {}
-    ssaq_args[:ssa_bucket]    = "evm-prototype"
-    ssaq_args[:region]        = ext_management_system.provider_region
-    ssaq_args[:sqs]           = @sqs
-    ssaq_args[:s3]            = @s3
+    ssaq_args              = {}
+    ssaq_args[:ssa_bucket] = "evm-prototype"
+    ssaq_args[:region]     = ext_management_system.provider_region
+    ssaq_args[:sqs]        = @sqs
+    ssaq_args[:s3]         = @s3
 
     begin
       ssaq = AmazonSsaSupport::SsaQueue.new(ssaq_args)
@@ -75,13 +75,13 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
   def perform_metadata_sync(ost)
     _log.debug("Syncing Metadata for #{ems_ref}")
     update_job_message(ost, "Synchronization in progress")
-    status, scan_message              = "OK"
-    status_code, categories_processed = 0
-    ost.xml_class                     = XmlHash::Document
-    bb, last_err                      = nil
+    status        = scan_message         = "OK"
+    status_code   = categories_processed = 0
+    ost.xml_class = XmlHash::Document
+    bb            = last_err             = nil
 
     xml_summary = ost.xml_class.createDoc(:summary)
-    xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
+    xml_node    = xml_node_scan = xml_summary.root.add_element("scanmetadata")
     xml_summary.root.add_attributes("taskid" => ost.taskid)
 
     data_dir = File.expand_path(Rails.root.join("data/metadata"))
@@ -135,7 +135,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
       if last_err
         status = "Error"
         status_code = 8
-        status_code = 16 if categories_processed.zero?
+	status_code = 16 if categories_processed.zero?
         scan_message = last_err.to_s
         _log.error "ScanMetadata error status:[#{status_code}]:  message:[#{last_err}]"
         _log.debug { last_err.backtrace.join("\n") }

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -78,19 +78,19 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     status        = scan_message         = "OK"
     status_code   = categories_processed = 0
     ost.xml_class = XmlHash::Document
-    bb            = last_err             = nil
+    bb            = last_err = nil
 
     xml_summary = ost.xml_class.createDoc(:summary)
     xml_node    = xml_node_scan = xml_summary.root.add_element("scanmetadata")
     xml_summary.root.add_attributes("taskid" => ost.taskid)
 
     data_dir = File.expand_path(Rails.root.join("data/metadata"))
-    _log.debug "creating #{data_dir}"
+    _log.debug("creating #{data_dir}")
     begin
       Dir.mkdir(data_dir)
     rescue Errno::EEXIST
       # Ignore if the directory was created by another thread
-      _log.debug "No need to create directory #{data_dir} since it exists."
+      _log.debug("No need to create directory #{data_dir} since it exists.")
     end unless File.exist?(data_dir)
     ost.skipConfig = true
     ost.config     = OpenStruct.new(
@@ -100,9 +100,9 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
 
     begin
       require 'blackbox/VmBlackBox'
-      _log.debug "instantiating BlackBox"
+      _log.debug("instantiating BlackBox")
       bb = Manageiq::BlackBox.new(guid, ost)
-      _log.debug "instantiated BlackBox"
+      _log.debug("instantiated BlackBox")
       categories = ost.category
       #
       # TODO: The amazon_ssa_support gem defines the category as an array,
@@ -116,9 +116,9 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
         st = Time.current
         xml = MIQRexml.load(ost.reply[:categories][c.to_sym])
         next unless xml
-        _log.debug "Writing scanned data to XML for [#{c}] to blackbox."
+        _log.debug("Writing scanned data to XML for [#{c}] to blackbox.")
         bb.saveXmlData(xml, c)
-        _log.debug "Writing XML complete."
+        _log.debug("Writing XML complete.")
 
         category_node = xml_summary.class.load(xml.root.shallow_copy.to_xml.to_s).root
         category_node.add_attributes("start_time" => st.utc.iso8601, "end_time" => Time.now.utc.iso8601)
@@ -127,17 +127,17 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
       end
     rescue NoMethodError => scan_err
       last_err = scan_err
-      _log.error "perform_metadata_sync Error - [#{scan_err}]"
-      _log.error "perform_metadata_sync Error - [#{scan_err.backtrace.join("\n")}]"
+      _log.error("perform_metadata_sync Error - [#{scan_err}]")
+      _log.error("perform_metadata_sync Error - [#{scan_err.backtrace.join("\n")}]")
     ensure
       bb.close if bb
       update_job_message(ost, "Scanning completed.")
       if last_err
         status = "Error"
-        status_code = 8
-	status_code = 16 if categories_processed.zero?
+        status_code  = 8
+        status_code  = 16 if categories_processed.zero?
         scan_message = last_err.to_s
-        _log.error "ScanMetadata error status:[#{status_code}]:  message:[#{last_err}]"
+        _log.error("ScanMetadata error status:[#{status_code}]:  message:[#{last_err}]")
         _log.debug { last_err.backtrace.join("\n") }
       end
 
@@ -148,7 +148,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
         "message"     => scan_message
       )
       save_metadata_op(MIQEncode.encode(xml_summary.to_xml.to_s), "b64,zlib,xml", ost.taskid)
-      _log.info "Completed: Sending scan summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
+      _log.info("Completed: Sending scan summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]")
     end
     sync_stashed_metadata(ost)
   end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -1,6 +1,8 @@
 module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
   extend ActiveSupport::Concern
   require 'amazon_ssa_support'
+  require 'xml/xml_utils'
+  require 'scanning_operations_mixin'
 
   included do
     supports :smartstate_analysis do
@@ -24,7 +26,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     @s3                    = ext_management_system.connect(connect_args)
     raise "Unable to obtain a new S3 resource" unless @s3
     ssaq_args                 = {}
-    ssaq_args[:ssa_bucket]    = name
+    ssaq_args[:ssa_bucket]    = "evm-prototype"
     ssaq_args[:region]        = ext_management_system.provider_region
     ssaq_args[:sqs]           = @sqs
     ssaq_args[:s3]            = @s3
@@ -32,13 +34,124 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     begin
       ssaq = AmazonSsaSupport::SsaQueue.new(ssaq_args)
       raise "Error creating SsaQueue for #{ems_ref}" unless ssaq
-      ssaq.send_extract_request(ems_ref, ost.jobid, AmazonSsaSupport::SsaQueueExtractor::CATEGORIES)
+      ost.ssaq = ssaq
+      _log.debug("sending extract request for #{ems_ref}")
+      ost.category   = AmazonSsaSupport::SsaQueueExtractor::CATEGORIES
+      request        = ssaq.send_extract_request(ems_ref, ost.jobid, ost.category)
+      ost.message_id = request.message_id
+      #
+      # TODO:  This request should be handed off to a worker responsible FOR watching for job completion
+      # In addition the instance manager should get kicked in the shin so it can determine if there
+      # are instances available to handle this request and act accordingly if not. 
+      # For now, we will simply call perform_instance_wait, which will wait for the *NEXT* job
+      # to be completed and handle it as if it is the one we care about (a possibly faulty assumption)
+      #
     rescue => err
-      raise "Unable to send extract request #{err}"
+      raise "Unable to send extract request: #{err}"
     end
+    perform_instance_wait(ost)
+  end
+
+  def perform_instance_wait(ost)
+    _log.debug("Waiting for Amazon Instance for #{ems_ref}")
+    ssaq          = ost.ssaq
+    extract_reply = nil
+    until extract_reply
+      sleep(60)
+      begin
+        ssaq.reply_loop do |reply|
+          _log.debug("Reply for #{ems_ref}: #{reply}")
+          extract_reply = reply
+        end
+      rescue => err
+        raise "Unable to get reply to scan request from instance: #{err}"
+      end
+    end
+    raise "No reply received for scan request from instance #{ems_ref}" unless extract_reply
+    ost.reply = extract_reply
+    perform_metadata_sync(ost)
   end
 
   def perform_metadata_sync(ost)
+    _log.debug("Syncing Metadata for #{ems_ref}")
+    update_job_message(ost, "Synchronization in progress")
+    status        = scan_message         = "OK"
+    status_code   = categories_processed = 0
+    ost.xml_class = XmlHash::Document
+
+    bb, last_err  = nil
+
+
+    xml_summary = ost.xml_class.createDoc(:summary)
+    xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
+    xml_summary.root.add_attributes("taskid" => ost.taskid)
+
+    data_dir = File.join(File.expand_path(Rails.root), "data/metadata")
+    _log.debug "creating #{data_dir}"
+    begin
+      Dir.mkdir(data_dir)
+    rescue Errno::EEXIST
+      # Ignore if the directory was created by another thread
+    end unless File.exist?(data_dir)
+    ost.skipConfig = true
+    ost.config     = OpenStruct.new(
+      :dataDir            => data_dir,
+      :forceFleeceDefault => false
+    )
+
+    begin
+      require 'blackbox/VmBlackBox'
+      _log.debug "instantiating BlackBox"
+      bb = Manageiq::BlackBox.new(guid, ost)
+      _log.debug "instantiated BlackBox"
+      categories = ost.category
+      #
+      # TODO: The amazon_ssa_support gem defines the category as an array,
+      # But the scanning_mixin expects it to be a comma-separated string.
+      # We should fix the gem....
+      #
+      ost.category = categories.join(",")
+
+      categories.each do |c|
+        update_job_message(ost, "Syncing #{c}")
+        st = Time.now
+        xml = MIQRexml.load(ost.reply[:categories][c.to_sym])
+        if xml
+          _log.debug "Writing scanned data to XML for [#{c}] to blackbox."
+          bb.saveXmlData(xml, c)
+          _log.debug "Writing XML complete."
+
+          category_node = xml_summary.class.load(xml.root.shallow_copy.to_xml.to_s).root
+          category_node.add_attributes("start_time" => st.utc.iso8601, "end_time" => Time.now.utc.iso8601)
+          xml_node << category_node
+          categories_processed += 1
+        end
+      end
+    rescue NoMethodError => scanErr
+      last_err = scanErr
+      _log.error "perform_metadata_sync Error - [#{scanErr}]"
+      _log.error "perform_metadata_sync Error - [#{scanErr.backtrace.join("\n")}]"
+    ensure
+      bb.close if bb
+      update_job_message(ost, "Scanning completed.")
+      if last_err
+        status = "Error"
+        status_code = 8
+        status_code = 16 if categories_processed.zero?
+        scan_message = last_err.to_s
+        _log.error "ScanMetadata error status:[#{status_code}]:  message:[#{last_err}]"
+        _log.debug { last_err.backtrace.join("\n") }
+      end
+
+      xml_node_scan.add_attributes(
+        "end_time"    => Time.now.utc.iso8601,
+        "status"      => status,
+        "status_code" => status_code.to_s,
+        "message"     => scan_message
+      )
+      save_metadata_op(MIQEncode.encode(xml_summary.to_xml.to_s), "b64,zlib,xml", ost.taskid)
+      _log.info "Completed: Sending scan summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
+    end
     sync_stashed_metadata(ost)
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -26,7 +26,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
     @s3                    = ext_management_system.connect(connect_args)
     raise "Unable to obtain a new S3 resource" unless @s3
     ssaq_args              = {}
-    ssaq_args[:ssa_bucket] = "evm-prototype"
+    ssaq_args[:ssa_bucket] = ext_management_system.guid
     ssaq_args[:region]     = ext_management_system.provider_region
     ssaq_args[:sqs]        = @sqs
     ssaq_args[:s3]         = @s3


### PR DESCRIPTION
Previously the request to perform SSA on AWS by the Scanning Instance was implemented.
We are now implementing the code to process the response from the the SSA scan upon
completion.

Note that much of the code to do this, in perform_metadata_sync,
was taken from the ScanningMixin method scan_via_miq_vm.  The intent will be to
mitigate duplication when possible moving forward but for now we wanted to get
this running at the very least.

Also note that for now this code will be reading the first available response from
SQS.  If more than one SSA request is issued simultaneously there is a good chance
that the responses will be handled out of order.  We intend to implement a worker
to perform this task in the near future to handle this issue.

@roliveri and @hsong-rh please review for relevance with regard to SSA.
@bronaghs please review and or assign appropriately to a Providers team member for merging
when satisfied.  Thanks.