### PR TITLE
Fix verify_credentials always returning true

### DIFF
--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -73,7 +73,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
       )
       secret_access_key = MiqPassword.try_decrypt(secret_access_key)
 
-      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, :assume_role => assume_role)
+      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => assume_role)
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,


### PR DESCRIPTION
The verify_credentials method wasn't checking that the AWS connection
was able to execute any commands.

Fixes https://github.com/ManageIQ/manageiq-providers-amazon/issues/587