### PR TITLE
new AWS EC2 instance types

### DIFF
--- a/db/fixtures/aws_instance_types.yml
+++ b/db/fixtures/aws_instance_types.yml
@@ -1005,6 +1005,35 @@ f1.2xlarge:
   :virtualization_type:
   - :hvm
   :vpc_only: true
+f1.4xlarge:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: F1 FPGA Instances 4XL
+  :ebs_only: false
+  :ebs_optimized_available: 
+  :enhanced_networking: true
+  :family: FPGA Instances
+  :instance_store_size: 1009317314560
+  :instance_store_size_gb: 940.0
+  :instance_store_type: 
+  :instance_store_volumes: 1
+  :intel_aes_ni: true
+  :intel_avx: true
+  :intel_avx2: true
+  :intel_turbo: true
+  :memory: 261993005056
+  :memory_gb: 244.0
+  :name: f1.4xlarge
+  :network_performance: :very_high
+  :physical_processor: Intel Xeon E5-2686 v4 (Broadwell)
+  :processor_clock_speed: 
+  :vcpu: 16
+  :virtualization_type:
+  - :hvm
+  :vpc_only: true
 g2.2xlarge:
   :architecture:
   - :x86_64
@@ -3594,6 +3623,209 @@ t2.xlarge:
   :virtualization_type:
   - :hvm
   :vpc_only: true
+t3.2xlarge:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose 2XL
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 34359738368
+  :memory_gb: 32.0
+  :name: t3.2xlarge
+  :network_performance: :moderate
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 8
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
+t3.large:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose Large
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 8589934592
+  :memory_gb: 8.0
+  :name: t3.large
+  :network_performance: :low_to_moderate
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 2
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
+t3.medium:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose Medium
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 4294967296
+  :memory_gb: 4.0
+  :name: t3.medium
+  :network_performance: :low_to_moderate
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 2
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
+t3.micro:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose Micro
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 1073741824
+  :memory_gb: 1.0
+  :name: t3.micro
+  :network_performance: :low_to_moderate
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 2
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
+t3.nano:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose Nano
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 536870912
+  :memory_gb: 0.5
+  :name: t3.nano
+  :network_performance: :low
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 2
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
+t3.small:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose Small
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 2147483648
+  :memory_gb: 2.0
+  :name: t3.small
+  :network_performance: :low_to_moderate
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 2
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
+t3.xlarge:
+  :architecture:
+  - :x86_64
+  :cluster_networking: 
+  :current_generation: true
+  :current_version: true
+  :description: T3 General purpose XL
+  :ebs_only: true
+  :ebs_optimized_available: 
+  :enhanced_networking: 
+  :family: General purpose
+  :instance_store_size: 0
+  :instance_store_size_gb: 0.0
+  :instance_store_type: 
+  :instance_store_volumes: 0
+  :intel_aes_ni: true
+  :intel_avx: 
+  :intel_avx2: 
+  :intel_turbo: 
+  :memory: 17179869184
+  :memory_gb: 16.0
+  :name: t3.xlarge
+  :network_performance: :moderate
+  :physical_processor: Intel Skylake E5 2686 v5 (2.5 GHz)
+  :processor_clock_speed: 
+  :vcpu: 4
+  :virtualization_type:
+  - :hvm
+  :vpc_only: false
 unknown:
   :architecture: []
   :cluster_networking: 

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -153,7 +153,7 @@ module AwsRefresherSpecCounts
       :custom_attribute              => custom_attributes_count,
       :disk                          => disks_count,
       :firewall_rule                 => firewall_rules_count,
-      :flavor                        => 132,
+      :flavor                        => 140,
       :floating_ip                   => floating_ips_count,
       :hardware                      => instances_and_images_count,
       :miq_template                  => images_count,

--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -138,7 +138,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
       :auth_private_key                  => test_counts[:key_pair_count],
       :ext_management_system             => expected_ext_management_systems_count,
       # TODO(lsmola) collect all flavors for original refresh
-      :flavor                            => @inventory_object_settings[:inventory_object_refresh] ? 137 : 132,
+      :flavor                            => @inventory_object_settings[:inventory_object_refresh] ? 145 : 140,
       :availability_zone                 => 5,
       :vm_or_template                    => vm_count_plus_disconnect_inv + image_count_plus_disconnect_inv,
       :vm                                => vm_count_plus_disconnect_inv,


### PR DESCRIPTION
announces:
- https://aws.amazon.com/about-aws/whats-new/2018/08/introducing-amazon-ec2-t3-instances
- https://aws.amazon.com/about-aws/whats-new/2018/09/amazon-ec2-f1-instances-now-available-in-an-additional-size

8 new types in total