### PR TITLE
Fix firewall rules parse

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -101,7 +101,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
   def firewall_rule(persister_security_group, perm, direction)
     common = {
       :direction             => direction,
-      :host_protocol         => perm['ip_protocol'].to_s.upcase,
+      :host_protocol         => perm['ip_protocol'].to_s == "-1" ? _("All") : perm['ip_protocol'].to_s.upcase,
       :port                  => perm['from_port'],
       :end_port              => perm['to_port'],
       :resource              => persister_security_group,

--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -120,6 +120,12 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
       firewall_rule[:source_ip_range] = r['cidr_ip']
       persister.firewall_rules.build(firewall_rule)
     end
+
+    (perm['ipv_6_ranges'] || []).each do |r|
+      firewall_rule                   = common.dup
+      firewall_rule[:source_ip_range] = r['cidr_ipv_6']
+      persister.firewall_rules.build(firewall_rule)
+    end
   end
 
   def load_balancers

--- a/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
@@ -282,6 +282,11 @@ class ManageIQ::Providers::Amazon::NetworkManager::RefreshParser
       new_result[:source_ip_range] = r.cidr_ip
       ret << new_result
     end
+    perm.ipv_6_ranges.each do |r|
+      new_result = common.dup
+      new_result[:source_ip_range] = r.cidr_ipv_6
+      ret << new_result
+    end
 
     ret
   end

--- a/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_parser.rb
@@ -267,7 +267,7 @@ class ManageIQ::Providers::Amazon::NetworkManager::RefreshParser
 
     common = {
       :direction     => direction,
-      :host_protocol => perm.ip_protocol.to_s.upcase,
+      :host_protocol => perm.ip_protocol.to_s == "-1" ? _("All") : perm.ip_protocol.to_s.upcase,
       :port          => perm.from_port,
       :end_port      => perm.to_port,
     }

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -91,10 +91,12 @@ module AwsRefresherSpecCounts
     # Total number of firewall rules is inferred from security groups
     firewall_rules_count  = security_group_hashes.map do |rule|
       (
-      rule["ip_permissions"].map { |perm| perm["user_id_group_pairs"] } +
+        rule["ip_permissions"].map { |perm| perm["user_id_group_pairs"] } +
         rule["ip_permissions"].map { |perm| perm["ip_ranges"] } +
+        rule["ip_permissions"].map { |perm| perm["ipv_6_ranges"] } +
         rule["ip_permissions_egress"].map { |perm| perm["user_id_group_pairs"] } +
-        rule["ip_permissions_egress"].map { |perm| perm["ip_ranges"] }
+        rule["ip_permissions_egress"].map { |perm| perm["ip_ranges"] } +
+        rule["ip_permissions_egress"].map { |perm| perm["ipv_6_ranges"] }
       )
     end.flatten.size
 

--- a/spec/models/manageiq/providers/amazon/network_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/network_manager/refresh_parser_spec.rb
@@ -1,0 +1,42 @@
+describe ManageIQ::Providers::Amazon::NetworkManager::RefreshParser do
+  require 'aws-sdk'
+  let(:ems) { FactoryGirl.create(:ems_amazon_with_authentication) }
+  let(:parser) { described_class.new(ems.network_manager, Settings.ems_refresh.ec2_network) }
+
+  describe "#parse_firewall_rule" do
+    let(:perm)         { Aws::EC2::Types::IpPermission.new(rule_options) }
+    let(:ip_protocol)  { "icmp" }
+    let(:ip_ranges)    { [] }
+    let(:ipv_6_ranges) { [] }
+    let(:rule_options) do
+      {
+        :ip_protocol         => ip_protocol,
+        :ip_ranges           => ip_ranges.map    { |ip| Aws::EC2::Types::IpRange.new(:cidr_ip => ip) },
+        :ipv_6_ranges        => ipv_6_ranges.map { |ip| Aws::EC2::Types::Ipv6Range.new(:cidr_ipv_6 => ip) },
+        :user_id_group_pairs => []
+      }
+    end
+    subject { parser.send(:parse_firewall_rule, perm, 'inbound') }
+
+    context "all ip_protocols" do
+      let(:ip_protocol) { -1 }
+      let(:ip_ranges) { ["1.1.1.0/24"] }
+
+      it { is_expected.to all(include(:host_protocol => "All")) }
+    end
+
+    context "ipv6 ranges" do
+      let(:ipv_6_ranges) { ["2001:DB8::0/120", "2001:DB8::80/122"] }
+
+      it { expect(subject.length).to eq(2) }
+      it { expect(subject.collect { |i| i[:source_ip_range] }).to eq(ipv_6_ranges) }
+    end
+
+    context "ipv4 ranges" do
+      let(:ip_ranges) { ["10.0.0.0/24", "10.0.1.0/24"] }
+
+      it { expect(subject.length).to eq(2) }
+      it { expect(subject.collect { |i| i[:source_ip_range] }).to eq(ip_ranges) }
+    end
+  end
+end


### PR DESCRIPTION
Update firewall rules parsing with:

- [x] Display :host_protocol correctly when "All" is selected
- [x] Enable IPv6 rules
- [x] Fix port ranges (_Update: fixed in https://github.com/ManageIQ/manageiq-ui-classic/pull/3710_ )
- [x] Update specs

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1540283
AWS Documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/3710

@miq-bot add_label bug, inventory