### PR TITLE
Include authtype when creating provider through DDF/API

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -186,7 +186,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     params[:zone] = Zone.find_by(:name => params.delete("zone_name"))
     new(params).tap do |ems|
       endpoints.each do |authtype, endpoint|
-        ems.authentications.new(endpoint)
+        ems.authentications.new(endpoint.merge(:authtype => authtype))
       end
 
       ems.save!


### PR DESCRIPTION
With the current codebase, the `authtype` for the credentials is set to `nil`, while it should be default. When creating the provider through the old forms, it is being set to `default`.

@miq-bot assign @agrare 