### PR TITLE
Service dialog for orchestration template no longer contains tenant selection

### DIFF
--- a/spec/models/dialog/orchestration_template_amazon_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_amazon_service_dialog_spec.rb
@@ -18,19 +18,17 @@ describe "OrchestrationTemplateServiceDialog for Amazon" do
     )
 
     fields = group.dialog_fields
-    expect(fields.size).to eq(10)
+    expect(fields.size).to eq(9)
 
-    expect(fields[0].resource_action.fqname).to eq('/Cloud/Orchestration/Operations/Methods/Available_Tenants')
-    assert_field(fields[0], DialogFieldDropDownList, :name => 'tenant_name',          :dynamic => true)
-    assert_field(fields[1], DialogFieldTextBox,      :name => 'stack_name',           :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => 'stack_onfailure',      :values => [%w(DELETE Delete\ stack), %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
-    assert_field(fields[3], DialogFieldTextBox,      :name => 'stack_timeout',        :data_type => 'integer')
-    assert_field(fields[4], DialogFieldTextAreaBox,  :name => 'stack_notifications',  :data_type => 'string')
-    assert_field(fields[5], DialogFieldDropDownList, :name => 'stack_capabilities',   :values => [[nil, '<None>'], ['CAPABILITY_IAM'] * 2, ['CAPABILITY_NAMED_IAM'] * 2])
-    assert_field(fields[6], DialogFieldTextBox,      :name => 'stack_resource_types', :data_type => 'string')
-    assert_field(fields[7], DialogFieldTextBox,      :name => 'stack_role',           :data_type => 'string')
-    assert_field(fields[8], DialogFieldTextBox,      :name => 'stack_tags',           :data_type => 'string')
-    assert_field(fields[9], DialogFieldTextBox,      :name => 'stack_policy',         :data_type => 'string')
+    assert_field(fields[0], DialogFieldTextBox,      :name => 'stack_name',           :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    assert_field(fields[1], DialogFieldDropDownList, :name => 'stack_onfailure',      :values => [%w(DELETE Delete\ stack), %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+    assert_field(fields[2], DialogFieldTextBox,      :name => 'stack_timeout',        :data_type => 'integer')
+    assert_field(fields[3], DialogFieldTextAreaBox,  :name => 'stack_notifications',  :data_type => 'string')
+    assert_field(fields[4], DialogFieldDropDownList, :name => 'stack_capabilities',   :values => [[nil, '<None>'], ['CAPABILITY_IAM'] * 2, ['CAPABILITY_NAMED_IAM'] * 2])
+    assert_field(fields[5], DialogFieldTextBox,      :name => 'stack_resource_types', :data_type => 'string')
+    assert_field(fields[6], DialogFieldTextBox,      :name => 'stack_role',           :data_type => 'string')
+    assert_field(fields[7], DialogFieldTextBox,      :name => 'stack_tags',           :data_type => 'string')
+    assert_field(fields[8], DialogFieldTextBox,      :name => 'stack_policy',         :data_type => 'string')
   end
 
   def assert_field(field, clss, attributes)

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_template_spec.rb
@@ -184,16 +184,15 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate do
   describe '#deployment_options' do
     it 'generates deployment options for AWS' do
       options = subject.deployment_options('ManageIQ::Providers::Amazon::CloudManager')
-      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
-      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
-      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, true, :reconfigurable => false)
-      assert_deployment_option(options[3], "stack_timeout", nil, false, :reconfigurable => false, :data_type => 'integer')
-      assert_deployment_option(options[4], "stack_notifications", nil, false)
-      assert_deployment_option(options[5], "stack_capabilities", :OrchestrationParameterAllowed, false)
-      assert_deployment_option(options[6], "stack_resource_types", nil, false)
-      assert_deployment_option(options[7], "stack_role", nil, false)
-      assert_deployment_option(options[8], "stack_tags", nil, false)
-      assert_deployment_option(options[9], "stack_policy", nil, false)
+      assert_deployment_option(options[0], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[1], "stack_onfailure", :OrchestrationParameterAllowed, true, :reconfigurable => false)
+      assert_deployment_option(options[2], "stack_timeout", nil, false, :reconfigurable => false, :data_type => 'integer')
+      assert_deployment_option(options[3], "stack_notifications", nil, false)
+      assert_deployment_option(options[4], "stack_capabilities", :OrchestrationParameterAllowed, false)
+      assert_deployment_option(options[5], "stack_resource_types", nil, false)
+      assert_deployment_option(options[6], "stack_role", nil, false)
+      assert_deployment_option(options[7], "stack_tags", nil, false)
+      assert_deployment_option(options[8], "stack_policy", nil, false)
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1642594

Fixes CI build failure caused by https://github.com/ManageIQ/manageiq/pull/18202