### PR TITLE
Force pagination of results for V3 library

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -354,7 +354,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
     vpcs = validated_vpcs
     raise "Smartstate analysis needs a VPC whose enableDnsSupport/enableDnsHostnames are true and valid gateway/route setting!" if vpcs.empty?
 
-    ec2.client.describe_availability_zones.availability_zones.each do |availability_zone|
+    ec2.client.describe_availability_zones.flat_map(&:availability_zones).each do |availability_zone|
       vpcs.each do |vpc|
         subnet = get_subnets(availability_zone.zone_name, vpc.vpc_id).try(:first)
         return subnet if subnet
@@ -470,7 +470,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
         :name   => "group-name",
         :values => [group_name]
       }]
-    ).security_groups.first
+    ).flat_map(&:security_groups).first
     return security_group.group_id unless security_group.nil?
 
     # create security group if not exist
@@ -528,7 +528,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
           :values => [vpc_id]
         }
       ]
-    ).subnets
+    ).flat_map(&:subnets)
   end
 
   # possible RHEL image name: values: [ "RHEL-7.3_HVM_GA*" ]
@@ -538,7 +538,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
         :name   => "name",
         :values => [image_name]
       }]
-    ).images.first
+    ).flat_map(&:images).first
     raise("Unable to find AMI Image #{image_name} to launch Smartstate agent") if image.nil?
 
     _log.info("AMI Image: #{image_name} [#{image.image_id}] is used to launch smartstate agent.")

--- a/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb
@@ -190,7 +190,7 @@ class ManageIQ::Providers::Amazon::CloudManager::MetricsCapture < ManageIQ::Prov
     counters, = Benchmark.realtime_block(:capture_counters) do
       filter = [{ :name => "InstanceId", :value => target.ems_ref }]
       data = cloud_watch.client.list_metrics(:dimensions => filter)
-      data.metrics.select { |m| m.metric_name.in?(COUNTER_NAMES) }
+      data.flat_map(&:metrics).select { |m| m.metric_name.in?(COUNTER_NAMES) }
     end
     counters
   end

--- a/app/models/manageiq/providers/amazon/inventory/collector.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector.rb
@@ -119,7 +119,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector < ManageIQ::Providers::I
     # Taking provisioning_artifacts of described product returns only active artifacts, doing list_provisioning_artifacts
     # we are not able to recognize the active ones. Same with describe_product_as_admin, status is missing. Status is
     # in the describe_provisioning_artifact, but it is wrong (always ACTIVE)
-    artifacts    = aws_service_catalog.client.describe_product(:id => product_id).provisioning_artifacts
+    artifacts    = aws_service_catalog.client.describe_product(:id => product_id).flat_map(&:provisioning_artifacts)
     launch_paths = aws_service_catalog.client.list_launch_paths(:product_id => product_id).flat_map(&:launch_path_summaries)
     parameters_sets = []
 

--- a/app/models/manageiq/providers/amazon/inventory/collector.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector.rb
@@ -120,7 +120,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector < ManageIQ::Providers::I
     # we are not able to recognize the active ones. Same with describe_product_as_admin, status is missing. Status is
     # in the describe_provisioning_artifact, but it is wrong (always ACTIVE)
     artifacts    = aws_service_catalog.client.describe_product(:id => product_id).provisioning_artifacts
-    launch_paths = aws_service_catalog.client.list_launch_paths(:product_id => product_id).launch_path_summaries
+    launch_paths = aws_service_catalog.client.list_launch_paths(:product_id => product_id).flat_map(&:launch_path_summaries)
     parameters_sets = []
 
     launch_paths.each do |launch_path|

--- a/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
@@ -8,11 +8,11 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
   end
 
   def availability_zones
-    hash_collection.new(aws_ec2.client.describe_availability_zones[:availability_zones])
+    hash_collection.new(aws_ec2.client.describe_availability_zones.flat_map(&:availability_zones))
   end
 
   def key_pairs
-    hash_collection.new(aws_ec2.client.describe_key_pairs[:key_pairs])
+    hash_collection.new(aws_ec2.client.describe_key_pairs.flat_map(&:key_pairs))
   end
 
   def private_images
@@ -21,7 +21,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
     @private_images_hashes ||= hash_collection.new(
       aws_ec2.client.describe_images(:owners  => [:self],
                                      :filters => [{:name   => "image-type",
-                                                   :values => ["machine"]}]).images
+                                                   :values => ["machine"]}]).flat_map(&:images)
     ).all
   end
 
@@ -31,7 +31,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
     @shared_images_hashes ||= hash_collection.new(
       aws_ec2.client.describe_images(:executable_users => [:self],
                                      :filters          => [{:name   => "image-type",
-                                                            :values => ["machine"]}]).images
+                                                            :values => ["machine"]}]).flat_map(&:images)
     ).all
   end
 
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
 
     @public_images_hashes ||= hash_collection.new(
       aws_ec2.client.describe_images(:executable_users => [:all],
-                                     :filters          => options.to_hash[:public_images_filters]).images
+                                     :filters          => options.to_hash[:public_images_filters]).flat_map(&:images)
     ).all
   end
 
@@ -49,13 +49,13 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
 
     multi_query(extra_image_references) do |refs|
       hash_collection.new(
-        aws_ec2.client.describe_images(:filters => [{:name => 'image-id', :values => refs}]).images
+        aws_ec2.client.describe_images(:filters => [{:name => 'image-id', :values => refs}]).flat_map(&:images)
       ).all
     end
   end
 
   def stacks
