### PR TITLE
[WIP] Amazon provider modal form demo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,31 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "> 1%",
+            "last 2 versions",
+            "Firefox ESR",
+            "IE 10",
+            "IE 11"
+          ]
+        }
+      }
+    ],
+    "react",
+    "es2015",
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-export-extensions",
+    "transform-object-rest-spread",
+    "transform-object-assign"
+  ],
+  "env": {
+    "test": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /config/environments/*.local.yml
 
 /spec/manageiq
+
+node_modules/
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# using yarn
+package-lock = false

--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,0 +1,4 @@
+plugins:
+  postcss-smart-import: {}
+  precss: {}
+  autoprefixer: {}

--- a/app/helpers/manageiq/providers/amazon/toolbar_overrides/ems_cloud_center.rb
+++ b/app/helpers/manageiq/providers/amazon/toolbar_overrides/ems_cloud_center.rb
@@ -1,0 +1,33 @@
+module ManageIQ
+  module Providers
+    module Amazon
+      module ToolbarOverrides
+        class EmsCloudCenter < ::ApplicationHelper::Toolbar::Override
+          button_group('magic', [
+            button(
+              :magic,
+              'fa fa-magic fa-lg',
+              t = N_('Magic'),
+              t,
+              :data  => {'function'      => 'sendDataWithRx',
+                         'function-data' => {:controller     => 'provider_dialogs', # this one is required
+                                             :button         => :magic,
+                                             :modal_title    => N_('Create a Security Group'),
+                                             :component_name => 'CreateAmazonSecurityGroupForm',
+                                             :ems_id         => EmsCloud.first.id}.to_json}, # this line to be removed, usage replaced with ManageIQ.record.recordId
+              :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
+            button(
+              :magic_dialog,
+              'fa fa-magic fa-lg',
+              t = N_('Magic'),
+              t,
+              :data  => {'function'      => 'sendDataWithRx',
+                         'function-data' => {:controller => 'provider_dialogs', # this one is required
+                                             :button     => :magic_dialog}.to_json},
+              :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
+          ])
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/manageiq/providers/amazon/toolbar_overrides/x_vm_cloud_center.rb
+++ b/app/helpers/manageiq/providers/amazon/toolbar_overrides/x_vm_cloud_center.rb
@@ -1,0 +1,43 @@
+module ManageIQ
+  module Providers
+    module Amazon
+      module ToolbarOverrides
+        class XVmCloudCenter < ::ApplicationHelper::Toolbar::Override
+          button_group('amazon_stuff', [
+            select(
+              :amazon_stuff,
+              'fa fa-cog fa-lg',
+              t = N_('Amazon Stuff'),
+              t,
+              :items => [
+                button(
+                  :amazon_do_start_instance,
+                  'fa fa-refresh fa-lg',
+                  N_('Do something to this Instance'),
+                  N_('Start this Instance'),
+                  :confirm => N_("Really wanna do something?"),
+                  :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+                ),
+                button(
+                  :amazon_do_stop_instance,
+                  'fa fa-search fa-lg',
+                  N_('Do something more to this Instance'),
+                  N_('Stop this Instance'),
+                  :confirm => N_("Still not enough?"),
+                  :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+                ),
+                button(
+                  :amazon_do_stop_instance,
+                  'fa fa-search fa-lg',
+                  N_('Do something more to this Instance'),
+                  N_('Create security group'),
+                  :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+                ),
+              ]
+            )
+          ])
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/components/create-amazon-security-group-form.jsx
+++ b/app/javascript/components/create-amazon-security-group-form.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AmazonSecurityGroupForm } from '@manageiq/react-ui-components/dist/amazon-security-form-group';
+import '@manageiq/react-ui-components/dist/amazon-security-form-group.css';
+
+const API = window.API;
+
+const getData = () => API.get("/api/cloud_networks/?attributes=ems_ref,name,type&expand=resources&filter[]=type='ManageIQ::Providers::Amazon*'")
+  .then(data => data.resources.map(resource => ({
+    value: resource.ems_ref,
+    label: resource.name,
+  })));
+
+const createGroups = (values, providerId) =>
+  API.post(`/api/providers/${providerId}/security_groups`, {
+    action: 'create',
+    resource: { ...values },
+  });
+
+const CreateAmazonSecurityGroupForm = ({ providerId }) => (
+  <AmazonSecurityGroupForm
+    onSave={values => createGroups(values, providerId)}
+    onCancel={() => console.log('Cancel clicked')}
+    loadData={getData}
+  />
+);
+
+CreateAmazonSecurityGroupForm.propTypes = {
+  providerId: PropTypes.number.isRequired,
+};
+
+export default CreateAmazonSecurityGroupForm;

--- a/app/javascript/components/create-amazon-security-group-form.jsx
+++ b/app/javascript/components/create-amazon-security-group-form.jsx
@@ -17,16 +17,16 @@ const createGroups = (values, providerId) =>
     resource: { ...values },
   });
 
-const CreateAmazonSecurityGroupForm = ({ providerId }) => (
+const CreateAmazonSecurityGroupForm = ({ recordId }) => (
   <AmazonSecurityGroupForm
-    onSave={values => createGroups(values, providerId)}
+    onSave={values => createGroups(values, recordId)}
     onCancel={() => console.log('Cancel clicked')}
     loadData={getData}
   />
 );
 
 CreateAmazonSecurityGroupForm.propTypes = {
-  providerId: PropTypes.number.isRequired,
+  recordId: PropTypes.string.isRequired,
 };
 
 export default CreateAmazonSecurityGroupForm;

--- a/app/javascript/components/create-amazon-security-group-form.jsx
+++ b/app/javascript/components/create-amazon-security-group-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { AmazonSecurityGroupForm } from '@manageiq/react-ui-components/dist/amazon-security-form-group';
-import '@manageiq/react-ui-components/dist/amazon-security-form-group.css';
 
 const API = window.API;
 
@@ -17,16 +17,55 @@ const createGroups = (values, providerId) =>
     resource: { ...values },
   });
 
-const CreateAmazonSecurityGroupForm = ({ recordId }) => (
-  <AmazonSecurityGroupForm
-    onSave={values => createGroups(values, recordId)}
-    onCancel={() => console.log('Cancel clicked')}
-    loadData={getData}
-  />
-);
+class CreateAmazonSecurityGroupForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      values: {},
+    };
+    this.handleFormStateUpdate = this.handleFormStateUpdate.bind(this);
+  }
+
+  componentDidMount() {
+    this.props.dispatch({
+      type: 'FormButtons.init',
+      payload: {
+        newRecord: true,
+        pristine: true,
+        addClicked: () => {
+          createGroups(this.state.values, ManageIQ.record.recordId);
+        },
+      },
+    });
+  }
+
+  handleFormStateUpdate(formState) {
+    this.props.dispatch({
+      type: 'FormButtons.saveable',
+      payload: formState.valid,
+    });
+    this.props.dispatch({
+      type: 'FormButtons.pristine',
+      payload: formState.pristine,
+    });
+    this.setState({ values: formState.values });
+  }
+
+  render() {
+    return (
+      <AmazonSecurityGroupForm
+        onSave={values => createGroups(values, ManageIQ.record.recordId)}
+        onCancel={() => console.log('Cancel clicked')}
+        loadData={getData}
+        updateFormState={this.handleFormStateUpdate}
+        hideControls
+      />
+    );
+  }
+}
 
 CreateAmazonSecurityGroupForm.propTypes = {
-  recordId: PropTypes.string.isRequired,
+  dispatch: PropTypes.func.isRequired,
 };
 
-export default CreateAmazonSecurityGroupForm;
+export default connect()(CreateAmazonSecurityGroupForm);

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,0 +1,3 @@
+import CreateAmazonSecurityGroupForm from '../components/create-amazon-security-group-form';
+
+ManageIQ.component.addReact('CreateAmazonSecurityGroupForm', CreateAmazonSecurityGroupForm);

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,3 +1,4 @@
 import CreateAmazonSecurityGroupForm from '../components/create-amazon-security-group-form';
+import '@manageiq/react-ui-components/dist/amazon-security-form-group.css';
 
 ManageIQ.component.addReact('CreateAmazonSecurityGroupForm', CreateAmazonSecurityGroupForm);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "manageiq-providers-amazon",
+  "version": "1.0.0",
+  "description": "ManageIQ Cloud Management Platform",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ManageIQ/manageiq.git"
+  },
+  "author": "ManageIQ",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ManageIQ/manageiq/issues"
+  },
+  "homepage": "https://github.com/ManageIQ/manageiq#readme",
+  "dependencies": {
+    "@manageiq/react-ui-components": "~0.9.1",
+    "prop-types": "^15.6.0",
+    "react": "^16.3.1",
+    "react-dom": "^16.3.1"
+  },
+  "devDependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1"
+  },
+  "engines": {
+    "node": ">= 6.9.1",
+    "npm": ">= 3.10.3",
+    "yarn": ">= 0.20.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "@manageiq/react-ui-components": "~0.9.1",
     "prop-types": "^15.6.0",
     "react": "^16.3.1",
-    "react-dom": "^16.3.1"
+    "react-dom": "^16.3.1",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@manageiq/react-ui-components": "~0.9.1",
+    "@manageiq/react-ui-components": "~0.9.5",
     "prop-types": "^15.6.0",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",


### PR DESCRIPTION
Do not merge this is a demo

Continuing #460. Adds Redux controls for the form.

## Controls
In order to avoid any bugs in current version, you can run a few commands from browser console.
```
ManageIQ.record.recordId = 'someId'
sendDataWithRx({controller: 'provider_dialogs', component_name: 'CreateAmazonSecurityGroupForm', modal_title: 'Create amazon provider.', props: {recordId: 'neco'}})
```

## Dependencies
~~This has a few dependencies in manageiq-ui-classic that need to be merged to make this working.
Generic form buttons https://github.com/ManageIQ/manageiq-ui-classic/pull/3509~~

~~For the latest version of the form component https://github.com/ManageIQ/react-ui-components/pull/61 (and new version release)~~

~~To enable direct import of css https://github.com/ManageIQ/manageiq-ui-classic/pull/4326~~

## Some issues
Currently props cannot be passed to component inside modal. That can be fixed ni `modal.js` in ui-classic. @himdel knows about this. Therefore the providerId must be set in console first, before showing the modal.

Importing css will also not work, if your webpack config does not have autoprefixer.

Also the API endpoint for creating is not available until https://github.com/ManageIQ/manageiq-providers-amazon/issues/453 will be merged or rebase from that PR