### PR TITLE
Verify Smartstate Credentials Should ALways Return True

### DIFF
--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -32,6 +32,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
   def verify_credentials(auth_type = nil, options = {})
     raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
 
+    return true if auth_type == "smartstate_docker"
     self.class.connection_rescue_block do
       # EC2 does Lazy Connections, so call a cheap function
       with_provider_connection(options.merge(:auth_type => auth_type)) do |ec2|


### PR DESCRIPTION
the verify_credentials method was failing for smartstate_docker credentials
which resulted in the provider being added with valid unchecked credentials
but the first time the scheduled credentials verification ran the provider
became invalid.  Changed to always return true for these credentials
which allows the provider to be valid.

This is related to but not exactly the same as issue https://github.com/ManageIQ/manageiq-providers-amazon/issues/335.

@roliveri @hsong-rh @fryguy please review and merge for today's build.  Thanks.