### PR TITLE
Remove allow_delete logic

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb
@@ -35,14 +35,6 @@ class ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair < ManageIQ::Provide
   end
 
   def validate_delete_key_pair
-    {:available => allow_delete?, :message => nil}
-  end
-
-  private
-
-  # Returns false if an auth_key is available true if not.
-  # Meaning we can delete if there is no auth_key.
-  def allow_delete?
-    !self.auth_key.present?
+    {:available => true, :message => nil}
   end
 end


### PR DESCRIPTION
This PR is reverting https://github.com/ManageIQ/manageiq-providers-amazon/pull/457 as that is causing an issue in deleting auth keys created, without a public key.

Also https://github.com/ManageIQ/manageiq-providers-amazon/pull/457 doesn't even seem to solve the issue of the bug it was suposed to be fixing.

This PR fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1718833

/cc @AlexanderZagaynov @agrare 