### PR TITLE
Handle possibility of empty string for Name tag

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -43,9 +43,9 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       uid      = image['image_id']
       location = image['image_location']
       name     = get_from_tags(image, :name)
-      name     ||= image['name']
-      name     ||= $1 if location =~ /^(.+?)(\.(image|img))?\.manifest\.xml$/
-      name     ||= uid
+      name     = image['name'] if name.blank?
+      name     = $1 if name.blank? && location =~ /^(.+?)(\.(image|img))?\.manifest\.xml$/
+      name     = uid if name.blank?
 
       persister_image = persister.miq_templates.find_or_build(uid).assign_attributes(
         :uid_ems            => uid,


### PR DESCRIPTION
Deals with the possibility of an empty string for a `Name` tag, which is defeating our `||=` logic.

I borrowed Adam's solution from https://github.com/ManageIQ/manageiq-providers-amazon/pull/273, just for the inventory side.

https://bugzilla.redhat.com/show_bug.cgi?id=1471297