### PR TITLE
Make the DDF fields more similar to the current form's layout + i18n

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -122,55 +122,61 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   def self.params_for_create
     @params_for_create ||= {
-      :title  => "Configure AWS",
       :fields => [
         {
-          :component  => "text-field",
-          :name       => "name",
-          :label      => "Name",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
-        },
-        {
-          :component  => "text-field",
-          :name       => "zone_name",
-          :label      => "Zone",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
-        },
-        {
-          :component  => "text-field",
+          :component  => "select-field",
           :name       => "provider_region",
-          :label      => "Region",
+          :label      => _("Region"),
           :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
+          :validate   => [{:type => "required-validator"}],
+          :options    => ManageIQ::Providers::Amazon::Regions.all.sort_by { |r| r[:description] }.map do |region|
+            {
+              :label => region[:description],
+              :value => region[:name]
+            }
+          end
         },
         {
-          :component  => "text-field",
-          :name       => "endpoints.default.userid",
-          :label      => "Access Key",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
+          :component => 'sub-form',
+          :name      => 'endpoints',
+          :title     => _("Endpoint"),
+          :fields    => [
+            {
+              :component              => 'validate-provider-credentials',
+              :name                   => 'aws-endpoint-valid',
+              :validationDependencies => %w[zone_name provider_region],
+              :fields                 => [
+                {
+                  :component => "text-field",
+                  :name      => "endpoints.default.url",
+                  :label     => _("Endpoint URL"),
+                },
+                {
+                  :component => "text-field",
+                  :name      => "endpoints.default.service_account",
+                  :label     => _("Assume role ARN"),
+                },
+                {
+                  :component  => "text-field",
+                  :name       => "endpoints.default.userid",
+                  :label      => _("Access Key ID"),
+                  :helperText => _("Should have privileged access, such as root or administrator."),
+                  :isRequired => true,
+                  :validate   => [{:type => "required-validator"}]
+                },
+                {
+                  :component  => "text-field",
+                  :name       => "endpoints.default.password",
+                  :label      => _("Secret Access Key"),
+                  :type       => "password",
+                  :isRequired => true,
+                  :validate   => [{:type => "required-validator"}]
+                },
+              ],
+            },
+          ],
         },
-        {
-          :component  => "text-field",
-          :name       => "endpoints.default.password",
-          :label      => "Secret Key",
-          :type       => "password",
-          :isRequired => true,
-          :validate   => [{:type => "required-validator"}]
-        },
-        {
-          :component => "text-field",
-          :name      => "endpoints.default.proxy_uri",
-          :label     => "Proxy URI"
-        },
-        {
-          :component => "text-field",
-          :name      => "endpoints.default.service_account",
-          :label     => "Assume Role"
-        }
-      ]
+      ],
     }.freeze
   end
 


### PR DESCRIPTION
This is a followup based on discussions with @hyperkid123 and earlier in Mahwah with @Fryguy and @agrare. I removed the `name` and `zone` fields as they will be provided by the add provider form in order to decrease redundancy among forms. We can still reverse out from this solution, but in any case, the ordering of fields should and will be a little different. Common stuff has to go first, we can't implement jumping inconsistencies in DDF nicely.

I also added i18n calls on the strings, so @mzazrivec can consume them.

**Old form:**
![Screenshot from 2020-02-04 20-39-59](https://user-images.githubusercontent.com/649130/73780340-97724d00-478e-11ea-920d-b1f3926208a3.png)

**New form:**
![Screenshot from 2020-02-05 20-47-16](https://user-images.githubusercontent.com/649130/73877951-f0f37e00-4859-11ea-850f-a9995b9a9267.png)

Note that the bottom screenshot doesn't show the `name`, `type` and `zone` fields in the correct order, because I'm using the schema from https://github.com/ManageIQ/manageiq-ui-classic/pull/6402.

There are still stuff missing:
* [x] Validation button
* [x] ~~Dynamically~~ loading the values for the region
* [x] The endpoint URL field's name
* [x] The proxy field that was in the DDF schema but not in the old implementation

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818
@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @Fryguy 