### PR TITLE
Optionally symlink a core repo in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,9 +1,17 @@
 #!/usr/bin/env ruby
 require 'pathname'
+require 'fileutils'
 
 gem_root = Pathname.new(__dir__).join("..")
+spec_manageiq = gem_root.join("spec/manageiq")
 
-unless gem_root.join("spec/manageiq").exist?
+if ENV.key?("MANAGEIQ_REPO")
+  manageiq_repo = Pathname.new(ENV["MANAGEIQ_REPO"])
+  puts "== Symlinking spec/manageiq to #{manageiq_repo}"
+
+  FileUtils.rm_rf(spec_manageiq.expand_path)
+  FileUtils.ln_s(manageiq_repo.expand_path, spec_manageiq.expand_path)
+elsif !spec_manageiq.exist?
   puts "== Cloning manageiq sample app =="
   system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
 end


### PR DESCRIPTION
If a MANAGEIQ_REPO env var is passed to bin/setup then symlink that repo
to spec/manageiq instead of cloning a new copy.  This makes it possible
to test cross-repo changes with a plugin.