### PR TITLE
ignore trailing whitespaces in yaml files

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,5 @@ rules:
     indent-sequences: false
   line-length:
     max: 120
+  trailing-spaces: false
+


### PR DESCRIPTION
This will force CI bot to ignore trailing whitespaces, otherwise it gives a huge bulk of related errors ([example](https://github.com/ManageIQ/manageiq-providers-amazon/pull/470#issuecomment-409263985)).
Related [discussion](https://github.com/ManageIQ/manageiq-providers-amazon/pull/449#discussion_r202394380).
Yamllint [documentation](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.trailing_spaces).