### PR TITLE
Remove zanata from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Security](https://hakiri.io/github/ManageIQ/manageiq-providers-amazon/master.svg)](https://hakiri.io/github/ManageIQ/manageiq-providers-amazon/master)
 
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq-providers-amazon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/manageiq-providers-amazon)
 
 ManageIQ plugin for the Amazon provider.
 


### PR DESCRIPTION
We no longer need to mention zanata in plugins:
* we no longer use Zanata
* we no longer do per-plugin translations

@miq-bot add_label cleanup

