### PR TITLE
Change saver_strategy value to String

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -88,19 +88,19 @@
     :inventory_object_refresh: true
     :allow_targeted_refresh: true
     :inventory_collections:
-      :saver_strategy: :batch
+      :saver_strategy: batch
   :ec2_network:
     :inventory_object_refresh: true
     :inventory_collections:
-      :saver_strategy: :batch
+      :saver_strategy: batch
   :s3:
     :inventory_object_refresh: true
     :inventory_collections:
-      :saver_strategy: :batch
+      :saver_strategy: batch
   :ec2_ebs_storage:
     :inventory_object_refresh: true
     :inventory_collections:
-      :saver_strategy: :batch
+      :saver_strategy: batch
 :http_proxy:
   :ec2:
     :host:

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -14,18 +14,18 @@ module AwsRefresherSpecCommon
     {
       :inventory_object_refresh => true,
       :inventory_collections    => {
-        :saver_strategy => :default,
+        :saver_strategy => "default",
       },
     }, {
       :inventory_object_refresh => true,
       :inventory_collections    => {
-        :saver_strategy => :batch,
+        :saver_strategy => "batch",
         :use_ar_object  => true,
       },
     }, {
       :inventory_object_refresh => true,
       :inventory_collections    => {
-        :saver_strategy => :batch,
+        :saver_strategy => "batch",
         :use_ar_object  => false,
       },
     }, {

--- a/spec/models/manageiq/providers/amazon/cloud_manager/vcr_specs/targeted_refresh_scope_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/vcr_specs/targeted_refresh_scope_spec.rb
@@ -25,7 +25,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   [
     :inventory_object_refresh => true,
     :inventory_collections    => {
-      :saver_strategy => :batch,
+      :saver_strategy => "batch",
       :use_ar_object  => false,
     },
   ].each do |settings|


### PR DESCRIPTION
@Fryguy @Ladas somehow we missed one provider.

Symbols in configuration values are problematic because Symbols do not
roundtrip through JSON.  Since the API now exposes Settings, it's not
possible to set Symbols as values.  The saver_strategy was fixed in
ManageIQ/manageiq#17168 to support String
values, and the next step is to remove all Symbols from the Settings.

ManageIQ/manageiq#17201
https://bugzilla.redhat.com/show_bug.cgi?id=1558031
@miq-bot add-labels bug, gaprindashvili/yes, hammer/yes