### PR TITLE
Always sort ems queue names before hitting miq_queue

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
@@ -5,11 +5,16 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshWorker < ManageIQ::Provi
   # Amazon-manager types from here.
   # This way, the refresher for Amazon's CloudManager will refresh *all*
   # of the Amazon inventory across all managers.
-  def self.queue_name_for_ems(ems)
-    if ems.kind_of?(ExtManagementSystem)
-      ["ems_#{ems.id}"] + ems.child_managers.collect { |manager| "ems_#{manager.id}" }
-    else
-      super
+  class << self
+    def queue_name_for_ems(ems)
+      return ems unless ems.kind_of?(ExtManagementSystem)
+      combined_managers(ems).collect(&:queue_name).sort
+    end
+
+    private
+
+    def combined_managers(ems)
+      [ems].concat(ems.child_managers)
     end
   end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresh_worker_spec.rb
@@ -1,0 +1,28 @@
+describe ManageIQ::Providers::Amazon::CloudManager::RefreshWorker do
+  context "EMS with children" do
+    let!(:network_manager) { FactoryGirl.create(:ems_network) }
+    let!(:storage_manager) { FactoryGirl.create(:ems_storage) }
+    let(:ems) do
+      FactoryGirl.create(:ems_cloud).tap do |ems|
+        network_manager.update_attributes(:parent_ems_id => ems.id)
+        storage_manager.update_attributes(:parent_ems_id => ems.id)
+      end
+    end
+
+    it ".queue_name_for_ems" do
+      queue_name = described_class.queue_name_for_ems(ems)
+      expect(queue_name.count).to eq(3)
+      expect(queue_name.sort).to  eq(queue_name)
+    end
+  end
+
+  context "EMS with no children" do
+    let(:ems) { FactoryGirl.create(:ems_cloud) }
+
+    it ".queue_name_for_ems" do
+      queue_name = described_class.queue_name_for_ems(ems)
+      expect(queue_name.count).to eq(1)
+      expect(queue_name.first).to eq(ems.queue_name)
+    end
+  end
+end


### PR DESCRIPTION
Queue name order is important to allow arrays of queue_names to work
like a single string queue_name.

This PR is related to https://github.com/ManageIQ/manageiq/commit/db6a096ebd97d09ab0a58d41c5518e3f69a46d58

Fixes BZ # https://bugzilla.redhat.com/show_bug.cgi?id=1500429

cc @juliancheal 