### PR TITLE
Add JSON-Schema create-params and a common Validate Credentials API

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -123,10 +123,10 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     {
       :title  => "Configure AWS",
       :fields => [
-        {:component => "text-field", :name => "role",                   :type => "hidden", :initialValue => "ec2"},
-        {:component => "text-field", :name => "region",                 :label => "Region"},
-        {:component => "text-field", :name => "endpoints.ec2.username", :label => "Access Key"},
-        {:component => "text-field", :name => "endpoints.ec2.password", :label => "Secret Key", :type => "password"}
+        {:component => "text-field", :name => "role",              :type => "hidden", :initialValue => "ec2"},
+        {:component => "text-field", :name => "region",            :label => "Region"},
+        {:component => "text-field", :name => "access_key",        :label => "Access Key"},
+        {:component => "text-field", :name => "secret_access_key", :label => "Secret Key", :type => "password"}
       ]
     }
   end

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -124,12 +124,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
       :title  => "Configure AWS",
       :fields => [
         {
-          :component    => "text-field",
-          :name         => "role",
-          :type         => "hidden",
-          :initialValue => "ec2"
-        },
-        {
           :component  => "text-field",
           :name       => "region",
           :label      => "Region",
@@ -138,14 +132,14 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
         },
         {
           :component  => "text-field",
-          :name       => "access_key",
+          :name       => "endpoints.default.access_key",
           :label      => "Access Key",
           :isRequired => true,
           :validate   => [{:type => "required-validator"}]
         },
         {
           :component  => "text-field",
-          :name       => "secret_access_key",
+          :name       => "endpoints.default.secret_access_key",
           :label      => "Secret Key",
           :type       => "password",
           :isRequired => true,
@@ -153,12 +147,12 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
         },
         {
           :component => "text-field",
-          :name      => "proxy_uri",
+          :name      => "endpoints.default.proxy_uri",
           :label     => "Proxy URI"
         },
         {
           :component => "text-field",
-          :name      => "assume_role",
+          :name      => "endpoints.default.assume_role",
           :label     => "Assume Role"
         }
       ]

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -119,6 +119,18 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     Settings.ems.ems_amazon.blacklisted_event_names
   end
 
+  def self.params_for_create
+    {
+      :title  => "Configure AWS",
+      :fields => [
+        {:component => "text-field", :name => "role",         :type => "hidden", :initialValue => "ec2"},
+        {:component => "text-field", :name => "region",       :label => "Region"},
+        {:component => "text-field", :name => "ec2_username", :label => "Access Key"},
+        {:component => "text-field", :name => "ec2_password", :label => "Secret Key", :type => "password"}
+      ]
+    }
+  end
+
   def supported_auth_types
     %w(default smartstate_docker)
   end

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -124,42 +124,42 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
       :title  => "Configure AWS",
       :fields => [
         {
-          :component => "text-field",
-          :name => "role",
-          :type => "hidden",
+          :component    => "text-field",
+          :name         => "role",
+          :type         => "hidden",
           :initialValue => "ec2"
         },
         {
-          :component => "text-field",
-          :name => "region",
-          :label => "Region",
+          :component  => "text-field",
+          :name       => "region",
+          :label      => "Region",
           :isRequired => true,
-          :validate => [{:type => "required-validator"}]
+          :validate   => [{:type => "required-validator"}]
         },
         {
-          :component => "text-field",
-          :name => "access_key",
-          :label => "Access Key",
+          :component  => "text-field",
+          :name       => "access_key",
+          :label      => "Access Key",
           :isRequired => true,
-          :validate => [{:type => "required-validator"}]
+          :validate   => [{:type => "required-validator"}]
         },
         {
-          :component => "text-field",
-          :name => "secret_access_key",
-          :label => "Secret Key",
-          :type => "password",
+          :component  => "text-field",
+          :name       => "secret_access_key",
+          :label      => "Secret Key",
+          :type       => "password",
           :isRequired => true,
-          :validate => [{:type => "required-validator"}]
+          :validate   => [{:type => "required-validator"}]
         },
         {
           :component => "text-field",
-          :name => "proxy_uri",
-          :label => "Proxy URI"
+          :name      => "proxy_uri",
+          :label     => "Proxy URI"
         },
         {
           :component => "text-field",
-          :name => "assume_role",
-          :label => "Assume Role"
+          :name      => "assume_role",
+          :label     => "Assume Role"
         }
       ]
     }

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -119,44 +119,46 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     Settings.ems.ems_amazon.blacklisted_event_names
   end
 
