### PR TITLE
Enable to save key_pair in Authentication

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
@@ -1,8 +1,9 @@
 class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair < ManageIQ::Providers::CloudManager::AuthKeyPair
+  AwsKeyPair = Struct.new(:name, :key_name, :fingerprint, :private_key)
+
   def self.raw_create_key_pair(ext_management_system, create_options)
     ec2 = ext_management_system.connect
     kp = ec2.create_key_pair(create_options)
-    AwsKeyPair = Struct.new(:name, :key_name, :fingerprint, :private_key)
     AwsKeyPair.new(kp.name, kp.name, kp.key_fingerprint, kp.key_material)
   rescue => err
     _log.error "keypair=[#{name}], error: #{err}"

--- a/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
@@ -1,2 +1,37 @@
 class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair < ManageIQ::Providers::CloudManager::AuthKeyPair
+  def self.raw_create_key_pair(ext_management_system, create_options)
+    ec2 = ext_management_system.connect
+    kp = ec2.create_key_pair(create_options)
+    ost = OpenStruct.new
+    ost.name = ost.key_name = kp.name
+    ost.fingerprint = kp.key_fingerprint
+    ost.private_key = kp.key_material
+    ost
+  rescue => err
+    _log.error "keypair=[#{name}], error: #{err}"
+    raise MiqException::Error, err.to_s, err.backtrace
+  end
+
+  def self.validate_create_key_pair(ext_management_system, _options = {})
+    if ext_management_system
+      {:available => true, :message => nil}
+    else
+      {:available => false,
+       :message   => _("The Keypair is not connected to an active %{table}") %
+         {:table => ui_lookup(:table => "ext_management_system")}}
+    end
+  end
+
+  def raw_delete_key_pair
+    ec2 = resource.connect
+    kp = ec2.key_pair(name)
+    kp.delete
+  rescue => err
+    _log.error "keypair=[#{name}], error: #{err}"
+    raise MiqException::Error, err.to_s, err.backtrace
+  end
+
+  def validate_delete_key_pair
+    {:available => true, :message => nil}
+  end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
@@ -2,11 +2,8 @@ class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair < ManageIQ::Provide
   def self.raw_create_key_pair(ext_management_system, create_options)
     ec2 = ext_management_system.connect
     kp = ec2.create_key_pair(create_options)
-    ost = OpenStruct.new
-    ost.name = ost.key_name = kp.name
-    ost.fingerprint = kp.key_fingerprint
-    ost.private_key = kp.key_material
-    ost
+    AwsKeyPair = Struct.new(:name, :key_name, :fingerprint, :private_key)
+    AwsKeyPair.new(kp.name, kp.name, kp.key_fingerprint, kp.key_material)
   rescue => err
     _log.error "keypair=[#{name}], error: #{err}"
     raise MiqException::Error, err.to_s, err.backtrace


### PR DESCRIPTION
Enable to save key_pair information in authentication table. Smart state analysis will use it to transfer files to the agent.