### PR TITLE
Return not set timeout in dialog as nil instead of 0.

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter.rb
@@ -3,13 +3,13 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationServiceOptionConve
   private_constant :REGEX_TAGS, :REGEX_TAGS
 
   def stack_create_options
-    timeout = @dialog_options['dialog_stack_timeout']
+    timeout = @dialog_options['dialog_stack_timeout'].to_i
     policy_body, policy_url = parse_policy(@dialog_options['dialog_stack_policy'])
 
     stack_options = {
       :parameters         => stack_parameters,
       :on_failure         => @dialog_options['dialog_stack_onfailure'],
-      :timeout_in_minutes => timeout.blank? ? nil : timeout.to_i,
+      :timeout_in_minutes => timeout.positive? ? timeout : nil,
       :notification_arns  => parse_multiple_lines(@dialog_options['dialog_stack_notifications']),
       :capabilities       => parse_capacities(@dialog_options['dialog_stack_capabilities']),
       :resource_types     => parse_multiple_lines(@dialog_options['dialog_stack_resource_types']),

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter_spec.rb
@@ -33,7 +33,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationServiceOptionCo
   context 'timeout option' do
     let(:options) { {'dialog_stack_timeout' => '30'} }
 
-    it { expect(subject.stack_create_options[:timeout_in_minutes]).to eq(30) }
+    it 'returns timeout when timeout > 0' do
+      expect(subject.stack_create_options[:timeout_in_minutes]).to eq(30)
+    end
+
+    it 'returns nil when timeout = 0' do
+      options['dialog_stack_timeout'] = 0
+      expect(subject.stack_create_options[:timeout_in_minutes]).to be_nil
+    end
   end
 
   context 'on_failure option' do


### PR DESCRIPTION
To pass the validation on timeoutInMinutes that the value must be greater than or equal to 1.

https://bugzilla.redhat.com/show_bug.cgi?id=1698439

@miq-bot add_label bug
cc @gmcculloug 