### PR TITLE
Overriding queue name to generate an array of queue names

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -73,13 +73,10 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   supports :regions
   supports :discovery
 
-  # overriding queue_name so PerEmsWorkerMixin picks up *all* of the
-  # Amazon-manager types from here.
-  # This way, the refresher for Amazon's CloudManager will refresh *all*
-  # of the Amazon inventory across all managers.
-  def queue_name
-    ["ems_#{id}"] + child_managers.collect { |manager| "ems_#{manager.id}" }
-  end
+
+  # def queue_name
+  #   ["ems_#{id}"] + child_managers.collect { |manager| "ems_#{manager.id}" }
+  # end
 
   def ensure_managers
     build_network_manager unless network_manager

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -73,11 +73,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   supports :regions
   supports :discovery
 
-
-  # def queue_name
-  #   ["ems_#{id}"] + child_managers.collect { |manager| "ems_#{manager.id}" }
-  # end
-
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name = "#{name} Network Manager"

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -73,6 +73,14 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   supports :regions
   supports :discovery
 
+  # overriding queue_name so PerEmsWorkerMixin picks up *all* of the
+  # Amazon-manager types from here.
+  # This way, the refresher for Amazon's CloudManager will refresh *all*
+  # of the Amazon inventory across all managers.
+  def queue_name
+    ["ems_#{id}"] + child_managers.collect { |manager| "ems_#{manager.id}" }
+  end
+
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name = "#{name} Network Manager"

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
@@ -1,3 +1,16 @@
 class ManageIQ::Providers::Amazon::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
   require_nested :Runner
+
+  # overriding queue_name_for_ems so PerEmsWorkerMixin picks up *all* of the
+  # Amazon-manager types from here.
+  # This way, the refresher for Amazon's CloudManager will refresh *all*
+  # of the Amazon inventory across all managers.
+  def self.queue_name_for_ems(ems)
+    return ems unless ems.kind_of?(ExtManagementSystem)
+    ["ems_#{ems.id}"] + ems.child_managers.collect { |manager| "ems_#{manager.id}" }
+  end
+
+  # MiQ complains if this isn't defined
+  def queue_name_for_ems(ems)
+  end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
@@ -6,8 +6,11 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshWorker < ManageIQ::Provi
   # This way, the refresher for Amazon's CloudManager will refresh *all*
   # of the Amazon inventory across all managers.
   def self.queue_name_for_ems(ems)
-    return ems unless ems.kind_of?(ExtManagementSystem)
-    ["ems_#{ems.id}"] + ems.child_managers.collect { |manager| "ems_#{manager.id}" }
+    if ems.kind_of?(ExtManagementSystem)
+      ["ems_#{ems.id}"] + ems.child_managers.collect { |manager| "ems_#{manager.id}" }
+    else
+      super
+    end
   end
 
   # MiQ complains if this isn't defined


### PR DESCRIPTION
this allows us to create an array of child managers for our queue.