### PR TITLE
Fix cloud manager refresher spec described class name

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -2,7 +2,7 @@ require_relative '../aws_helper'
 require_relative '../aws_stubs'
 require_relative '../aws_refresher_spec_common'
 
-describe ManageIQ::Providers::Amazon::NetworkManager::Refresher do
+describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
   include AwsRefresherSpecCommon
   include AwsStubs
 


### PR DESCRIPTION
Should be `CloudManager` instead of `NetworkManager` in spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb.