### PR TITLE
Use name to create key pair

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -254,7 +254,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
       _log.info("KeyPair #{keypair_name} will be created!")
       # Delete from Aws if existing
       ec2.key_pair(keypair_name).try(:delete)
-      ManageIQ::Providers::CloudManager::AuthKeyPair.create_key_pair(@ems.id, :key_name => keypair_name)
+      ManageIQ::Providers::CloudManager::AuthKeyPair.create_key_pair(@ems.id, :name => keypair_name)
     end
   end
 


### PR DESCRIPTION
The fix in https://github.com/ManageIQ/manageiq-providers-amazon/issues/365 adds a new check.  When generating Amazon key pair, the hash parameter create_options has to have :name set, rather than key_name before.  This causes Amazon SSA support failed to create key pair.

https://bugzilla.redhat.com/show_bug.cgi?id=1514192