### PR TITLE
Remove invalid partials in Amazon specs

### DIFF
--- a/spec/models/manageiq/providers/amazon/aws_stubs.rb
+++ b/spec/models/manageiq/providers/amazon/aws_stubs.rb
@@ -50,14 +50,6 @@ module AwsStubs
       receive(:delete).and_raise("Not allowed delete operation detected. The probable cause is a wrong manager_ref"\
                                  " causing create&delete instead of update")
     )
-    allow_any_instance_of(ApplicationRecord).to(
-      receive(:disconnect_inv).and_raise("Not allowed delete operation detected. The probable cause is a wrong"\
-                                         " manager_ref causing create&disconnect_inv instead of update")
-    )
-    allow_any_instance_of(ActiveRecord::Associations::CollectionProxy).to(
-      receive(:disconnect_inv).and_raise("Not allowed delete operation detected. The probable cause is a wrong"\
-                                         "manager_ref causing create&disconnect_inv instead of update")
-    )
   end
 
   def mocked_floating_ips


### PR DESCRIPTION
This removes a couple invalid partials that causes errors if strict partial validation is enabled. In this case, objects are stubbing methods that they don't actually implement. With these removed, the specs still pass.