### PR TITLE
Fall back with default endpoint in DDF if nothing comes from the API

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -181,14 +181,13 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   end
 
   def self.create_from_params(params)
-    endpoints = params.delete("endpoints")
+    endpoints = params.delete("endpoints") || {'default' => {}} # Fall back to an empty default endpoint
     authentications = params.delete("authentications")
 
     params[:zone] = Zone.find_by(:name => params.delete("zone_name"))
     new(params).tap do |ems|
       endpoints.each do |authtype, endpoint|
-        url = endpoint.delete("url")
-        ems.endpoints.new(:role => authtype, :url => url)
+        ems.endpoints.new(endpoint.merge(:role => authtype))
       end
 
       authentications.each do |authtype, authentication|


### PR DESCRIPTION
Newly DDF doesn't want to send me the empty object for the endpoints, so I created a fallback to make sure that the default one is always created.

@miq-bot assign @agrare 