### PR TITLE
handle volume snapshot status changes

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_target_parser.rb
@@ -30,6 +30,8 @@ class ManageIQ::Providers::Amazon::CloudManager::EventTargetParser
                                          event.full_data.fetch_path("detail", "responseElements") || {})
     when :cloud_watch_ec2
       collect_cloudwatch_ec2_references!(target_collection, event.full_data)
+    when :cloud_watch_ec2_ebs_snapshot
+      collect_cloudwatch_ec2_ebs_snapshot_references!(target_collection, event.full_data)
     when :config
       collect_config_references!(target_collection, event.full_data)
     end
@@ -52,6 +54,12 @@ class ManageIQ::Providers::Amazon::CloudManager::EventTargetParser
   def collect_cloudwatch_ec2_references!(target_collection, event_data)
     instance_id = event_data.fetch_path("detail", "instance-id")
     add_target(target_collection, :vms, instance_id) if instance_id
+  end
+
+  def collect_cloudwatch_ec2_ebs_snapshot_references!(target_collection, event_data)
+    if (snapshot_id = event_data.fetch_path('detail', 'snapshot_id'))
+      add_target(target_collection, :cloud_volume_snapshots, snapshot_id.split('/').last)
+    end
   end
 
   def collect_config_references!(target_collection, event_data)

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
@@ -61,6 +61,14 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot < ::
 
   def raw_delete_snapshot
     with_provider_object(&:delete)
+    update!(:status => 'deleting')
+    EmsRefresh.queue_refresh(
+      ManagerRefresh::Target.new(
+        :association => :cloud_volume_snapshots,
+        :manager_ref => { :ems_ref => ems_ref },
+        :manager_id  => ems_id,
+      )
+    )
   rescue => e
     _log.error "volume=[#{name}], error: #{e}"
     raise MiqException::MiqVolumeSnapshotDeleteError, e.to_s, e.backtrace

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/config/EBS_Snapshot_Notification.json
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/config/EBS_Snapshot_Notification.json
@@ -1,0 +1,11 @@
+{
+  "Type" : "Notification",
+  "MessageId" : "38a41df6-c96f-52fe-86b5-4e93f8ca43e1",
+  "TopicArn" : "arn:aws:sns:eu-central-1:200278856672:AWSConfig_topic",
+  "Message" : "{\"version\":\"0\",\"id\":\"29df4485-86c1-db72-78d1-e0ecdbdd3021\",\"detail-type\":\"EBS Snapshot Notification\",\"source\":\"aws.ec2\",\"account\":\"200278856672\",\"time\":\"2018-05-03T15:48:52Z\",\"region\":\"eu-central-1\",\"resources\":[\"arn:aws:ec2::eu-central-1:snapshot/snap-0089df02c4373d7a0\"],\"detail\":{\"event\":\"createSnapshot\",\"result\":\"succeeded\",\"cause\":\"\",\"request-id\":\"\",\"snapshot_id\":\"arn:aws:ec2::eu-central-1:snapshot/snap-0089df02c4373d7a0\",\"source\":\"arn:aws:ec2::eu-central-1:volume/vol-006e52cf74d8f3e7c\",\"startTime\":\"2018-05-03T15:48:26.000Z\",\"endTime\":\"2018-05-03T15:48:52.883Z\"}}",
+  "Timestamp" : "2018-05-03T15:48:53.716Z",
+  "SignatureVersion" : "1",
+  "Signature" : "A1pihqCuih3CEAqzej6OZLjUQw3UVjmvucSKZu90Rqak/pKH1gbiLOzz5hEEm6scFt/RAhSZ/tQpjs5tWyKylDWgawUFr9KZlir5uqZnjAA/8PVdtSG4h7Rz6mM6T9aZliXDdx/NfrOX6rgDM6PomzqDkAAM1M2bQkq6wLRr+OUjKjutJP0otLNwl834QHRNOf9SCdBuCK7I6Rr0LtS304jo/grcodc8DROMfunihjSItbamtEudSSS1DlcQBbcc/me7r1u3nzLHxFXyijUxTr4lqPqPE7Do51/TMcT9QzVyMyl3TNfemR+7cwiPPa4fdmaxZ8ySVkn9s/1nVhsIBg==",
+  "SigningCertURL" : "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+  "UnsubscribeURL" : "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:200278856672:AWSConfig_topic:fb3aae8a-78bd-45c2-aeb7-75097bd230d9"
+}

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_target_parser_spec.rb
@@ -466,6 +466,15 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventTargetParser do
         )
       )
     end
+
+    it 'parses EBS_Snapshot_Notification event' do
+      ems_event = create_ems_event("config/EBS_Snapshot_Notification.json")
+      parsed_targets = described_class.new(ems_event).parse
+
+      expect(parsed_targets.size).to eq(1)
+      expect(target_references(parsed_targets))
+        .to match_array([[:cloud_volume_snapshots, { :ems_ref => 'snap-0089df02c4373d7a0' }]])
+    end
   end
 
   context "AWS CloudWatch with CloudTrail API" do

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot_spec.rb
@@ -9,14 +9,13 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot d
   describe "cloud volume operations" do
     context "#delete_snapshot" do
       it "deletes the cloud volume snapshot" do
-        stubbed_responses = {
-          :ec2 => {
-            :delete_snapshot => {}
-          }
-        }
+        stubbed_responses = { :ec2 => { :delete_snapshot => {} } }
+        allow(EmsRefresh).to receive(:queue_refresh)
 
         with_aws_stubbed(stubbed_responses) do
-          expect(cloud_volume_snapshot.delete_snapshot).to be_truthy
+          expect { cloud_volume_snapshot.delete_snapshot }.to_not raise_error
+          expect(cloud_volume_snapshot.status).to eq('deleting')
+          expect(EmsRefresh).to have_received(:queue_refresh)
         end
       end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1561937
Related: https://github.com/ManageIQ/manageiq-content/pull/285

Note:
AWS CloudWatch should send specific events. 
To setup, one should create CloudWatch rule and target it to the `AWSConfig_topic` SNS topic.
This rule's event pattern should be:
```json
{
  "source": [
    "aws.ec2"
  ],
  "detail-type": [
    "EBS Snapshot Notification"
  ]
}
```
More info: https://aws.amazon.com/ru/blogs/aws/new-cloudwatch-events-for-ebs-snapshots