### PR TITLE
[FINE] Add seed method for Amazon cloud manager

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -74,6 +74,13 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   supports :regions
   supports :discovery
 
+  def self.seed
+    all.each do |manager|
+      manager.ensure_managers
+      manager.save!
+    end
+  end
+
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name = "#{name} Network Manager"


### PR DESCRIPTION
Addresses an issue where the EMS association between the cloud manager and storage manager were not established when upgrading from 5.7 to 5.8, resulting in no storage information displayed in the UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1480629

The DB migration was already taken care of by @Fryguy in https://github.com/ManageIQ/manageiq-schema/pull/117