### PR TITLE
Return true for memory_mb_available?

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -21,6 +21,10 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
     connection.instance(ems_ref)
   end
 
+  def memory_mb_available?
+    true
+  end
+
   #
   # Relationship methods
   #


### PR DESCRIPTION
Memory chart is not showing for Amazon Instances in UI.
` ManageIQ::Providers::Amazon::CloudManager::Vm` is returning false for `memory_mb_available?` and that is the reason why the memory chart is not showing im UI.
This behavior is inherited from `VmOrTemplate` `non_generic_charts_available?` method.


https://bugzilla.redhat.com/show_bug.cgi?id=1676761

@Ladas I am not sure if this is the correct fix, so please feel free to correct me ;)
