### PR TITLE
Fix deprecated use of `have_attributes`

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
@@ -116,7 +116,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
       context 'options are for sdk v1' do
         it 'converts options to sdk v2 format' do
           v1_options = {:stack_name => 'mystack', :parameters => {'user' => 'smith'}}
-          expect(described_class.format_v2_options(v1_options)).to have_attributes(
+          expect(described_class.format_v2_options(v1_options)).to include(
             :stack_name => expected_options[:stack_name],
             :parameters => expected_options[:parameters]
           )


### PR DESCRIPTION
ManageIQ has its own `have_attributes` which has diverged from upstream rspec's. It'll go away at some point, for now shows warning (see https://github.com/ManageIQ/manageiq/pull/16188):
```
Randomized with seed 13795
............................................................................
WARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
If you're matching attributes in hashes, use appropriate hash matchers instead (`include`, `eq`).
Called from /home/bpaskinc/miq/quota-scopes/plugins/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb:119:in `block (5 levels) in <top (required)>'
```
Using `include` will work when we drop the custom matcher.