### PR TITLE
Remove unused sub-manager refresh workers

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_worker.rb
@@ -1,7 +1,0 @@
-class ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_amazon_network
-  end
-end

--- a/app/models/manageiq/providers/amazon/network_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/network_manager/refresh_worker/runner.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_worker.rb
@@ -1,7 +1,0 @@
-class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_amazon_ebs_storage
-  end
-end

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/refresh_worker/runner.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker::Runner <
-  ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end


### PR DESCRIPTION
Refresh of network and storage managers except for S3is handled
by the cloud manager refresh worker

cc @agrare 
see also: https://github.com/ManageIQ/manageiq/pull/19524