### PR TITLE
Pass id to AR::Base find, not AR::Base objs

### DIFF
--- a/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb
@@ -30,7 +30,7 @@ describe ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume do
         }
 
         with_aws_stubbed(stubbed_responses) do
-          expect(CloudVolume.create_volume(ebs, options)).to be_truthy
+          expect(CloudVolume.create_volume(ebs.id, options)).to be_truthy
         end
       end
     end


### PR DESCRIPTION
On Rails 5.1, this raises an ArgumentError.

```
  1) ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume cloud volume operations .raw_create_volume creates a volume
     Failure/Error: ext_management_system = ExtManagementSystem.find(ems_id)

     ArgumentError:
       You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
     # ./spec/manageiq/app/models/cloud_volume.rb:55:in `create_volume'
     # ./spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb:33:in `block (5 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/amazon/aws_helper.rb:9:in `with_aws_stubbed'
     # ./spec/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_spec.rb:32:in `block (4 levels) in <top (required)>'
```