### PR TITLE
Retrieve the password from the DB when validating an existing EMS

### DIFF
--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -71,7 +71,10 @@ module ManageIQ::Providers::Amazon::ManagerMixin
       access_key, secret_access_key, proxy_uri, service_account = default_endpoint&.values_at(
         "userid", "password", "proxy_uri", "service_account"
       )
+
       secret_access_key = MiqPassword.try_decrypt(secret_access_key)
+      # Pull out the password from the database if a provider ID is available
+      secret_access_key ||= find(args["id"]).authentication_password('default')
 
       !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => service_account)
     end


### PR DESCRIPTION
When validating an existing provider, we don't want to send down the password to the browser. MartinM already created a component that sorts out this problem, basically the password field is a dummy and if it's untouched, it never gets submitted with the rest of the form. However, this causes issues with the validation.

My solution is to [pass the `id`](https://github.com/ManageIQ/manageiq-api/pull/751) of the provider to the validation task if available and retrieve the password using this ID if there is no submitted password.

@agrare @Fryguy we talked about this in Mahwah, what do you think? It's a little problemmatic that the retrieval is implemented in the provider, but the endpoints are different and some providers even have more than one, so there's no simple way to do this.

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818