### PR TITLE
Add patch to aws-sdk-core to fix auth bug

### DIFF
--- a/app/models/authenticator/amazon.rb
+++ b/app/models/authenticator/amazon.rb
@@ -130,6 +130,7 @@ module Authenticator
       proxy_uri ||= VMDB::Util.http_proxy_uri
 
       require 'aws-sdk'
+      require 'patches/aws-sdk-core/seahorse_client_net_http_pool_patch'
       Aws.const_get(service)::Resource.new(
         :access_key_id     => access_key_id,
         :secret_access_key => secret_access_key,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -50,6 +50,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
 
     def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri = nil, validate = false)
       require 'aws-sdk'
+      require 'patches/aws-sdk-core/seahorse_client_net_http_pool_patch'
 
       connection = Aws.const_get(service)::Resource.new(
         :access_key_id     => access_key_id,
@@ -84,6 +85,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
 
     def translate_exception(err)
       require 'aws-sdk'
+      require 'patches/aws-sdk-core/seahorse_client_net_http_pool_patch'
       case err
       when Aws::EC2::Errors::SignatureDoesNotMatch
         MiqException::MiqHostError.new "SignatureMismatch - check your AWS Secret Access Key and signing method"

--- a/lib/patches/aws-sdk-core/seahorse_client_net_http_pool_patch.rb
+++ b/lib/patches/aws-sdk-core/seahorse_client_net_http_pool_patch.rb
@@ -1,0 +1,44 @@
+# Autoload the connection pool
+Seahorse::Client::NetHttp::ConnectionPool
+
+module Seahorse
+  module Client
+    module NetHttp
+      class ConnectionPool
+        def start_session endpoint
+
+          endpoint = URI.parse(endpoint)
+
+          args = []
+          args << endpoint.host
+          args << endpoint.port
+          args << http_proxy.host
+          args << http_proxy.port
+          args << (http_proxy.user && CGI::unescape(http_proxy.user))
+          args << (http_proxy.password && CGI::unescape(http_proxy.password))
+
+          http = ExtendedSession.new(Net::HTTP.new(*args.compact))
+          http.set_debug_output(logger) if http_wire_trace?
+          http.open_timeout = http_open_timeout
+
+          if endpoint.scheme == 'https'
+            http.use_ssl = true
+            if ssl_verify_peer?
+              http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+              http.ca_file = ssl_ca_bundle if ssl_ca_bundle
+              http.ca_path = ssl_ca_directory if ssl_ca_directory
+              http.cert_store = ssl_ca_store if ssl_ca_store
+            else
+              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            end
+          else
+            http.use_ssl = false
+          end
+
+          http.start
+          http
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a bug with the aws-sdk that prevents the API from working properly when using a proxy, and the auth for the proxy includes a special character (like a question mark: `?`).  This is described here:

https://github.com/aws/aws-sdk-ruby/pull/1760

Since the release of the fix in `aws-sdk` is unknown, this currently monkey patches the fix to MIQ to allow it to work without it.


TODO
----

* [ ] Add tests to exercise this patch, and the future fix.  Unsure how to do this at the moment.


Links
-----

* Pull-request for the patch in lib:  https://github.com/aws/aws-sdk-ruby/pull/1760
* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567418


QA Steps
--------

* Add a proxy for `:ec2` in the advanced config.  Make sure either the `:user:` and/or `:password:` has a special character in it (`?` works for example):
  
  ```
  :http_proxy:
    :ec2:
      :host: <<PROXY_HOST>>
      :port: <<PROXY_PORT>>
      :user: <<PROXY_USERNAME>>
      :password: <<PROXY_PASSWORD>>
  ```
  
* Create a new Amazon provider, and verify that the credentials work for it.

To test in the UI, this requires https://github.com/ManageIQ/manageiq/pull/17218 and https://github.com/ManageIQ/manageiq-ui-classic/pull/3693 as well.