### PR TITLE
[WIP] Add JS in general, amazon-security-group component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,31 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "> 1%",
+            "last 2 versions",
+            "Firefox ESR",
+            "IE 10",
+            "IE 11"
+          ]
+        }
+      }
+    ],
+    "react",
+    "es2015",
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-export-extensions",
+    "transform-object-rest-spread",
+    "transform-object-assign"
+  ],
+  "env": {
+    "test": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /config/environments/*.local.yml
 
 /spec/manageiq
+
+node_modules/
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# using yarn
+package-lock = false

--- a/app/javascript/components/create-amazon-security-group-form.jsx
+++ b/app/javascript/components/create-amazon-security-group-form.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AmazonSecurityGroupForm } from '@manageiq/react-ui-components/dist/amazon-security-form-group';
+import '@manageiq/react-ui-components/dist/amazon-security-form-group.css';
+
+const API = window.API;
+
+const getData = () => API.get("/api/cloud_networks/?attributes=ems_ref,name,type&expand=resources&filter[]=type='ManageIQ::Providers::Amazon*'")
+  .then(data => data.resources.map(resource => ({
+    value: resource.ems_ref,
+    label: resource.name,
+  })));
+
+const createGroups = (values, providerId) =>
+  API.post(`/api/providers/${providerId}/security_groups`, {
+    action: 'create',
+    resource: { ...values },
+  });
+
+const CreateAmazonSecurityGroupForm = ({ providerId }) => (
+  <AmazonSecurityGroupForm
+    onSave={values => createGroups(values, providerId)}
+    onCancel={() => console.log('Cancel clicked')}
+    loadData={getData}
+  />
+);
+
+CreateAmazonSecurityGroupForm.propTypes = {
+  providerId: PropTypes.number.isRequired,
+};
+
+export default CreateAmazonSecurityGroupForm;

--- a/app/javascript/components/create-amazon-security-group-form.jsx
+++ b/app/javascript/components/create-amazon-security-group-form.jsx
@@ -17,16 +17,16 @@ const createGroups = (values, providerId) =>
     resource: { ...values },
   });
 
-const CreateAmazonSecurityGroupForm = ({ providerId }) => (
+const CreateAmazonSecurityGroupForm = ({ recordId }) => (
   <AmazonSecurityGroupForm
-    onSave={values => createGroups(values, providerId)}
+    onSave={values => createGroups(values, recordId)}
     onCancel={() => console.log('Cancel clicked')}
     loadData={getData}
   />
 );
 
 CreateAmazonSecurityGroupForm.propTypes = {
-  providerId: PropTypes.number.isRequired,
+  recordId: PropTypes.string.isRequired,
 };
 
 export default CreateAmazonSecurityGroupForm;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,0 +1,3 @@
+import CreateAmazonSecurityGroupForm from '../components/create-amazon-security-group-form';
+
+ManageIQ.component.addReact('CreateAmazonSecurityGroupForm', CreateAmazonSecurityGroupForm);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "manageiq-providers-amazon",
+  "version": "1.0.0",
+  "description": "ManageIQ Cloud Management Platform",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ManageIQ/manageiq.git"
+  },
+  "author": "ManageIQ",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ManageIQ/manageiq/issues"
+  },
+  "homepage": "https://github.com/ManageIQ/manageiq#readme",
+  "dependencies": {
+    "@manageiq/react-ui-components": "~0.9.1",
+    "prop-types": "^15.6.0",
+    "react": "^16.3.1",
+    "react-dom": "^16.3.1"
+  },
+  "devDependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1"
+  },
+  "engines": {
+    "node": ">= 6.9.1",
+    "npm": ">= 3.10.3",
+    "yarn": ">= 0.20.1"
+  }
+}


### PR DESCRIPTION
The component comes from https://github.com/ManageIQ/manageiq-ui-classic/pull/4181,
the rest of the JS config is just the needed bits from ui-classic, and dependencies.

Differences from the original:

* (js) `API` comes from `window.API`, not imported directly
* (js) `addReact` comes from `ManageIQ.component.addReact`, not imported directly (should probably change this in ui-classic too)
* (css) not included via the asset pipeline, use webpack (=> gaprindashvili/no)
* (props) use `recordId` instead of `providerId` in the wrapper (toolbar interface)
* (props) make `recordId` string, not number (bigint)

---

Meant to go together with https://github.com/ManageIQ/manageiq-ui-classic/pull/4267 and https://github.com/ManageIQ/manageiq-providers-amazon/pull/460 .. and https://github.com/ManageIQ/manageiq-ui-classic/pull/4268 .. and https://github.com/ManageIQ/manageiq-ui-classic/pull/4262