+  PARAMS_FOR_CREATE = {
+    :title  => "Configure AWS",
+    :fields => [
+      {
+        :component  => "text-field",
+        :name       => "region",
+        :label      => "Region",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component  => "text-field",
+        :name       => "endpoints.default.access_key",
+        :label      => "Access Key",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component  => "text-field",
+        :name       => "endpoints.default.secret_access_key",
+        :label      => "Secret Key",
+        :type       => "password",
+        :isRequired => true,
+        :validate   => [{:type => "required-validator"}]
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.default.proxy_uri",
+        :label     => "Proxy URI"
+      },
+      {
+        :component => "text-field",
+        :name      => "endpoints.default.assume_role",
+        :label     => "Assume Role"
+      }
+    ]
+  }.freeze
+
   def self.params_for_create
-    {
-      :title  => "Configure AWS",
-      :fields => [
-        {
-          :component  => "text-field",
-          :name       => "region",
-          :label      => "Region",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
-        },
-        {
-          :component  => "text-field",
-          :name       => "endpoints.default.access_key",
-          :label      => "Access Key",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
-        },
-        {
-          :component  => "text-field",
-          :name       => "endpoints.default.secret_access_key",
-          :label      => "Secret Key",
-          :type       => "password",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
-        },
-        {
-          :component => "text-field",
-          :name      => "endpoints.default.proxy_uri",
-          :label     => "Proxy URI"
-        },
-        {
-          :component => "text-field",
-          :name      => "endpoints.default.assume_role",
-          :label     => "Assume Role"
-        }
-      ]
-    }
+    PARAMS_FOR_CREATE
   end
 
   def supported_auth_types

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -123,10 +123,44 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     {
       :title  => "Configure AWS",
       :fields => [
-        {:component => "text-field", :name => "role",              :type => "hidden", :initialValue => "ec2"},
-        {:component => "text-field", :name => "region",            :label => "Region"},
-        {:component => "text-field", :name => "access_key",        :label => "Access Key"},
-        {:component => "text-field", :name => "secret_access_key", :label => "Secret Key", :type => "password"}
+        {
+          :component => "text-field",
+          :name => "role",
+          :type => "hidden",
+          :initialValue => "ec2"
+        },
+        {
+          :component => "text-field",
+          :name => "region",
+          :label => "Region",
+          :isRequired => true,
+          :validate => [{:type => "required-validator"}]
+        },
+        {
+          :component => "text-field",
+          :name => "access_key",
+          :label => "Access Key",
+          :isRequired => true,
+          :validate => [{:type => "required-validator"}]
+        },
+        {
+          :component => "text-field",
+          :name => "secret_access_key",
+          :label => "Secret Key",
+          :type => "password",
+          :isRequired => true,
+          :validate => [{:type => "required-validator"}]
+        },
+        {
+          :component => "text-field",
+          :name => "proxy_uri",
+          :label => "Proxy URI"
+        },
+        {
+          :component => "text-field",
+          :name => "assume_role",
+          :label => "Assume Role"
+        }
       ]
     }
   end

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -123,10 +123,10 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     {
       :title  => "Configure AWS",
       :fields => [
-        {:component => "text-field", :name => "role",         :type => "hidden", :initialValue => "ec2"},
-        {:component => "text-field", :name => "region",       :label => "Region"},
-        {:component => "text-field", :name => "ec2_username", :label => "Access Key"},
-        {:component => "text-field", :name => "ec2_password", :label => "Secret Key", :type => "password"}
+        {:component => "text-field", :name => "role",                   :type => "hidden", :initialValue => "ec2"},
+        {:component => "text-field", :name => "region",                 :label => "Region"},
+        {:component => "text-field", :name => "endpoints.ec2.username", :label => "Access Key"},
+        {:component => "text-field", :name => "endpoints.ec2.password", :label => "Secret Key", :type => "password"}
       ]
     }
   end

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -65,6 +65,8 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     def validate_credentials(args)
       region = args["region"]
       ec2_endpoint = args.dig("endpoints", "ec2")
+      raise MiqException::MiqInvalidCredentialsError, _("Provided credentials are invalid") if ec2_endpoint.nil?
+
       raw_connect(ec2_endpoint["access_key"], ec2_endpoint["secret_access_key"], "ec2", region)
     end
 

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -51,6 +51,23 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     # Connections
     #
 
