### PR TITLE
Switch find_by_* to lookup_by_

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -237,7 +237,7 @@ describe Authenticator::Amazon do
         it "immediately completes the task" do
           task_id = authenticate
           task = MiqTask.find(task_id)
-          expect(User.find_by_userid(task.userid)).to eq(local_user)
+          expect(User.lookup_by_userid(task.userid)).to eq(local_user)
         end
 
         context "with no corresponding Amazon IAM user" do
@@ -398,7 +398,7 @@ describe Authenticator::Amazon do
         it "immediately completes the task" do
           task_id = authenticate
           task = MiqTask.find(task_id)
-          user = User.find_by_userid(task.userid)
+          user = User.lookup_by_userid(task.userid)
           expect(user.userid).to eq(username)
           expect(user.email).to be_nil
         end


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_*
Switching the callers in this repo to the lookup_by_ methods.

Depend on ManageIQ/manageiq#19313