### PR TITLE
Fix provision request specs

### DIFF
--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -97,7 +97,7 @@ describe "Provision Requests API" do
         )
       )
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -125,7 +125,7 @@ describe "Provision Requests API" do
         )
       )
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -154,7 +154,7 @@ describe "Provision Requests API" do
         )
       )
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
   end


### PR DESCRIPTION
These were broken by the introduction of
https://github.com/ManageIQ/manageiq/pull/15430 and
https://github.com/ManageIQ/manageiq/pull/15186

@miq-bot add-label test, bug
@miq-bot assign @durandom 