### PR TITLE
Fix default filter for public images

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
   end
 
   def get_public_images
-    filters = @options.public_images_filters
+    filters = @options.to_hash[:public_images_filters]
     get_images(
       @aws_ec2.client.describe_images(:executable_users => [:all],
                                       :filters          => filters)[:images], true)

--- a/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
 
     @public_images_hashes ||= hash_collection.new(
       aws_ec2.client.describe_images(:executable_users => [:all],
-                                     :filters          => options.public_images_filters).images
+                                     :filters          => options.to_hash[:public_images_filters]).images
     ).all
   end
 

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -293,7 +293,7 @@ module AwsRefresherSpecCounts
 
     hash_collection.new(
       aws_ec2.client.describe_images(:executable_users => [:all],
-                                     :filters          => options.public_images_filters).images
+                                     :filters          => options.to_hash[:public_images_filters]).images
     ).all
   end
 


### PR DESCRIPTION
Fix passing of the default filter for the `get_public_images` and `public_images` methods.

The validation in `aws-sdk` prevents passing object of `Config::Options` type and requires `Hash` instead, e.g.:
```ruby
# correct
:filters => [{:name=>"image-type", :values=>["machine"]}]
# wrong
:filters => [#<Config::Options name="image-type", values=["machine"]>]
```

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1554914

Also additional test coverage for the public image filter should follow.

@miq-bot add_label bug, gaprindashvili/yes, inventory