### PR TITLE
Rename aws-endpoint-valid to endpoints.default.valid in DDF schema

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -143,7 +143,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
           :fields    => [
             {
               :component              => 'validate-provider-credentials',
-              :name                   => 'aws-endpoint-valid',
+              :name                   => 'endpoints.default.valid',
               :validationDependencies => %w[zone_name provider_region],
               :fields                 => [
                 {


### PR DESCRIPTION
I missed this from https://github.com/ManageIQ/manageiq-providers-amazon/pull/586 sorry :sweat_smile: 

@miq-bot assign @agrare 