### PR TITLE
Do not downcase the amazon IAM username

### DIFF
--- a/app/models/authenticator/amazon.rb
+++ b/app/models/authenticator/amazon.rb
@@ -141,5 +141,9 @@ module Authenticator
         :log_formatter     => Aws::Log::Formatter.new(Aws::Log::Formatter.default.pattern.chomp)
       )
     end
+
+    def normalize_username(username)
+      username
+    end
   end
 end

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -1,8 +1,8 @@
 require 'aws-sdk'
 
 describe Authenticator::Amazon do
-  AWS_ROOT_USER_KEY = 'aws_root_key'
-  AWS_IAM_USER_KEY = 'aws_iam_key'
+  AWS_ROOT_USER_KEY = 'aws_root_key'.freeze
+  AWS_IAM_USER_KEY = 'AWS_IAM_KEY'.freeze
 
   subject { Authenticator::Amazon.new(config) }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1489596

### Summary:

Fix authentication **mode:** _amazon_

### Description:

This PR address a regression that was introduce by PR [15796](https://github.com/ManageIQ/manageiq/pull/15716) which
caused a regression in authentication preventing logins when the authentication
mode is configured for "Amazon"

### Notes to QE on how to test this fix:

1. Configure an appliance for authentication mode of "Amazon"
2. Configure an valid group on the appliance for a valid Amazon user.
2. Attempt to login with valid user credentials from the Amazon account.
