### PR TITLE
Fix missing MiqServer in Authenticator spec

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -151,6 +151,7 @@ describe Authenticator::Amazon do
   end
 
   describe '#authenticate' do
+    before { EvmSpecHelper.local_miq_server(:is_master => true) }
     def authenticate
       subject.authenticate(username, "some_password")
     end


### PR DESCRIPTION
The new audit_failure method in authenticator/base raises an evm event
on auth failure which targets the MiqServer.my_server.  In the amazon
authenticator spec this was nil which was causing the audit_failure
method to throw an exception trying to get class and id from the target.

https://bugzilla.redhat.com/show_bug.cgi?id=1318353