### PR TITLE
Delay load ssa support

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -4,7 +4,6 @@ require 'net/scp'
 require 'tempfile'
 require 'linux_admin'
 require 'awesome_spawn'
-require 'amazon_ssa_support'
 
 class ManageIQ::Providers::Amazon::AgentCoordinator
   include Vmdb::Logging
@@ -15,6 +14,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
   WORK_DIR  = "/opt/ssa_container".freeze
 
   def initialize(ems)
+    require 'amazon_ssa_support'
     @ems = ems
 
     # List of active agent ids

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -1,6 +1,5 @@
 module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
   extend ActiveSupport::Concern
-  require 'amazon_ssa_support'
   require 'xml/xml_utils'
   require 'scanning_operations_mixin'
 
@@ -26,6 +25,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
   end
 
   def perform_metadata_scan(ost)
+    require 'amazon_ssa_support'
     connect_args           = {}
     connect_args[:service] = :SQS
     @sqs = ext_management_system.connect(connect_args)
@@ -61,6 +61,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
   end
 
   def perform_metadata_sync(ost)
+    require 'amazon_ssa_support'
     sync_stashed_metadata(ost)
   end
 


### PR DESCRIPTION
We don't need ssa support when we load the provider.  We can load this when we
need it.  Just loading the Amazon provider was costing 1-2 seconds, 20-40 MB depending on
what files were already loaded, and loaded an additional 512 files.

Before:

```
irb(main):001:0> ManageIQ::Providers::Amazon::AgentCoordinator
=> ManageIQ::Providers::Amazon::AgentCoordinator
irb(main):002:0> $LOADED_FEATURES.length
=> 3539

209.5 MB rails console.
```

After:

```
irb(main):001:0> ManageIQ::Providers::Amazon::AgentCoordinator
=> ManageIQ::Providers::Amazon::AgentCoordinator
irb(main):002:0> $LOADED_FEATURES.length
=> 3027

162.2 MB rails console.
```

Note, I needed this hack to load rails console from this repo's directory:

```diff
diff --git a/bin/rails b/bin/rails
index 183a93e..e0ba6af 100755
--- a/bin/rails
+++ b/bin/rails
@@ -4,6 +4,8 @@

 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/manageiq/providers/amazon/engine', __FILE__)
+APP_PATH = File.expand_path('../../spec/manageiq/config/application', __FILE__)
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
```