### PR TITLE
Add smartstate_docker authtype

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -121,6 +121,14 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     Settings.ems.ems_amazon.blacklisted_event_names
   end
 
+  def supported_auth_types
+    %w(default smartstate_docker)
+  end
+
+  def supports_authentication?(authtype)
+    supported_auth_types.include?(authtype.to_s)
+  end
+
   #
   # Operations
   #


### PR DESCRIPTION
Add the additional smartstate_docker authentication type
to be used for Docker Registry login on the remote AWS instance running smart state.

This change goes hand-in-hand with the [UI PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/2525) under separate cover which relies on this to succeed.

@roliveri @hsong-rh @Fryguy @bronaghs please review and merge when ready.