### PR TITLE
Use proper nested references in parser

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -83,7 +83,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def image_operating_system(persister_image, image)
     persister.operating_systems.find_or_build(persister_image).assign_attributes(
       # FIXME: duplicated information used by some default reports
-      :product_name => persister.hardwares.lazy_find(image['image_id'], :key => :guest_os)
+      :product_name => persister.hardwares.lazy_find(persister.miq_templates.lazy_find(image['image_id']), :key => :guest_os)
     )
   end
 
@@ -251,7 +251,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
   def instance_operating_system(persister_instance, instance)
     persister.operating_systems.find_or_build(persister_instance).assign_attributes(
       # FIXME: duplicated information used by some default reports
-      :product_name => persister.hardwares.lazy_find(instance['image_id'], :key => :guest_os)
+      :product_name => persister.hardwares.lazy_find(persister.miq_templates.lazy_find(instance['image_id']), :key => :guest_os)
     )
   end
 

--- a/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/storage_manager/ebs.rb
@@ -54,7 +54,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::StorageManager::Ebs < Mana
       dev = File.basename(a['device'])
 
       persister.disks.find_or_build_by(
-        :hardware    => persister.hardwares.lazy_find(a["instance_id"]),
+        :hardware    => persister.hardwares.lazy_find(persister.vms.lazy_find(a["instance_id"])),
         :device_name => dev
       ).assign_attributes(
         :location => dev,

--- a/app/models/manageiq/providers/amazon/inventory/persister/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/storage_manager/ebs.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Amazon::Inventory::Persister::StorageManager::Ebs < M
   def initialize_inventory_collections
     add_inventory_collections(storage, %i(cloud_volumes cloud_volume_snapshots))
 
-    add_inventory_collections(cloud, %i(availability_zones hardwares),
+    add_inventory_collections(cloud, %i(availability_zones hardwares vms),
                               :parent   => manager.parent_manager,
                               :strategy => :local_db_cache_all)
 


### PR DESCRIPTION
Depends on:

- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/375
- [x] https://github.com/ManageIQ/manageiq/pull/16659

Use proper nested references in parser. Adding nested
lazy_finds to correctly model a complex link.