### PR TITLE
Add display_name() for Network Router model

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/network_router.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::Amazon::NetworkManager::NetworkRouter < ::NetworkRouter
+  def self.display_name(number = 1)
+    n_('Network Router (Amazon)', 'Network Routers (Amazon)', number)
+  end
 end


### PR DESCRIPTION
This PR is to bring the changes from https://github.com/ManageIQ/manageiq/pull/16912 into the provider plugin (for consistency).