### PR TITLE
exclude on_failure and timeout_in_minutes when update a stack

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ManageIQ::
 
   def raw_update_stack(template, options)
     options = self.class.format_v2_options(options)
-    update_options = {:template_body => template.content}.merge(options.except(:disable_rollback, :timeout))
+    update_options = {:template_body => template.content}.merge(options.except(:on_failure, :timeout_in_minutes))
     ext_management_system.with_provider_connection(:service => :CloudFormation) do |service|
       service.stack(name).update(update_options)
     end

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
@@ -96,22 +96,24 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
     choices = {'ROLLBACK' => 'Rollback', 'DO_NOTHING' => 'Do nothing', 'DELETE' => 'Delete stack'}
 
     OrchestrationTemplate::OrchestrationParameter.new(
-      :name          => "stack_onfailure",
-      :label         => "On Failure",
-      :data_type     => "string",
-      :description   => "Select what to do if stack creation failed",
-      :default_value => 'ROLLBACK',
-      :required      => true,
-      :constraints   => [OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => choices)]
+      :name           => "stack_onfailure",
+      :label          => "On Failure",
+      :data_type      => "string",
+      :description    => "Select what to do if stack creation failed",
+      :default_value  => 'ROLLBACK',
+      :required       => true,
+      :reconfigurable => false,
+      :constraints    => [OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => choices)]
     )
   end
 
   def timeout_opt
     OrchestrationTemplate::OrchestrationParameter.new(
-      :name        => "stack_timeout",
-      :label       => "Timeout(minutes, optional)",
-      :data_type   => "integer",
-      :description => "Abort the creation if it does not complete in a proper time window"
+      :name           => "stack_timeout",
+      :label          => "Timeout(minutes, optional)",
+      :data_type      => "integer",
+      :reconfigurable => false,
+      :description    => "Abort the creation if it does not complete in a proper time window"
     )
   end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_template_spec.rb
@@ -186,8 +186,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate do
       options = subject.deployment_options('ManageIQ::Providers::Amazon::CloudManager')
       assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
       assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
-      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, true)
-      assert_deployment_option(options[3], "stack_timeout", nil, false, 'integer')
+      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, true, :reconfigurable => false)
+      assert_deployment_option(options[3], "stack_timeout", nil, false, :reconfigurable => false, :data_type => 'integer')
       assert_deployment_option(options[4], "stack_notifications", nil, false)
       assert_deployment_option(options[5], "stack_capabilities", :OrchestrationParameterAllowed, false)
       assert_deployment_option(options[6], "stack_resource_types", nil, false)
@@ -197,9 +197,8 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate do
     end
   end
 
-  def assert_deployment_option(option, name, constraint_type, required, data_type = 'string')
-    expect(option.name).to eq(name)
-    expect(option.data_type).to eq(data_type)
+  def assert_deployment_option(option, name, constraint_type, required, attrs = {})
+    expect(option).to have_attributes(attrs.merge(:name => name))
     expect(option.required?).to eq(required)
     expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize) if constraint_type
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1503781

According to AWS SDK document `on_failure` and `timeout_in_minutes` are not in the list of arguments the `stack#update` method would expect.

Also modify the deployment options in the service dialog so that `stack_onfailure` and `stack_timeout` are disabled when a user reconfigures a stack.