### PR TITLE
Changes allowed cloud network to be updated by zone

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -200,6 +200,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
       @az3 = FactoryGirl.create(:availability_zone_amazon, :ext_management_system => ems)
 
       @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager)
+      @cn2 = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager)
 
       @cs1 = FactoryGirl.create(:cloud_subnet, :cloud_network         => @cn1,
                                                :availability_zone     => @az1,
@@ -216,11 +217,23 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
       @sg1 = FactoryGirl.create(:security_group_amazon, :name                  => "sgn_1",
                                                         :ext_management_system => ems.network_manager,
                                                         :cloud_network         => @cn1)
+      @cs3 = FactoryGirl.create(:cloud_subnet, :cloud_network         => @cn2,
+                                               :availability_zone     => @az2,
+                                               :ext_management_system => ems.network_manager)
+
       @sg2 = FactoryGirl.create(:security_group_amazon, :name => "sgn_2", :ext_management_system => ems.network_manager)
     end
 
-    it "#allowed_cloud_networks" do
-      expect(workflow.allowed_cloud_networks.length).to eq(1)
+    context "#allowed_cloud_networks" do
+      it "without a zone" do
+        expect(workflow.allowed_cloud_networks.length).to eq(2)
+      end
+
+      it "with a zone" do
+        workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
+        expect(workflow.allowed_cloud_networks.length).to eq(1)
+        expect(workflow.allowed_cloud_networks).to eq(@cn1.id => @cn1.name)
+      end
     end
 
     context "#allowed_availability_zones" do


### PR DESCRIPTION
Per discussion of #16804, I think this should be reverted to the way it was before 16688 broke the provider subclass code

Previously, cloud network list was only updated after selection of security group, or change of tab, or a select set of other actions that completely voided the list of parameters passed to the filtering method. This adds a change so that availability zone updates the selection of cloud network, preventing incorrect cloud networks from showing up in the after the zone dropdown changes. This code should live in the specific provider that needs it though and that seems to only be Amazon afaik.

Should fix broken test in main and [UI issue that Roman brought up](https://github.com/ManageIQ/manageiq/pull/16804) (that 16804 also fixes but probably not correctly)

## related to:
https://github.com/ManageIQ/manageiq/pull/16806