### PR TITLE
Compact targeted refresh references

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -9,11 +9,11 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   end
 
   def references(collection)
-    target.manager_refs_by_association.try(:[], collection).try(:[], :ems_ref).try(:to_a) || []
+    target.manager_refs_by_association.try(:[], collection).try(:[], :ems_ref).try(:to_a).try(:compact) || []
   end
 
   def name_references(collection)
-    target.manager_refs_by_association.try(:[], collection).try(:[], :name).try(:to_a) || []
+    target.manager_refs_by_association.try(:[], collection).try(:[], :name).try(:to_a).try(:compact) || []
   end
 
   def instances


### PR DESCRIPTION
Compact targeted refresh references, AWS API will throw en rror
if there is nil among them.