### PR TITLE
Remove zanata.xml

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://translate.zanata.org/</url>
-  <project>manageiq-providers-amazon</project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
The file is no longer needed: we don't do per-plugin translations anymore.

@miq-bot add_label cleanup