### PR TITLE
Adjust the DDF schema to be more similar to the DB schema

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -153,12 +153,12 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
                 },
                 {
                   :component => "text-field",
-                  :name      => "endpoints.default.service_account",
+                  :name      => "authentications.default.service_account",
                   :label     => _("Assume role ARN"),
                 },
                 {
                   :component  => "text-field",
-                  :name       => "endpoints.default.userid",
+                  :name       => "authentications.default.userid",
                   :label      => _("Access Key ID"),
                   :helperText => _("Should have privileged access, such as root or administrator."),
                   :isRequired => true,
@@ -166,7 +166,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
                 },
                 {
                   :component  => "text-field",
-                  :name       => "endpoints.default.password",
+                  :name       => "authentications.default.password",
                   :label      => _("Secret Access Key"),
                   :type       => "password",
                   :isRequired => true,
@@ -182,13 +182,17 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   def self.create_from_params(params)
     endpoints = params.delete("endpoints")
+    authentications = params.delete("authentications")
 
     params[:zone] = Zone.find_by(:name => params.delete("zone_name"))
     new(params).tap do |ems|
       endpoints.each do |authtype, endpoint|
         url = endpoint.delete("url")
         ems.endpoints.new(:role => authtype, :url => url)
-        ems.authentications.new(endpoint.merge(:authtype => authtype))
+      end
+
+      authentications.each do |authtype, authentication|
+        ems.authentications.new(authentication.merge(:authtype => authtype))
       end
 
       ems.save!

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -55,25 +55,25 @@ module ManageIQ::Providers::Amazon::ManagerMixin
     # args:
     # {
     #   "region" => "",
-    #   "endpoints" => {
+    #   "authentications" => {
     #     "default" => {
     #       "access_key" => "",
     #       "secret_access_key" => "",
     #       "proxy_uri => "",
-    #       "assume_role" => ""
+    #       "service_account" => ""
     #     }
     #   }
     # }
     def verify_credentials(args)
       region           = args["provider_region"]
-      default_endpoint = args.dig("endpoints", "default")
+      default_endpoint = args.dig("authentications", "default")
 
-      access_key, secret_access_key, proxy_uri, assume_role = default_endpoint&.values_at(
-        "userid", "password", "proxy_uri", "assume_role"
+      access_key, secret_access_key, proxy_uri, service_account = default_endpoint&.values_at(
+        "userid", "password", "proxy_uri", "service_account"
       )
       secret_access_key = MiqPassword.try_decrypt(secret_access_key)
 
-      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => assume_role)
+      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => service_account)
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,


### PR DESCRIPTION
Providers have two extra underlying models (endpoints and authentications) storing data that we are displaying in the provider forms. In order to be able to pull in the data from the API to the edit provider forms more effectively, the DDF schema fields have to be named properly. 

There's an [API PR](https://github.com/ManageIQ/manageiq-api/pull/741) that allows to load these underlying models for a given provider and there's a [UI PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/6698) that works with these data and prefills them into the form that is described in this PR. 

Of course these changes in the schema required some modifications in the validation and creation methods to have them still working.

https://github.com/ManageIQ/manageiq-ui-classic/pull/6698
https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot assign @agrare 