### PR TITLE
Subclass CloudManager metrics capture

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ManageIQ::Providers::Amazon::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+class ManageIQ::Providers::Amazon::CloudManager::MetricsCapture < ManageIQ::Providers::CloudManager::MetricsCapture
   INTERVALS = [5.minutes.freeze, 1.minute.freeze].freeze
 
   COUNTER_INFO = [

--- a/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
@@ -6,6 +6,12 @@ describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
   let(:ems) { FactoryBot.create(:ems_amazon_with_authentication) }
   let(:vm)  { FactoryBot.build(:vm_amazon, :ems_ref => vm_name, :ext_management_system => ems) }
 
+  context "#perf_capture_object" do
+    it "returns the correct class" do
+      expect(vm.perf_capture_object.class).to eq(described_class)
+    end
+  end
+
   context "#perf_collect_metrics" do
     it "raises an error when no EMS is defined" do
       vm = FactoryBot.build(:vm_amazon, :ext_management_system => nil)


### PR DESCRIPTION
amazon is a cloud metrics capture class. subclassing the proper parent

part of https://github.com/ManageIQ/manageiq/pull/19684