+    # Validate Credentials
+    # args:
+    # {
+    #   "region" => "",
+    #   "endpoints" => {
+    #     "ec2" => {
+    #       "access_key" => "",
+    #       "secret_access_key" => "",
+    #     }
+    #   }
+    # }
+    def validate_credentials(args)
+      region = args["region"]
+      ec2_endpoint = args.dig("endpoints", "ec2")
+      raw_connect(ec2_endpoint["access_key"], ec2_endpoint["secret_access_key"], "ec2", region)
+    end
+
     def raw_connect(access_key_id, secret_access_key, service, region,
                     proxy_uri = nil, validate = false, uri = nil, assume_role: nil)
 

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -54,13 +54,15 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     # Validate Credentials
     # args:
     # {
-    #   "region" => "",
     #   "access_key" => "",
-    #   "secret_access_key" => ""
+    #   "secret_access_key" => "",
+    #   "region" => "",
+    #   "proxy_uri => "",
+    #   "assume_role" => ""
     # }
     def validate_credentials(args)
       raw_connect(args["access_key"], args["secret_access_key"], "ec2",
-                  args["region"], args["proxy_uri"], assume_role: args["assume_role"])
+                  args["region"], args["proxy_uri"], :assume_role => args["assume_role"])
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -68,10 +68,9 @@ module ManageIQ::Providers::Amazon::ManagerMixin
       region           = args["region"]
       default_endpoint = args.dig("endpoints", "default")
 
-      access_key        = default_endpoint&.dig("access_key")
-      secret_access_key = default_endpoint&.dig("secret_access_key")
-      proxy_uri         = default_endpoint&.dig("proxy_uri")
-      assume_role       = default_endpoint&.dig("assume_role")
+      access_key, secret_access_key, proxy_uri, assume_role = default_endpoint&.values_at(
+        "access_key", "secret_access_key", "proxy_uri", "assume_role"
+      )
 
       raw_connect(access_key, secret_access_key, "ec2", region, proxy_uri, :assume_role => assume_role)
     end

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -54,15 +54,26 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     # Validate Credentials
     # args:
     # {
-    #   "access_key" => "",
-    #   "secret_access_key" => "",
     #   "region" => "",
-    #   "proxy_uri => "",
-    #   "assume_role" => ""
+    #   "endpoints" => {
+    #     "default" => {
+    #       "access_key" => "",
+    #       "secret_access_key" => "",
+    #       "proxy_uri => "",
+    #       "assume_role" => ""
+    #     }
+    #   }
     # }
     def validate_credentials(args)
-      raw_connect(args["access_key"], args["secret_access_key"], "ec2",
-                  args["region"], args["proxy_uri"], :assume_role => args["assume_role"])
+      region           = args["region"]
+      default_endpoint = args.dig("endpoints", "default")
+
+      access_key        = default_endpoint&.dig("access_key")
+      secret_access_key = default_endpoint&.dig("secret_access_key")
+      proxy_uri         = default_endpoint&.dig("proxy_uri")
+      assume_role       = default_endpoint&.dig("assume_role")
+
+      raw_connect(access_key, secret_access_key, "ec2", region, proxy_uri, :assume_role => assume_role)
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -55,19 +55,11 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     # args:
     # {
     #   "region" => "",
-    #   "endpoints" => {
-    #     "ec2" => {
-    #       "access_key" => "",
-    #       "secret_access_key" => "",
-    #     }
-    #   }
+    #   "access_key" => "",
+    #   "secret_access_key" => ""
     # }
     def validate_credentials(args)
-      region = args["region"]
-      ec2_endpoint = args.dig("endpoints", "ec2")
-      raise MiqException::MiqInvalidCredentialsError, _("Provided credentials are invalid") if ec2_endpoint.nil?
-
-      raw_connect(ec2_endpoint["access_key"], ec2_endpoint["secret_access_key"], "ec2", region)
+      raw_connect(args["access_key"], args["secret_access_key"], "ec2", args["region"])
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -59,7 +59,8 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     #   "secret_access_key" => ""
     # }
     def validate_credentials(args)
-      raw_connect(args["access_key"], args["secret_access_key"], "ec2", args["region"])
+      raw_connect(args["access_key"], args["secret_access_key"], "ec2",
+                  args["region"], args["proxy_uri"], assume_role: args["assume_role"])
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,


### PR DESCRIPTION
Add a set of parameters required by the UI to drive their data-driven-forms and implement the common validate_credentials API instead of raw_connect.