### PR TITLE
Add YAML support for Amazon OrchestrationTemplate

### DIFF
--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :orchestration_template_amazon,
+          :parent => :orchestration_template,
+          :class  => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate" do
+    sequence(:content) { |n| "{\"AWSTemplateFormatVersion\" : \"version(#{seq_padded_for_sorting(n)})\"}" }
+  end
+
+  factory :orchestration_template_amazon_with_stacks, :parent => :orchestration_template_amazon do
+    stacks { [FactoryGirl.create(:orchestration_stack)] }
+  end
+
+  factory :orchestration_template_amazon_in_json, :parent => :orchestration_template_amazon do
+    content File.read(ManageIQ::Providers::Amazon::Engine.root.join(*%w(spec fixtures orchestration_templates cfn_parameters.json)))
+  end
+
+  factory :orchestration_template_amazon_in_yaml, :parent => :orchestration_template_amazon do
+    content File.read(ManageIQ::Providers::Amazon::Engine.root.join(*%w(spec fixtures orchestration_templates cfn_parameters.yaml)))
+  end
+end

--- a/spec/fixtures/orchestration_templates/cfn_parameters.json
+++ b/spec/fixtures/orchestration_templates/cfn_parameters.json
@@ -1,0 +1,96 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Incomplete sample template for testing parsing of various parameters",
+
+  "Parameters" : {
+
+    "KeyName" : {
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instances",
+      "Type" : "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
+    },
+
+    "WebServerInstanceType" : {
+      "Description" : "WebServer Server EC2 instance type",
+      "Type" : "String",
+      "Default" : "m1.small",
+      "AllowedValues" : [ "t2.small", "t2.medium", "m1.small" ]
+,
+      "ConstraintDescription" : "must be a valid EC2 instance type."
+    },
+
+    "SecondaryIPAddressCount" : {
+      "Type" : "Number",
+      "Default" : "1",
+      "MinValue" : "1",
+      "MaxValue" : "5",
+      "Description" : "Number of secondary IP addresses to assign to the network interface (1-5)",
+      "ConstraintDescription": "must be a number from 1 to 5."
+    },
+
+    "MasterUserPassword": {
+      "Description": "The password associated with the aster user account for the redshift cluster that is being created. ",
+      "Type": "String",
+      "NoEcho": "true",
+      "MinLength": "1",
+      "MaxLength": "41",
+      "AllowedPattern" : "[a-zA-Z0-9]*",
+      "ConstraintDescription" : "must contain only alphanumeric characters."
+    },
+
+    "Subnets" : {
+      "Type" : "List<AWS::EC2::Subnet::Id>",
+      "Description" : "The list of SubnetIds in your Virtual Private Cloud (VPC)",
+      "ConstraintDescription" : "must be a list of an existing subnets in the selected Virtual Private Cloud."
+    },
+
+    "AZs" : {
+      "Type" : "List<String>",
+      "Description" : "The list of AvailabilityZones for your Virtual Private Cloud (VPC)",
+      "ConstraintDescription" : "must be a list if valid EC2 availability zones for the selected Virtual Private Cloud"
+    }
+  },
+
+  "Resources" : {
+    "MyEC2Instance" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId" : "ami-2f726546"
+      }
+    },
+
+    "InstanceSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable SSH access via port 22",
+        "SecurityGroupIngress" : [ {
+          "IpProtocol" : "tcp",
+          "FromPort" : "22",
+          "ToPort" : "22",
+          "CidrIp" : { "Ref" : "SSHLocation"}
+        } ]
+      }
+    },
+
+    "WebServerScaleUpPolicy" : {
+      "Type" : "AWS::AutoScaling::ScalingPolicy",
+      "Properties" : {
+        "AdjustmentType" : "ChangeInCapacity",
+        "AutoScalingGroupName" : { "Ref" : "WebServerGroup" },
+        "Cooldown" : "60",
+        "ScalingAdjustment" : "1"
+      }
+    },
+
+    "WebServerScaleDownPolicy" : {
+      "Type" : "AWS::AutoScaling::ScalingPolicy",
+      "Properties" : {
+        "AdjustmentType" : "ChangeInCapacity",
+        "AutoScalingGroupName" : { "Ref" : "WebServerGroup" },
+        "Cooldown" : "60",
+        "ScalingAdjustment" : "-1"
+      }
+    }
+  }
+}

--- a/spec/fixtures/orchestration_templates/cfn_parameters.yaml
+++ b/spec/fixtures/orchestration_templates/cfn_parameters.yaml
@@ -1,0 +1,75 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Incomplete sample template for testing parsing of various parameters
+Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
+    Type: AWS::EC2::KeyPair::KeyName
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+  WebServerInstanceType:
+    Description: WebServer Server EC2 instance type
+    Type: String
+    Default: m1.small
+    AllowedValues:
+    - t2.small
+    - t2.medium
+    - m1.small
+    ConstraintDescription: must be a valid EC2 instance type.
+  SecondaryIPAddressCount:
+    Type: Number
+    Default: '1'
+    MinValue: '1'
+    MaxValue: '5'
+    Description: Number of secondary IP addresses to assign to the network interface
+      (1-5)
+    ConstraintDescription: must be a number from 1 to 5.
+  MasterUserPassword:
+    Description: 'The password associated with the aster user account for the redshift
+      cluster that is being created. '
+    Type: String
+    NoEcho: 'true'
+    MinLength: '1'
+    MaxLength: '41'
+    AllowedPattern: "[a-zA-Z0-9]*"
+    ConstraintDescription: must contain only alphanumeric characters.
+  Subnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
+    ConstraintDescription: must be a list of an existing subnets in the selected Virtual
+      Private Cloud.
+  AZs:
+    Type: List<String>
+    Description: The list of AvailabilityZones for your Virtual Private Cloud (VPC)
+    ConstraintDescription: must be a list if valid EC2 availability zones for the
+      selected Virtual Private Cloud
+Resources:
+  MyEC2Instance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: ami-2f726546
+  InstanceSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+        CidrIp:
+          Ref: SSHLocation
+  WebServerScaleUpPolicy:
+    Type: "AWS::AutoScaling::ScalingPolicy"
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName:
+        Ref: WebServerGroup
+      Cooldown: '60'
+      ScalingAdjustment: '1'
+  WebServerScaleDownPolicy:
+    Type: "AWS::AutoScaling::ScalingPolicy"
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName:
+        Ref: WebServerGroup
+      Cooldown: '60'
+      ScalingAdjustment: "-1"


### PR DESCRIPTION
The primary purpose of this work is to accept YAML format content as an OrchestrationTemplate. It also refactors the spec tests to move sample templates from manageiq repo to amazon repo.

https://bugzilla.redhat.com/show_bug.cgi?id=1417021