### PR TITLE
Turn on graph refresh with targeted refresh as default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,14 +49,14 @@
         :values:
           - machine
     :ignore_terminated_instances: true
-    :inventory_object_refresh: false
-    :allow_targeted_refresh: false
+    :inventory_object_refresh: true
+    :allow_targeted_refresh: true
   :ec2_network:
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true
   :s3:
     :inventory_object_refresh: true
   :ec2_ebs_storage:
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true
 :http_proxy:
   :ec2:
     :host:


### PR DESCRIPTION
Turn on graph refresh with targeted refresh as default

Partially implements:
https://bugzilla.redhat.com/show_bug.cgi?id=1395356


----
related PRs for actually making targeted refresh work from automate event handlers

https://github.com/ManageIQ/manageiq-content/pull/178
https://github.com/ManageIQ/manageiq-content/pull/179
https://github.com/ManageIQ/manageiq-automation_engine/pull/67