### PR TITLE
Raise Exception if AMI not visible

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -428,6 +428,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
         :values => [image_name]
       }]
     ).images.first
+    raise("Unable to find AMI Image #{image_name} to launch Smartstate agent") if image.nil?
 
     _log.info("AMI Image: #{image_name} [#{image.image_id}] is used to launch smartstate agent.")
 


### PR DESCRIPTION
In the case that the AMI in AWS that is to be used for Smartstate is not visible
to the user, raise a meaningful error which will be visible in the log.

Previously this resulted in a nil object and a stack trace which was confusing in the least.

In a separate PR we will look at marking any jobs waiting for the agent to be deployed
as failed when this happens but this current PR should be merged first.

@roliveri @hsong-rh please review.  Thanks.