### PR TITLE
Check instance exists before getting status during provisioning

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision/cloning.rb
@@ -2,13 +2,11 @@ module ManageIQ::Providers::Amazon::CloudManager::Provision::Cloning
   def do_clone_task_check(clone_task_ref)
     source.with_provider_connection(:sdk_v2 => true) do |ec2|
       instance = ec2.instance(clone_task_ref)
-      if instance.exists?
-        status   = instance.state.name.to_sym
-        return true if status == :running
-        return false, status
-      else
-        return false, :pending
-      end
+      return false, :pending unless instance.exists?
+
+      status = instance.state.name.to_sym
+      return true if status == :running
+      return false, status
     end
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision/cloning.rb
@@ -2,9 +2,13 @@ module ManageIQ::Providers::Amazon::CloudManager::Provision::Cloning
   def do_clone_task_check(clone_task_ref)
     source.with_provider_connection(:sdk_v2 => true) do |ec2|
       instance = ec2.instance(clone_task_ref)
-      status   = instance.state.name.to_sym
-      return true if status == :running
-      return false, status
+      if instance.exists?
+        status   = instance.state.name.to_sym
+        return true if status == :running
+        return false, status
+      else
+        return false, :pending
+      end
     end
   end
 


### PR DESCRIPTION
During AWS provisioning, I have been experiencing  intermittent errors indicating invalid instance IDs ( longer trace attached ):

`MIQ(ManageIQ::Providers::Amazon::CloudManager::Provision#provision_error) [[Aws::EC2::Errors::InvalidInstanceIDNotFound]: The instance ID 'i-xxxxxxxxxxxx' does not exist] encountered during phase [poll_clone_complete]`

These requests did not include additional network interfaces. The solution posted to a similar issue - https://access.redhat.com/solutions/3638601 - did not help in my case.

This appears to be because the clone_task_check did not check if the instance existed before getting instance status. Since implementing this PR in my environment, I have not encountered errors during AWS provisioning.

[aws-prov-trace-20200228-1258.log](https://github.com/ManageIQ/manageiq-providers-amazon/files/4299432/aws-prov-trace-20200228-1258.log)
