### PR TITLE
Added allow_delete method on AuthKeyPairs

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
@@ -35,6 +35,14 @@ class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair < ManageIQ::Provide
   end
 
   def validate_delete_key_pair
-    {:available => true, :message => nil}
+    {:available => allow_delete?, :message => nil}
+  end
+
+  private
+
+  # Returns false if an auth_key is available true if not.
+  # Meaning we can delete if there is no auth_key.
+  def allow_delete?
+    !self.auth_key.present?
   end
 end


### PR DESCRIPTION
Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1418481

When a local user auth key is created that can be deleted, but not
ones imported from the provider.
