### PR TITLE
Support custom instance_types

### DIFF
--- a/app/models/manageiq/providers/amazon/instance_types.rb
+++ b/app/models/manageiq/providers/amazon/instance_types.rb
@@ -1373,7 +1373,7 @@ module ManageIQ::Providers::Amazon::InstanceTypes
       :cluster_networking      => nil,
       :vpc_only                => false,
     },
-  }
+  }.freeze
 
   # Types that are still advertised, but not recommended for new instances.
   DEPRECATED_TYPES = {
@@ -1832,7 +1832,7 @@ module ManageIQ::Providers::Amazon::InstanceTypes
       :cluster_networking      => true,
       :vpc_only                => false,
     },
-  }
+  }.freeze
 
   # Types that are no longer advertised
   DISCONTINUED_TYPES = {
@@ -1885,13 +1885,19 @@ module ManageIQ::Providers::Amazon::InstanceTypes
       :cluster_networking      => nil,
       :vpc_only                => false,
     },
-  }
+  }.freeze
+
+  def self.instance_types
+    additional = Hash(Settings.ems.ems_amazon.try!(:additional_instance_types)).stringify_keys
+    disabled = Array(Settings.ems.ems_amazon.try!(:disabled_instance_types))
+    AVAILABLE_TYPES.merge(DEPRECATED_TYPES).merge(DISCONTINUED_TYPES).merge(additional).except(*disabled)
+  end
 
   def self.all
-    AVAILABLE_TYPES.values + DEPRECATED_TYPES.values + DISCONTINUED_TYPES.values
+    instance_types.values
   end
 
   def self.names
-    AVAILABLE_TYPES.keys + DEPRECATED_TYPES.keys + DISCONTINUED_TYPES.keys
+    instance_types.keys
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,19 @@
     #   :name: Special Region
     #   :hostname: ec2.spec-region-1.amazonaws.com
     #   :description: Super Special Region
+
+    # add additional instance_types as found in app/models/manageiq/providers/amazon/instance_types.rb
+    :additional_instance_types: {}
+    #  :t9.large:
+    #  :name: t9.large
+    #  :family: General purpose
+    #  :description: T9 Large
+    #  ...
+
+    :disabled_instance_types: []
+    # disable instance_types by their keys found in app/models/manageiq/providers/amazon/instance_types.rb e.g.
+    # - t2.nano
+
 :ems_refresh:
   :ec2:
     :get_private_images: true

--- a/spec/models/manageiq/providers/amazon/instance_types_spec.rb
+++ b/spec/models/manageiq/providers/amazon/instance_types_spec.rb
@@ -1,0 +1,75 @@
+describe ManageIQ::Providers::Amazon::InstanceTypes do
+  context "disable instance_types via Settings" do
+    it "contains t2.nano without it being disabled" do
+      allow(Settings.ems.ems_amazon).to receive(:disabled_instance_types).and_return([])
+      expect(described_class.names).to include("t2.nano")
+    end
+
+    it "does not contain t2.nano that is disabled" do
+      allow(Settings.ems.ems_amazon).to receive(:disabled_instance_types).and_return(['t2.nano'])
+      expect(described_class.names).not_to include('t2.nano')
+    end
+  end
+
+  context "add instance_types via Settings" do
+    let(:additional) do
+      {
+        "makeups.xlarge"  => {
+          :name        => "makeups.xlarge",
+          :family      => "Compute Optimized",
+          :description => "Cluster Compute Quadruple Extra Large",
+          :memory      => 23.gigabytes,
+          :vcpu        => 16,
+        },
+        "makeups.2xlarge" => {
+          :name        => "makeups.2xlarge",
+          :family      => "Compute Optimized",
+          :description => "Cluster Compute Quadruple Extra Large",
+          :memory      => 23.gigabytes,
+          :vcpu        => 32,
+        },
+      }
+    end
+
+    context "with no additional instance_types set" do
+      let(:settings) do
+        {:ems => {:ems_amazon => {:additional_instance_types => nil}}}
+      end
+
+      it "returns standard instance_types" do
+        stub_settings(settings)
+        expect(described_class.names).not_to include("makeups.xlarge", "makeups.2xlarge")
+      end
+    end
+
+    context "with additional" do
+      let(:settings) do
+        {:ems => {:ems_amazon => {:additional_instance_types => additional}}}
+      end
+
+      it "returns the custom instance_types" do
+        stub_settings(settings)
+        expect(described_class.names).to include("makeups.xlarge", "makeups.2xlarge")
+      end
+    end
+
+    context "with additional instance_types and disabled instance_types" do
+      let(:settings) do
+        {
+          :ems => {
+            :ems_amazon => {
+              :disabled_instance_types   => ["makeups.2xlarge"],
+              :additional_instance_types => additional
+            }
+          }
+        }
+      end
+
+      it "disabled_instance_types overrides additional_instance_types" do
+        stub_settings(settings)
+        expect(described_class.names).to     include("makeups.xlarge")
+        expect(described_class.names).not_to include("makeups.2xlarge")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow user to add instance_types that MIQ doesn't include. These are types that added by AWS after MIQ's code freeze for release.