### PR TITLE
Add endpoint support to raw_connect

### DIFF
--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -48,11 +48,11 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     # Connections
     #
 
-    def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri = nil, validate = false)
+    def raw_connect(access_key_id, secret_access_key, service, region, proxy_uri = nil, validate = false, uri = nil)
       require 'aws-sdk'
       require 'patches/aws-sdk-core/seahorse_client_net_http_pool_patch'
 
-      connection = Aws.const_get(service)::Resource.new(
+      options = {
         :access_key_id     => access_key_id,
         :secret_access_key => MiqPassword.try_decrypt(secret_access_key),
         :region            => region,
@@ -60,7 +60,11 @@ module ManageIQ::Providers::Amazon::ManagerMixin
         :logger            => $aws_log,
         :log_level         => :debug,
         :log_formatter     => Aws::Log::Formatter.new(Aws::Log::Formatter.default.pattern.chomp)
-      )
+      }
+
+      options[:endpoint] = uri.to_s if uri.to_s.present?
+
+      connection = Aws.const_get(service)::Resource.new(options)
 
       validate_connection(connection) if validate
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -14,6 +14,12 @@ describe ManageIQ::Providers::Amazon::CloudManager do
       described_class.raw_connect('access_key', 'secret_access_key', :EC2, 'region', 'uri', true)
     end
 
+    it "validates credentials with an optional uri endpoint" do
+      expect(described_class).to receive(:validate_connection)
+      endpoint_uri = URI.parse('https://apigateway.us-east-1.amazonaws.com')
+      described_class.raw_connect('access_key', 'secret_access_key', :EC2, 'region', 'uri', true, endpoint_uri)
+    end
+
     it "returns the connection if not specified" do
       expect(described_class.raw_connect('access_key', 'secret_access_key', :EC2, 'region', 'uri')).to be_a_kind_of(Aws::EC2::Resource)
     end


### PR DESCRIPTION
This adds a uri endpoint argument to the `raw_connect` method. It is nil by default, but if present it will be passed to the AWS connection code.

Note that this PR depends on a change on the classic UI side. The UI change will add an endpoint text field, which is handled as a URI object, and its parts saved to the `endpoints` table.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1339398

See also: https://github.com/ManageIQ/manageiq-ui-classic/issues/3907