### PR TITLE
Update attrs deprecation

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision/state_machine.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Amazon::CloudManager::Provision::StateMachine
     update_and_notify_parent(:message => message)
 
     destination.set_custom_field("Name", dest_name)
-    destination.update_attributes(:name => dest_name)
+    destination.update(:name => dest_name)
 
     super
   end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
@@ -7,6 +7,6 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
     with_provider_object(&:terminate)
-    update_attributes!(:raw_power_state => "shutting-down")
+    update!(:raw_power_state => "shutting-down")
   end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/guest.rb
@@ -11,6 +11,6 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations::Guest
   def raw_reboot_guest
     with_provider_object(&:reboot)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "shutting_down")
+    self.update!(:raw_power_state => "shutting_down")
   end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/power.rb
@@ -11,12 +11,12 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations::Power
   def raw_start
     with_provider_object(&:start)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "powering_up")
+    self.update!(:raw_power_state => "powering_up")
   end
 
   def raw_stop
     with_provider_object(&:stop)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "shutting_down")
+    self.update!(:raw_power_state => "shutting_down")
   end
 end


### PR DESCRIPTION
 update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.