### PR TITLE
Add worker kill priority to the AgentCoordinatorWorker

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
@@ -13,4 +13,8 @@ class ManageIQ::Providers::Amazon::AgentCoordinatorWorker < MiqWorker
     # All cloud managers will share the same agent coordinator
     super.any? ? ["ems_agent_coordinator"] : []
   end
+
+  def self.kill_priority
+    MiqWorkerType::KILL_PRIORITY_REFRESH_WORKERS
+  end
 end


### PR DESCRIPTION
This is needed in order to seed the MiqWorkerType model