### PR TITLE
Create ems.endpoints when using create_from_params

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -186,6 +186,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     params[:zone] = Zone.find_by(:name => params.delete("zone_name"))
     new(params).tap do |ems|
       endpoints.each do |authtype, endpoint|
+        url = endpoint.delete("url")
+        ems.endpoints.new(:role => authtype, :url => url)
         ems.authentications.new(endpoint.merge(:authtype => authtype))
       end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_catcher/stream_spec.rb
@@ -1,6 +1,7 @@
 require_relative "../../aws_helper"
 
 require 'aws-sdk-sns'
+require 'aws-sdk-sqs'
 
 describe ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Stream do
   subject do


### PR DESCRIPTION
When using create_from_params make sure to create endpoints as well as
authentications.

https://github.com/ManageIQ/manageiq-providers-amazon/issues/594