### PR TITLE
Use Concern for ResponseThread include

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner < MiqWorker::Runner
-  include ResponseThread
+  include_concern 'ResponseThread'
   def do_before_work_loop
     @coordinators = self.class.all_agent_coordinators_in_zone
     start_response_thread

--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner/response_thread.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner/response_thread.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner::ResponseThread
-  require 'xml/xml_utils'
-  require 'scanning_mixin'
+  extend ActiveSupport::Concern
   include ScanningMixin
+  require 'xml/xml_utils'
 
   #
   # This thread startup method is called by the AgentCoordinatorWorker::Runner

--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner/response_thread.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner/response_thread.rb
@@ -1,5 +1,4 @@
 module ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner::ResponseThread
-  extend ActiveSupport::Concern
   include ScanningMixin
   require 'xml/xml_utils'
 


### PR DESCRIPTION
Change the includes/requires for the AgentCoordinatorWorker::Runner::ResponseThread to use include_concern.

This issue was called out by @Fryguy on the initial PR for the ResponseThread for Amazon Smartstate - https://github.com/ManageIQ/manageiq-providers-amazon/pull/319.  Fixing this for the build today.

@Fryguy @roliveri @hsong-rh please review.  Merge when appropriate.