-    hash_collection.new(aws_cloud_formation.client.describe_stacks[:stacks])
+    hash_collection.new(aws_cloud_formation.client.describe_stacks.flat_map(&:stacks))
   end
 
   def stack_resources(stack_name)

--- a/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
@@ -59,7 +59,13 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
   end
 
   def stack_resources(stack_name)
-    stack_resources = aws_cloud_formation.client.list_stack_resources(:stack_name => stack_name).try(:stack_resource_summaries)
+    stack_resources = aws_cloud_formation.client.list_stack_resources(:stack_name => stack_name)
+
+    if stack_resources.respond_to?(:stack_resource_summaries)
+      stack_resources = stack_resources.flat_map(&:stack_resource_summaries)
+    else
+      stack_resources = nil
+    end
 
     hash_collection.new(stack_resources || [])
   end

--- a/app/models/manageiq/providers/amazon/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/network_manager.rb
@@ -1,10 +1,10 @@
 class ManageIQ::Providers::Amazon::Inventory::Collector::NetworkManager < ManageIQ::Providers::Amazon::Inventory::Collector
   def cloud_networks
-    hash_collection.new(aws_ec2.client.describe_vpcs[:vpcs])
+    hash_collection.new(aws_ec2.client.describe_vpcs.flat_map(&:vpcs))
   end
 
   def cloud_subnets
-    hash_collection.new(aws_ec2.client.describe_subnets[:subnets])
+    hash_collection.new(aws_ec2.client.describe_subnets.flat_map(&:subnets))
   end
 
   def security_groups
@@ -12,21 +12,21 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::NetworkManager < Manage
   end
 
   def network_ports
-    hash_collection.new(aws_ec2.client.describe_network_interfaces.network_interfaces)
+    hash_collection.new(aws_ec2.client.describe_network_interfaces.flat_map(&:network_interfaces))
   end
 
   def load_balancers
-    hash_collection.new(aws_elb.client.describe_load_balancers.load_balancer_descriptions)
+    hash_collection.new(aws_elb.client.describe_load_balancers.flat_map(&:load_balancer_descriptions))
   end
 
   def health_check_members(load_balancer_name)
     hash_collection.new(aws_elb.client.describe_instance_health(
       :load_balancer_name => load_balancer_name
-    ).instance_states)
+    ).flat_map(&:instance_states))
   end
 
   def floating_ips
-    hash_collection.new(aws_ec2.client.describe_addresses.addresses)
+    hash_collection.new(aws_ec2.client.describe_addresses.flat_map(&:addresses))
   end
 
   def instances

--- a/app/models/manageiq/providers/amazon/inventory/collector/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/storage_manager/ebs.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::Amazon::Inventory::Collector::StorageManager::Ebs < ManageIQ::Providers::Amazon::Inventory::Collector
   def cloud_volumes
-    hash_collection.new(aws_ec2.client.describe_volumes[:volumes])
+    hash_collection.new(aws_ec2.client.describe_volumes.flat_map(&:volumes))
   end
 
   def cloud_volume_snapshots
-    hash_collection.new(aws_ec2.client.describe_snapshots(:owner_ids => [:self])[:snapshots])
+    hash_collection.new(aws_ec2.client.describe_snapshots(:owner_ids => [:self]).flat_map(&:snapshots))
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/collector/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/storage_manager/s3.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::StorageManager::S3 <
   ManageIQ::Providers::Amazon::Inventory::Collector
 
   def cloud_object_store_containers
-    hash_collection.new(aws_s3.client.list_buckets.buckets)
+    hash_collection.new(aws_s3.client.list_buckets.flat_map(&:buckets))
   end
 
   def cloud_object_store_objects(options = {})

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -183,7 +183,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
     begin
       stack_resources = aws_cloud_formation.client.list_stack_resources(:stack_name => stack_name)
       if stack_resources.respond_to?(:stack_resource_summaries)
-        stack_resources.flat_map(&:stack_resource_summaries)
+        stack_resources = stack_resources.flat_map(&:stack_resource_summaries)
       else
         stack_resources = nil
       end

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -181,7 +181,12 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   # Nested API calls, we want all of them for our filtered list of LBs and Stacks
   def stack_resources(stack_name)
     begin
-      stack_resources = aws_cloud_formation.client.list_stack_resources(:stack_name => stack_name).try(:stack_resource_summaries)
+      stack_resources = aws_cloud_formation.client.list_stack_resources(:stack_name => stack_name)
+      if stack_resources.respond_to?(:stack_resource_summaries)
+        stack_resources.flat_map(&:stack_resource_summaries)
+      else
+        stack_resources = nil
+      end
     rescue Aws::CloudFormation::Errors::ValidationError => _e
       # When Stack was deleted we want to return empty list of resources
     end


### PR DESCRIPTION
The aws-sdk v3 list calls cap out at 100 records per call. You either have to manually iterate using a next token, or explicitly force pagination via an iterator. Since we're dealing with hash results, that means calling `flat_map`.

```
Example using our current test environment:

aws = Aws::EC2::Client.new(region: 'us-east-1')

results1 = aws.describe_instance_types.instance_types
results2 = aws.describe_instance_types.flat_map(&:instance_types)

p results1.size # 100
p results2.size # 258
```

So, this PR goes through and updates the `describe_` and `list_` calls to explicitly use `flat_map`.