### PR TITLE
Explicitly disable ems_network_new creation

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -34,6 +34,8 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
            :to        => :parent_manager,
            :allow_nil => true
 
+  supports_not :ems_network_new
+
   def self.ems_type
     @ems_type ||= "ec2_network".freeze
   end

--- a/spec/models/manageiq/providers/amazon/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/network_manager_spec.rb
@@ -1,0 +1,39 @@
+require_relative 'aws_helper'
+
+describe ManageIQ::Providers::Amazon::NetworkManager do
+  context "ems" do
+    it "does not support network creation" do
+      ems = FactoryGirl.create(:ems_amazon)
+      expect(ems.supports_ems_network_new?).to eq(false)
+    end
+  end
+
+  context "singleton methods" do
+    it "returns the expected value for the description method" do
+      expect(described_class.description).to eq('Amazon EC2 Network')
+    end
+
+    it "returns the expected value for the ems_type method" do
+      expect(described_class.ems_type).to eq('ec2_network')
+    end
+
+    it "returns the expected value for the hostname_required? method" do
+      expect(described_class.hostname_required?).to eq(false)
+    end
+
+    it "returns the expected value for the default_blacklisted_event_names method" do
+      array = %w(
+        ConfigurationSnapshotDeliveryCompleted
+        ConfigurationSnapshotDeliveryStarted
+        ConfigurationSnapshotDeliveryFailed
+      )
+
+      expect(described_class.default_blacklisted_event_names).to eq(array)
+    end
+
+    it "returns the expected value for the display_name method" do
+      expect(described_class.display_name).to eq('Network Provider (Amazon)')
+      expect(described_class.display_name(2)).to eq('Network Providers (Amazon)')
+    end
+  end
+end


### PR DESCRIPTION
Currently the Amazon provider does not explicitly disable EMS network creation and editing. Based on the current UI code, as well the Nuage provider code, support for `:ems_network_new` should be disabled.

Note that this will also require at least one code change on the classic UI side. Please see https://github.com/ManageIQ/manageiq-ui-classic/pull/3976, which properly uses the `SupportsFeatureMixin` hook.

While I was here I also added the beginnings of a test suite for the Amazon NetworkManager.

Partial fix for https://bugzilla.redhat.com/show_bug.cgi?id=1577888