### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -174,4 +174,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     _log.error "template=[#{template.name}], error: #{err}"
     raise MiqException::MiqOrchestrationValidationError, err.to_s, err.backtrace
   end
+
+  def self.display_name(number = 1)
+    n_('Cloud Provider (Amazon)', 'Cloud Providers (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -53,4 +53,8 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ManageIQ::
     _log.error "stack=[#{name}], error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
+
+  def self.display_name(number = 1)
+    n_('Orchestration Stack (Amazon)', 'Orchestration Stacks (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
@@ -62,6 +62,10 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
     content.strip.start_with?('{') ? :json : :yaml
   end
 
+  def self.display_name(number = 1)
+    n_('CloudFormation Template', 'CloudFormation Templates', number)
+  end
+
   private
 
   def parse

--- a/app/models/manageiq/providers/amazon/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/template.rb
@@ -20,4 +20,8 @@ class ManageIQ::Providers::Amazon::CloudManager::Template < ManageIQ::Providers:
       :message => 'Perform SmartState Analysis on this Image'
     }
   end
+
+  def self.display_name(number = 1)
+    n_('Image (Amazon)', 'Images (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -63,4 +63,8 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
     # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceState.html
     POWER_STATES[raw_power_state.to_s] || "terminated"
   end
+
+  def self.display_name(number = 1)
+    n_('Instance (Amazon)', 'Instances (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -53,4 +53,8 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
       ConfigurationSnapshotDeliveryFailed
     )
   end
+
+  def self.display_name(number = 1)
+    n_('Network Provider (Amazon)', 'Network Providers (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/cloud_network.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork < ::CloudNetwork
+  def self.display_name(number = 1)
+    n_('Cloud Network (Amazon)', 'Cloud Networks (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/cloud_subnet.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet < ::CloudSubnet
+  def self.display_name(number = 1)
+    n_('Cloud Subnet (Amazon)', 'Cloud Subnets (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager/floating_ip.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/floating_ip.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::FloatingIp < ::FloatingIp
+  def self.display_name(number = 1)
+    n_('Floating IP (Amazon)', 'Floating IPs (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager/load_balancer.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/load_balancer.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::LoadBalancer < ::LoadBalancer
+  def self.display_name(number = 1)
+    n_('Load Balancer (Amazon)', 'Load Balancers (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/network_port.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::NetworkPort < ::NetworkPort
+  def self.display_name(number = 1)
+    n_('Network Port (Amazon)', 'Network Ports (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/amazon/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/security_group.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup < ::SecurityGroup
+  def self.display_name(number = 1)
+    n_('Security Group (Amazon)', 'Security Groups (Amazon)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836