### PR TITLE
Update specs to look for CloudManager::AuthKeyPair

### DIFF
--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -178,7 +178,7 @@ module AwsRefresherSpecCounts
 
   def assert_table_counts(expected_table_counts)
     actual = {
-      :auth_private_key              => AuthPrivateKey.count,
+      :auth_private_key              => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :cloud_volume                  => CloudVolume.count,
       :cloud_volume_backup           => CloudVolumeBackup.count,
       :cloud_volume_snapshot         => CloudVolumeSnapshot.count,

--- a/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/provision_workflow_spec.rb
@@ -42,7 +42,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow do
     end
 
     it "#allowed_guest_access_key_pairs" do
-      kp = AuthPrivateKey.create(:name => "auth_1")
+      kp = ManageIQ::Providers::CloudManager::AuthKeyPair.create(:name => "auth_1")
       ems.key_pairs << kp
       expect(workflow.allowed_guest_access_key_pairs).to eq(kp.id => kp.name)
     end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -180,7 +180,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
   def assert_table_counts
     actual = {
-      :auth_private_key                  => AuthPrivateKey.count,
+      :auth_private_key                  => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :ext_management_system             => ExtManagementSystem.count,
       :flavor                            => Flavor.count,
       :availability_zone                 => AvailabilityZone.count,

--- a/spec/models/manageiq/providers/amazon/network_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/network_manager/stubbed_refresher_spec.rb
@@ -156,7 +156,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
   def assert_table_counts
     actual = {
-      :auth_private_key                  => AuthPrivateKey.count,
+      :auth_private_key                  => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :ext_management_system             => ExtManagementSystem.count,
       :flavor                            => Flavor.count,
       :availability_zone                 => AvailabilityZone.count,

--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/stubbed_refresher_spec.rb
@@ -141,7 +141,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::Refresher do
 
   def assert_table_counts
     actual = {
-      :auth_private_key                  => AuthPrivateKey.count,
+      :auth_private_key                  => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :ext_management_system             => ExtManagementSystem.count,
       :flavor                            => Flavor.count,
       :availability_zone                 => AvailabilityZone.count,

--- a/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/s3/stubbed_refresher_spec.rb
@@ -407,7 +407,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::S3::Refresher do
 
   def assert_table_counts
     actual = {
-      :auth_private_key                  => AuthPrivateKey.count,
+      :auth_private_key                  => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :ext_management_system             => ExtManagementSystem.count,
       :flavor                            => Flavor.count,
       :availability_zone                 => AvailabilityZone.count,

--- a/spec/tools/refresh_performance/aws_refresh_performance_cloud_manager.rb
+++ b/spec/tools/refresh_performance/aws_refresh_performance_cloud_manager.rb
@@ -235,7 +235,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
   def assert_table_counts
     actual = {
-      :auth_private_key                  => AuthPrivateKey.count,
+      :auth_private_key                  => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :ext_management_system             => ExtManagementSystem.count,
       :flavor                            => Flavor.count,
       :availability_zone                 => AvailabilityZone.count,

--- a/spec/tools/refresh_performance/aws_refresh_performance_network_manager.rb
+++ b/spec/tools/refresh_performance/aws_refresh_performance_network_manager.rb
@@ -213,7 +213,7 @@ describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
 
   def assert_table_counts
     actual = {
-      :auth_private_key                  => AuthPrivateKey.count,
+      :auth_private_key                  => ManageIQ::Providers::CloudManager::AuthKeyPair.count,
       :ext_management_system             => ExtManagementSystem.count,
       :flavor                            => Flavor.count,
       :availability_zone                 => AvailabilityZone.count,


### PR DESCRIPTION
Now that ManageIQ/manageiq#18633 is merged we can update this to only look for CloudManager::AuthKeyPairs