### PR TITLE
Add raw_delete_snapshot to CloudVolumeSnapshot model

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
@@ -59,33 +59,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot < ::
     raise MiqException::MiqVolumeSnapshotCreateError, e.to_s, e.backtrace
   end
 
-  def delete_snapshot_queue(userid = "system", _options = {})
-    task_opts = {
-      :action => "deleting volume snapshot #{inspect} in #{ext_management_system.inspect}",
-      :userid => userid
-    }
-
-    queue_opts = {
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => 'delete_snapshot',
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => my_zone,
-      :args        => []
-    }
-
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
-  def delete_snapshot(_options = {})
-    with_provider_object do |snapshot|
-      if snapshot
-        snapshot.delete
-      else
-        _log.warn "snapshot=[#{name}] already deleted"
-      end
-    end
+  def raw_delete_snapshot
+    with_provider_object(&:delete)
   rescue => e
     _log.error "volume=[#{name}], error: #{e}"
     raise MiqException::MiqVolumeSnapshotDeleteError, e.to_s, e.backtrace

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot_spec.rb
@@ -1,6 +1,7 @@
 require_relative "../../aws_helper"
 
 describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot do
+  before { NotificationType.seed }
   let(:amazon) { FactoryGirl.create(:ems_amazon_with_authentication) }
   let(:ems) { FactoryGirl.create(:ems_amazon_ebs, :parent_ems_id => amazon.id) }
   let(:cloud_volume_snapshot) { FactoryGirl.create(:cloud_volume_snapshot_amazon, :ext_management_system => ems, :ems_ref => "snapshot_1") }


### PR DESCRIPTION
Add raw_delete_snapshot function. This function is now called from snapshot_delete, which was moved to core model together with snapshot_delete_queue.

This PR is replacement for: https://github.com/ManageIQ/manageiq-providers-amazon/pull/260

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1449243

Depends on: https://github.com/ManageIQ/manageiq/pull/15624
