### PR TITLE
Move Inventory from ManagerRefresh to ManageIQ::Providers

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresher.rb
@@ -4,7 +4,7 @@ class ManageIQ::Providers::Amazon::CloudManager::Refresher < ManageIQ::Providers
   # @param ems [ManageIQ::Providers::BaseManager] Manager owning the refresh
   # @param target [ManageIQ::Providers::BaseManager or ManagerRefresh::Target or ManagerRefresh::TargetCollection]
   #        Target we are refreshing
-  # @param _hashes_or_persister [Array<Hash> or ManagerRefresh::Inventory::Persister] Used in superclass
+  # @param _hashes_or_persister [Array<Hash> or ManageIQ::Providers::Inventory::Persister] Used in superclass
   def save_inventory(ems, target, _hashes_or_persister)
     super
 

--- a/app/models/manageiq/providers/amazon/inventory.rb
+++ b/app/models/manageiq/providers/amazon/inventory.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Amazon::Inventory < ManagerRefresh::Inventory
+class ManageIQ::Providers::Amazon::Inventory < ManageIQ::Providers::Inventory
   require_nested :Collector
   require_nested :Parser
   require_nested :Persister

--- a/app/models/manageiq/providers/amazon/inventory/collector.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Amazon::Inventory::Collector < ManagerRefresh::Inventory::Collector
+class ManageIQ::Providers::Amazon::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :CloudManager
   require_nested :NetworkManager
   require_nested :TargetCollection

--- a/app/models/manageiq/providers/amazon/inventory/parser.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Amazon::Inventory::Parser < ManagerRefresh::Inventory::Parser
+class ManageIQ::Providers::Amazon::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :CloudManager
   require_nested :NetworkManager
 

--- a/app/models/manageiq/providers/amazon/inventory/persister.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Amazon::Inventory::Persister < ManagerRefresh::Inventory::Persister
+class ManageIQ::Providers::Amazon::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :CloudManager
   require_nested :NetworkManager
   require_nested :TargetCollection
@@ -10,7 +10,7 @@ class ManageIQ::Providers::Amazon::Inventory::Persister < ManagerRefresh::Invent
 
   # @param manager [ManageIQ::Providers::BaseManager] A manager object
   # @param target [Object] A refresh Target object
-  # @param collector [ManagerRefresh::Inventory::Collector] A Collector object
+  # @param collector [ManageIQ::Providers::Inventory::Collector] A Collector object
   def initialize(manager, target = nil, collector = nil)
     @manager   = manager
     @target    = target


### PR DESCRIPTION
Move away from the compatibility ManagerRefresh::Inventory class to ManageIQ::Providers::Inventory