### PR TITLE
Remove the overridden persister initialize

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/persister.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister.rb
@@ -8,19 +8,6 @@ class ManageIQ::Providers::Amazon::Inventory::Persister < ManageIQ::Providers::I
   # Accessed by cloud parser.
   attr_reader :tag_mapper
 
-  # @param manager [ManageIQ::Providers::BaseManager] A manager object
-  # @param target [Object] A refresh Target object
-  # @param collector [ManageIQ::Providers::Inventory::Collector] A Collector object
-  def initialize(manager, target = nil, collector = nil)
-    @manager   = manager
-    @target    = target
-    @collector = collector
-
-    @collections = {}
-
-    initialize_inventory_collections
-  end
-
   protected
 
   # TODO: this reads whole table ContainerLabelTagMapping.all.

--- a/app/models/manageiq/providers/amazon/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/definitions/cloud_collections.rb
@@ -58,7 +58,6 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::CloudColl
   def add_key_pairs(extra_properties = {})
     add_collection(cloud, :key_pairs, extra_properties) do |builder|
       builder.add_properties(:model_class => ::ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair)
-      builder.add_properties(:manager_uuids => name_references(:key_pairs)) if targeted?
     end
   end
 end


### PR DESCRIPTION
There was a pointless overridden Persister#initialize method and manager_uuids for key_pairs that are already added by the builder