### PR TITLE
Use `zone_id` instead of `zone_name` in the DDF form

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -144,7 +144,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
             {
               :component              => 'validate-provider-credentials',
               :name                   => 'authentications.default.valid',
-              :validationDependencies => %w[type zone_name provider_region],
+              :validationDependencies => %w[type zone_id provider_region],
               :fields                 => [
                 {
                   :component => "text-field",
@@ -184,7 +184,6 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     endpoints = params.delete("endpoints")
     authentications = params.delete("authentications")
 
-    params[:zone] = Zone.find_by(:name => params.delete("zone_name"))
     new(params).tap do |ems|
       endpoints.each do |authtype, endpoint|
         url = endpoint.delete("url")


### PR DESCRIPTION
We can directly send the `zone_id` instead of sending the `zone_name` and looking it up explicitly when handling the API payload. 

@miq-bot assign @agrare 

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818