### PR TITLE
Use symbols instead of strings for accessing secrets

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
       zone
     end
     after(:create) do |ems|
-      client_id  = Rails.application.secrets.amazon.try(:[], 'client_id') || 'AMAZON_CLIENT_ID'
-      client_key = Rails.application.secrets.amazon.try(:[], 'client_secret') || 'AMAZON_CLIENT_SECRET'
+      client_id  = Rails.application.secrets.amazon.try(:[], :client_id) || 'AMAZON_CLIENT_ID'
+      client_key = Rails.application.secrets.amazon.try(:[], :client_secret) || 'AMAZON_CLIENT_SECRET'
 
       cred = {
         :userid   => client_id,


### PR DESCRIPTION
It seems we must use a symbol now to access `Rails.application.secrets` provider info.

I'm not sure when it changed, but futzing on the rails console confirms that this works:

`Rails.application.secrets.amazon.try(:[], 'client_id') # nil`
vs
`Rails.application.secrets.amazon.try(:[], :client_id) # stuff`
