### PR TITLE
Return created topic

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream.rb
@@ -124,8 +124,9 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream
   end
 
   def create_topic(sns)
-    sns.create_topic(:name => @topic_name)
+    topic = sns.create_topic(:name => @topic_name)
     $aws_log.info("Created SNS topic #{@topic_name}")
+    topic
   rescue Aws::SNS::Errors::ServiceError => err
     raise ProviderUnreachable, "Cannot create SNS topic #{@topic_name}, #{err.class.name}, Message=#{err.message}"
   end


### PR DESCRIPTION
Return created topic instead of log.info, which always returns true.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1545147