### PR TITLE
Fix metrics_capture_spec vcr cassettes

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
@@ -113,7 +113,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
       let(:vm) { FactoryBot.create(:vm_amazon, :ext_management_system => ems) }
 
       subject do
-        with_vcr_data { vm.perf_capture('realtime') }
+        with_vcr_data { vm.perf_capture('realtime', 4.hours.ago) }
         vm.metrics.reload.last
       end
 


### PR DESCRIPTION
The AWS Metrics Capture is using end_time - 4.hours which is different from the core 4.hours.ago.utc.beginning_of_day default that core is now using.