### PR TITLE
Handle empty string in image name tags

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -177,9 +177,9 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     end
 
     name = get_from_tags(image, :name)
-    name ||= image.name
-    name ||= $1 if location =~ /^(.+?)(\.(image|img))?\.manifest\.xml$/
-    name ||= uid
+    name = image.name if name.blank?
+    name = $1         if name.blank? && location =~ /^(.+?)(\.(image|img))?\.manifest\.xml$/
+    name = uid        if name.blank?
 
     labels = parse_labels(image.tags)
 


### PR DESCRIPTION
It is possible for the name coming from a tag to be an empty string,
this was bypassing the ||= check but failing the validation on the
VmOrTemplate model causing the refresh to fail.

This same issue was fixed for instances by https://github.com/ManageIQ/manageiq-providers-amazon/pull/35

https://bugzilla.redhat.com/show_bug.cgi?id=1471297