### PR TITLE
disable new us-gov region by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,7 @@
     :disabled_regions:
       - cn-north-1
       - cn-northwest-1
+      - us-gov-east-1
       - us-gov-west-1
 
     # add additional regions as found in app/models/manageiq/providers/amazon/regions.rb


### PR DESCRIPTION
@agrare @djberg96 this is a very simple change, just hide a new us-gov region by default, as we do that with other special regions.