### PR TITLE
Add parameter in setting for SSA support

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,7 +50,7 @@
     # disable instance_types by their keys found in app/models/manageiq/providers/amazon/instance_types.rb e.g.
     # - t2.nano
 
-    :agent_manager:
+    :agent_coordinator:
       :bucket_prefix: miq-ssa
       :request_queue_prefix: ssa_extract_request
       :reply_queue_prefix: ssa_extract_reply
@@ -60,9 +60,9 @@
       :log_level: INFO
       :heartbeat_interval: 120
       :agent_idle_period: 900
-      :userdata_script: tools/amazon_agent_settings/prepare_userdata
+      :userdata_script_file: tools/amazon_agent_settings/prepare_userdata
       :agent_ami: centos-7.2-hvm
-      :ruby_version: 2.3.3
+      :agent_ruby_version: 2.3.3
 :ems_refresh:
   :ec2:
     :get_private_images: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,19 @@
     # disable instance_types by their keys found in app/models/manageiq/providers/amazon/instance_types.rb e.g.
     # - t2.nano
 
+    :agent_manager:
+      :bucket_prefix: miq-ssa
+      :request_queue_prefix: ssa_extract_request
+      :reply_queue_prefix: ssa_extract_reply
+      :reply_prefix: extract/queue-reply/
+      :heartbeat_prefix: extract/heartbeat/
+      :log_prefix: extract/logs/
+      :log_level: INFO
+      :heartbeat_interval: 120
+      :agent_idle_period: 900
+      :userdata_script: tools/amazon_agent_settings/prepare_userdata
+      :agent_ami: centos-7.2-hvm
+      :ruby_version: 2.3.3
 :ems_refresh:
   :ec2:
     :get_private_images: true


### PR DESCRIPTION
Add some parameters in settings. Both AmazonAgentMangerWorker and the agent (EC2 instance deployed in AWS cloud) will use this parameters to share same request/reply SQS queue and S3 bucket.