### PR TITLE
Adjust test result to match new data_type

### DIFF
--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -92,7 +92,7 @@ describe "Provision Requests API" do
           "placement_availability_zone" => [az.id, az.name],
           "cloud_network"               => [cloud_network1.id, cloud_network1.name],
           "cloud_subnet"                => [cloud_subnet1.id, anything],
-          "security_groups"             => [security_group1.id, security_group1.name],
+          "security_groups"             => [security_group1.id],
           "floating_ip_address"         => [floating_ip1.id, floating_ip1.name]
         )
       )


### PR DESCRIPTION
The security_groups key now defaults to a data_type of `:array_integer`.  The resulting value is an Array of Integers as opposed to an array with the first value being an integer and the second being a human readable value.  

This fix modifies the resulting hash to expect an array of Integers.

Dependent on: https://github.com/ManageIQ/manageiq/pull/15572