### PR TITLE
Change provider form password field to a password-field component

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -165,7 +165,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
                   :validate   => [{:type => "required-validator"}]
                 },
                 {
-                  :component  => "text-field",
+                  :component  => "password-field",
                   :name       => "authentications.default.password",
                   :label      => _("Secret Access Key"),
                   :type       => "password",


### PR DESCRIPTION
This component has been [renamed](https://github.com/ManageIQ/manageiq-ui-classic/pull/6704) just to make provider forms and provider developers' life easier. It supports editing and it never contains the actual password.

Hopefully there will be no more schema changes, just the edit method :pray: 

@miq-bot assign @agrare 