### PR TITLE
Add wait_until_exists on instance_profile creation

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -220,6 +220,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
   def find_or_create_profile(profile_name = label, role_name = label)
     ssa_profile = iam.instance_profile(profile_name)
     ssa_profile = iam.create_instance_profile(:instance_profile_name => profile_name) unless ssa_profile.exists?
+    ssa_profile.wait_until_exists
 
     find_or_create_role(role_name)
     ssa_profile.add_role(:role_name => role_name) if ssa_profile.roles.empty?


### PR DESCRIPTION
Add wait_until to make sure instance_profile is created and ready to be used.