### PR TITLE
Various changes for SSA support

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -192,7 +192,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
   end
 
   def docker_auth
-    @ems.authentications.find_by(:type => "Smartstate_Docker")
+    @ems.authentications.find_by(:type => "ssa_docker")
   end
 
   # Get Key Pair for SSH. Create a new one if not exists.

--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -171,10 +171,15 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
     # prepare work directory
     ssh.perform_commands(["sudo mkdir -p #{WORK_DIR}"])
     ssh.perform_commands(["sudo chmod go+w #{WORK_DIR}"])
+
     # scp the default setting yaml file
-    Tempfile.open('config.yml') do |config|
+    config = Tempfile.new('config.yml')
+    begin
       config.write(create_config_yaml)
-      scp_file(ip, agent_ami_login_user, auth_key, config, WORK_DIR)
+      config.close
+      out = scp_file(ip, agent_ami_login_user, auth_key, config.path, "#{WORK_DIR}/config.yml")
+    ensure
+      config.unlink
     end
 
     # docker register

--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -140,7 +140,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
       :max_count            => 1,
       :min_count            => 1,
       :placement            => {:availability_zone => zone_name},
-      :tag_specifications   => [{:resource_type => "instance", :tags => [{:key => "Name", :value => label}]}]
+      :tag_specifications   => [{:resource_type => "instance", :tags => [{:key => "Name", :value => label}]}],
       :network_interfaces   => [{
         :associate_public_ip_address => true,
         :delete_on_termination       => true,
@@ -195,7 +195,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
   end
 
   def docker_auth
-    @ems.authentications.find_by(:type => "ssa_docker")
+    @ems.authentications.find_by(:type => "smartstate_docker")
   end
 
   # Get Key Pair for SSH. Create a new one if not exists.
@@ -339,8 +339,8 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
     pem_file_name
   end
 
-  def create_config_yaml(yml = "config.yml")
-    defaults = agent_coordinator_settings.to_hash.except(:agent_ami_name, :docker_image, :agent_label, :agent_ami_login_user, :docker_login_required?, :response_thread_sleep_seconds)
+  def create_config_yaml
+    defaults = agent_coordinator_settings.to_hash.except(:agent_ami_name, :docker_image, :agent_label, :agent_ami_login_user, :docker_login_required, :response_thread_sleep_seconds)
     defaults[:reply_queue]   = reply_queue
     defaults[:request_queue] = request_queue
     defaults[:ssa_bucket]    = ssa_bucket

--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -69,11 +69,6 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
     _log.error(err.message)
   end
 
-  def ssh_commands(ip, username = "centos", auth_key = '', commands = [])
-    ssh = LinuxAdmin::SSH.new(ip, username, auth_key)
-    ssh.perform_commands(commands)
-  end
-
   def agent_ids
     # reset to empty
     @agent_ids = []

--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -340,7 +340,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
   end
 
   def create_config_yaml(yml = "config.yml")
-    defaults = agent_coordinator_settings.to_hash.except(:agent_ami_name, :agent_docker_name, :agent_label, :agent_ami_login_user, :agent_ami_registration_required, :response_thread_sleep_seconds)
+    defaults = agent_coordinator_settings.to_hash.except(:agent_ami_name, :docker_image, :agent_label, :agent_ami_login_user, :docker_login_required?, :response_thread_sleep_seconds)
     defaults[:reply_queue]   = reply_queue
     defaults[:request_queue] = request_queue
     defaults[:ssa_bucket]    = ssa_bucket

--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
@@ -1,8 +1,15 @@
 class ManageIQ::Providers::Amazon::AgentCoordinatorWorker < MiqWorker
   require_nested :Runner
 
+  include PerEmsWorkerMixin
+
   self.required_roles = ['smartproxy']
 
-  # Don't allow multiple workers to run at once
-  self.include_stopping_workers_on_synchronize = true
+  def self.desired_queue_names
+    return [] if MiqServer.minimal_env? && !self.has_minimal_env_option?
+    cloud_managers = all_valid_ems_in_zone.collect { |e| e.kind_of?(ManageIQ::Providers::Amazon::CloudManager) }
+
+    # All cloud managers will share the same agent coordinator
+    cloud_managers.any? ? ["ems_agent_coordinator"] : []
+  end
 end

--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
@@ -40,11 +40,11 @@ class ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner < MiqWorker::R
   end
 
   def self.all_ems_in_zone
-    ExtManagementSystem.where(:zone_id => MiqServer.my_server.zone.id).to_a
+    MiqServer.my_server.zone.ext_management_systems
   end
 
   def self.all_valid_ems_in_zone
-    all_ems_in_zone.select {|e| e.enabled && e.authentication_status_ok?}
+    all_ems_in_zone.select { |e| e.enabled && e.authentication_status_ok? }
   end
 
   def self.all_amazon_ems_in_zone

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,10 +52,11 @@
     :agent_coordinator:
       :agent_ami_name: CentOS Atomic Host 7 x86_64 HVM EBS 1706_01
       :agent_ami_login_user: centos
-      :agent_ami_registration_required: false
-      :agent_docker_name: manageiq/amazon-smartstate:latest
       :agent_idle_period: 900
       :agent_label: smartstate
+      :docker_image: manageiq/amazon-smartstate:latest
+      :docker_login_required: false
+      :docker_registry_url:
       :log_level: INFO
       :heartbeat_interval: 120
       :response_thread_sleep_seconds: 10

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,11 +52,11 @@
     :agent_coordinator:
       :agent_ami_name: CentOS Atomic Host 7 x86_64 HVM EBS 1706_01
       :agent_ami_login_user: centos
-      # TODO: will replace with official docker image name
-      :agent_docker_name: docker.io/hsong/ssa_support
+      :agent_ami_registration_required: false
+      :agent_docker_name: manageiq/amazon-smartstate:latest
       :agent_idle_period: 900
       :agent_label: smartstate
-      :agent_log_level: INFO
+      :log_level: INFO
       :heartbeat_interval: 120
       :response_thread_sleep_seconds: 10
 


### PR DESCRIPTION
This PR contains the following changes:
1. Start AgentCoordinatorWorker only when role of 'smartproxy' is enabled and Amazon provider exists;
2. Add register flag for both docker register and Redhat downstream register;
3. Change KeyPair name into uniq, so different users from the same AWS account use their own key pair.
4. Other changes based on reviewers' comments.