### PR TITLE
Include ResponseThread in Runner

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner < MiqWorker::Runner
+
+  include ResponseThread
   def do_before_work_loop
     @coordinators = self.class.all_agent_coordinators_in_zone
     start_response_thread

--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner < MiqWorker::Runner
-
   include ResponseThread
   def do_before_work_loop
     @coordinators = self.class.all_agent_coordinators_in_zone


### PR DESCRIPTION
The ResponseThread "include" statement was inadvertantly left out of the Runner
for the AgentCoordinatorWorker when it was ported out of the ManageIQ repo
into the manageiq-provider-amazon repo in https://github.com/ManageIQ/manageiq-providers-amazon/pull/319.  This PR adds it back in.

@Fryguy you found this issue - this fixes it.  Please review and merge.
@roliveri @hsong-rh @bronaghs fyi - one line fix for an omitted line of code.