### PR TITLE
Don't dependent => destroy child_managers

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -24,14 +24,12 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::Amazon::NetworkManager",
-          :autosave    => true,
-          :dependent   => :destroy
+          :autosave    => true
 
   has_many :storage_managers,
            :foreign_key => :parent_ems_id,
            :class_name  => "ManageIQ::Providers::StorageManager",
-           :autosave    => true,
-           :dependent   => :destroy
+           :autosave    => true
 
   delegate :floating_ips,
            :security_groups,


### PR DESCRIPTION
Destroying child_managers is orchestrated by the parent and destroying
them prematurely leads to issues when the endpoints are shared between
the two managers.

Example failure: https://travis-ci.org/ManageIQ/manageiq-providers-openstack/jobs/332446792#L2079-L2091

Depends: https://github.com/ManageIQ/manageiq/pull/16871