### PR TITLE
Add OrchestrationParameterMultiline constraints to options that require a text area

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
@@ -119,8 +119,9 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
     OrchestrationTemplate::OrchestrationParameter.new(
       :name        => "stack_notifications",
       :label       => "Notification ARNs",
-      :data_type   => "text",
-      :description => "Notification SNS topic ARNs, one ARN per line"
+      :data_type   => "string",
+      :description => "Notification SNS topic ARNs, one ARN per line",
+      :constraints => [OrchestrationTemplate::OrchestrationParameterMultiline.new]
     )
   end
 
@@ -139,8 +140,9 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
     OrchestrationTemplate::OrchestrationParameter.new(
       :name        => "stack_resource_types",
       :label       => "Permitted resource types",
-      :data_type   => "text",
-      :description => "Grand permissions to selected types, one type per line"
+      :data_type   => "string",
+      :description => "Grand permissions to selected types, one type per line",
+      :constraints => [OrchestrationTemplate::OrchestrationParameterMultiline.new]
     )
   end
 
@@ -157,8 +159,9 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
     OrchestrationTemplate::OrchestrationParameter.new(
       :name        => "stack_tags",
       :label       => "AWS Tags",
-      :data_type   => "text",
-      :description => "Key-value pairs with format key1=>val1, one pair per line"
+      :data_type   => "string",
+      :description => "Key-value pairs with format key1=>val1, one pair per line",
+      :constraints => [OrchestrationTemplate::OrchestrationParameterMultiline.new]
     )
   end
 
@@ -166,8 +169,9 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
     OrchestrationTemplate::OrchestrationParameter.new(
       :name        => "stack_policy",
       :label       => "Policy",
-      :data_type   => "text",
-      :description => "URL of an policy file or the actual content of the policy"
+      :data_type   => "string",
+      :description => "URL of an policy file or the actual content of the policy",
+      :constraints => [OrchestrationTemplate::OrchestrationParameterMultiline.new]
     )
   end
 

--- a/spec/models/dialog/orchestration_template_amazon_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_amazon_service_dialog_spec.rb
@@ -1,0 +1,40 @@
+describe "OrchestrationTemplateServiceDialog for Amazon" do
+  let(:dialog_service)  { Dialog::OrchestrationTemplateServiceDialog.new }
+  let(:template_amazon) { FactoryGirl.create(:orchestration_template_amazon_in_json) }
+
+  describe "#create_dialog" do
+    it "creates a dialog from CloudFormation template with stack basic info and parameters" do
+      dialog = dialog_service.create_dialog("test", template_amazon)
+
+      tabs = dialog.dialog_tabs
+      assert_stack_group(tabs[0].dialog_groups[0])
+    end
+  end
+
+  def assert_stack_group(group)
+    expect(group).to have_attributes(
+      :label   => "Options",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(10)
+
+    expect(fields[0].resource_action.fqname).to eq('/Cloud/Orchestration/Operations/Methods/Available_Tenants')
+    assert_field(fields[0], DialogFieldDropDownList, :name => 'tenant_name',          :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => 'stack_name',           :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    assert_field(fields[2], DialogFieldDropDownList, :name => 'stack_onfailure',      :values => [%w(DELETE Delete\ stack), %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+    assert_field(fields[3], DialogFieldTextBox,      :name => 'stack_timeout',        :data_type => 'integer')
+    assert_field(fields[4], DialogFieldTextAreaBox,  :name => 'stack_notifications',  :data_type => 'string')
+    assert_field(fields[5], DialogFieldDropDownList, :name => 'stack_capabilities',   :values => [[nil, '<None>'], ['CAPABILITY_IAM'] * 2, ['CAPABILITY_NAMED_IAM'] * 2])
+    assert_field(fields[6], DialogFieldTextBox,      :name => 'stack_resource_types', :data_type => 'string')
+    assert_field(fields[7], DialogFieldTextBox,      :name => 'stack_role',           :data_type => 'string')
+    assert_field(fields[8], DialogFieldTextBox,      :name => 'stack_tags',           :data_type => 'string')
+    assert_field(fields[9], DialogFieldTextBox,      :name => 'stack_policy',         :data_type => 'string')
+  end
+
+  def assert_field(field, clss, attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
+  end
+end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_template_spec.rb
@@ -188,12 +188,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate do
       assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
       assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, true)
       assert_deployment_option(options[3], "stack_timeout", nil, false, 'integer')
-      assert_deployment_option(options[4], "stack_notifications", nil, false, 'text')
+      assert_deployment_option(options[4], "stack_notifications", nil, false)
       assert_deployment_option(options[5], "stack_capabilities", :OrchestrationParameterAllowed, false)
-      assert_deployment_option(options[6], "stack_resource_types", nil, false, 'text')
+      assert_deployment_option(options[6], "stack_resource_types", nil, false)
       assert_deployment_option(options[7], "stack_role", nil, false)
-      assert_deployment_option(options[8], "stack_tags", nil, false, 'text')
-      assert_deployment_option(options[9], "stack_policy", nil, false, 'text')
+      assert_deployment_option(options[8], "stack_tags", nil, false)
+      assert_deployment_option(options[9], "stack_policy", nil, false)
     end
   end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -302,7 +302,7 @@ describe ManageIQ::Providers::Amazon::CloudManager do
 
   context "#orchestration_template_validate" do
     it "validates a correct template" do
-      template = FactoryGirl.create(:orchestration_template_cfn_with_content)
+      template = FactoryGirl.create(:orchestration_template_amazon_in_json)
       stubbed_aws = {:validate_template => {}}
       with_aws_stubbed(:cloudformation => stubbed_aws) do
         ems = FactoryGirl.create(:ems_amazon_with_authentication)
@@ -311,7 +311,7 @@ describe ManageIQ::Providers::Amazon::CloudManager do
     end
 
     it "returns an error string for an incorrect template" do
-      template      = FactoryGirl.create(:orchestration_template_cfn_with_content)
+      template      = FactoryGirl.create(:orchestration_template_amazon_in_json)
       stubbed_aws   = {:validate_template => 'ValidationError'}
       with_aws_stubbed(:cloudformation => stubbed_aws) do
         ems = FactoryGirl.create(:ems_amazon_with_authentication)


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq/pull/16047 the use of TextArea requires the constraint `OrchestrationParameterMultiline`. This work fix the stack options for AWS Cloudformation deployment that require a text area.