### PR TITLE
Require aws-sdk-core in aws spec helper

### DIFF
--- a/spec/models/manageiq/providers/amazon/aws_helper.rb
+++ b/spec/models/manageiq/providers/amazon/aws_helper.rb
@@ -1,4 +1,5 @@
 def with_aws_stubbed(stub_responses_per_service)
+  require "aws-sdk-core"
   stub_responses_per_service.each do |service, stub_responses|
     if Aws.config.dig(service, :stub_responses).present?
       raise "Aws.config[#{service}][:stub_responses] already set"


### PR DESCRIPTION
We are going through Aws.config to look for services without requiring anything to pull in Aws (which is defined in aws-sdk-core).