### PR TITLE
Sort Queue_name_for_ems order

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
@@ -7,7 +7,8 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshWorker < ManageIQ::Provi
   # of the Amazon inventory across all managers.
   def self.queue_name_for_ems(ems)
     if ems.kind_of?(ExtManagementSystem)
-      ["ems_#{ems.id}"] + ems.child_managers.collect { |manager| "ems_#{manager.id}" }
+      queue = ["ems_#{ems.id}"] + ems.child_managers.collect { |manager| "ems_#{manager.id}" }
+      queue.sort
     else
       super
     end


### PR DESCRIPTION
Queue name order is important to allow arrays of queue_names to work
like a single string queue_name.

This PR is related to https://github.com/ManageIQ/manageiq/commit/db6a096ebd97d09ab0a58d41c5518e3f69a46d58

Fixes BZ # https://bugzilla.redhat.com/show_bug.cgi?id=1500429