### PR TITLE
Update Floating IP target and event collection

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_target_parser.rb
@@ -107,6 +107,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventTargetParser
     add_target(target_collection, :network_ports, event_data["networkInterfaceId"]) if event_data["networkInterfaceId"]
     add_target(target_collection, :security_groups, event_data["groupId"]) if event_data["groupId"]
     add_target(target_collection, :floating_ips, event_data["allocationId"]) if event_data["allocationId"]
+    add_target(target_collection, :floating_ips, event_data["publicIp"]) if event_data["publicIp"]
     add_target(target_collection, :load_balancers, event_data["loadBalancerName"]) if event_data["loadBalancerName"]
     # Block Storage
     add_target(target_collection, :cloud_volumes, event_data["volumeId"]) if event_data["volumeId"]

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -139,12 +139,12 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   def floating_ips
     return [] if references(:floating_ips).blank?
 
-    multi_query(references(:floating_ips)) do |refs|
-      results = aws_ec2.client.describe_addresses.flat_map(&:addresses).select { |addr|
-        refs.include?(addr.allocation_id) || refs.include?(addr.public_ip)
-      }
 
-      hash_collection.new(results).all
+    multi_query(references(:floating_ips)) do |refs|
+      hash_collection.new(
+        aws_ec2.client.describe_addresses(:filters => [{:name => 'allocation-id', :values => refs}]).flat_map(&:addresses) +
+        aws_ec2.client.describe_addresses(:filters => [{:name => 'public-ip', :values => refs}]).flat_map(&:addresses)
+      ).all
     end
   end
 

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -140,9 +140,11 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
     return [] if references(:floating_ips).blank?
 
     multi_query(references(:floating_ips)) do |refs|
-      hash_collection.new(
-        aws_ec2.client.describe_addresses(:filters => [{:name => 'public-ip', :values => refs}]).flat_map(&:addresses)
-      ).all
+      results = aws_ec2.client.describe_addresses.flat_map(&:addresses).select { |addr|
+        refs.include?(addr.allocation_id) || refs.include?(addr.public_ip)
+      }
+
+      hash_collection.new(results).all
     end
   end
 

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -141,7 +141,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
 
     multi_query(references(:floating_ips)) do |refs|
       hash_collection.new(
-        aws_ec2.client.describe_addresses(:filters => [{:name => 'allocation-id', :values => refs}]).flat_map(&:addresses)
+        aws_ec2.client.describe_addresses(:filters => [{:name => 'public-ip', :values => refs}]).flat_map(&:addresses)
       ).all
     end
   end

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -139,7 +139,6 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   def floating_ips
     return [] if references(:floating_ips).blank?
 
-
     multi_query(references(:floating_ips)) do |refs|
       hash_collection.new(
         aws_ec2.client.describe_addresses(:filters => [{:name => 'allocation-id', :values => refs}]).flat_map(&:addresses) +

--- a/spec/models/manageiq/providers/amazon/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/event_target_parser_spec.rb
@@ -497,12 +497,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventTargetParser do
       ems_event      = create_ems_event("cloud_watch/AWS_API_CALL_AllocateAddress.json")
       parsed_targets = described_class.new(ems_event).parse
 
-      # TODO(lsmola) we get just \"publicIp\":\"23.23.209.146\" for domain standard, we have to test also VPC and see
-      # what targets we can parse there
-      expect(parsed_targets.size).to eq(0)
+      expect(parsed_targets.size).to eq(1)
       expect(target_references(parsed_targets)).to(
         match_array(
-          []
+          [[:floating_ips, {:ems_ref=>"23.23.209.146"}]]
         )
       )
     end
@@ -1369,11 +1367,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::EventTargetParser do
       ems_event      = create_ems_event("cloud_watch/AWS_API_CALL_ReleaseAddress.json")
       parsed_targets = described_class.new(ems_event).parse
 
-      # TODO(lsmola) again only {\"publicIp\":\"23.21.100.183\"} mentioned, not sure what domain
-      expect(parsed_targets.size).to eq(0)
+      expect(parsed_targets.size).to eq(1)
       expect(target_references(parsed_targets)).to(
         match_array(
-          []
+          [[:floating_ips, {:ems_ref=>"23.21.100.183"}]]
         )
       )
     end

--- a/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/ec2_classic_vm_and_lb_full_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/ec2_classic_vm_and_lb_full_refresh.yml
@@ -134,7 +134,7 @@ http_interactions:
                 </item>
             </reservationSet>
         </DescribeInstancesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:22 GMT
 - request:
     method: post
@@ -190,7 +190,7 @@ http_interactions:
                 </item>
             </availabilityZoneInfo>
         </DescribeAvailabilityZonesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:25 GMT
 - request:
     method: post
@@ -242,7 +242,7 @@ http_interactions:
                 </item>
             </keySet>
         </DescribeKeyPairsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:25 GMT
 - request:
     method: post
@@ -325,7 +325,7 @@ http_interactions:
                 </item>
             </imagesSet>
         </DescribeImagesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:27 GMT
 - request:
     method: post
@@ -542,7 +542,7 @@ http_interactions:
                 </item>
             </securityGroupInfo>
         </DescribeSecurityGroupsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:27 GMT
 - request:
     method: post
@@ -642,7 +642,7 @@ http_interactions:
             <RequestId>7c3e0343-af85-11e8-97ac-bbd8964c9d05</RequestId>
           </ResponseMetadata>
         </DescribeLoadBalancersResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:28 GMT
 - request:
     method: post
@@ -699,7 +699,7 @@ http_interactions:
             <RequestId>7c8bae38-af85-11e8-97ac-bbd8964c9d05</RequestId>
           </ResponseMetadata>
         </DescribeInstanceHealthResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:29 GMT
 - request:
     method: post
@@ -748,7 +748,56 @@ http_interactions:
             <requestId>302a0993-a8eb-4c29-99c9-2c00b9a9d19c</requestId>
             <addressesSet/>
         </DescribeAddressesResponse>
-    http_version: 
+    http_version:
+  recorded_at: Mon, 03 Sep 2018 14:27:29 GMT
+- request:
+    method: post
+    uri: https://ec2.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAddresses&Filter.1.Name=public-ip&Filter.1.Value.1=54.221.202.53&Version=2016-11-15
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.9.44 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20180903T142729Z
+      X-Amz-Content-Sha256:
+      - 2c78f1ad1dfa1273041e2e2ca1ebe682d22be25a3e4ca677f9efe3364177dd87
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AMAZON_CLIENT_ID/20180903/us-east-1/ec2/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=f86c0be0510b033c47feb3b0a3196d78f24b0d55ab1ccdfb11e74e48934a40ce
+      Content-Length:
+      - '102'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 03 Sep 2018 14:27:29 GMT
+      Server:
+      - AmazonEC2
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+            <requestId>302a0993-a8eb-4c29-99c9-2c00b9a9d19c</requestId>
+            <addressesSet/>
+        </DescribeAddressesResponse>
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:29 GMT
 - request:
     method: post
@@ -824,6 +873,6 @@ http_interactions:
                 </item>
             </volumeSet>
         </DescribeVolumesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:27:30 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/orchestration_stacks_nested_with_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/orchestration_stacks_nested_with_vm.yml
@@ -190,7 +190,7 @@ http_interactions:
                 </item>
             </reservationSet>
         </DescribeInstancesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:47 GMT
 - request:
     method: post
@@ -293,7 +293,7 @@ http_interactions:
                 </item>
             </networkInterfaceSet>
         </DescribeNetworkInterfacesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:48 GMT
 - request:
     method: post
@@ -349,7 +349,7 @@ http_interactions:
                 </item>
             </availabilityZoneInfo>
         </DescribeAvailabilityZonesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:49 GMT
 - request:
     method: post
@@ -401,7 +401,7 @@ http_interactions:
                 </item>
             </keySet>
         </DescribeKeyPairsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:49 GMT
 - request:
     method: post
@@ -506,7 +506,7 @@ http_interactions:
             <RequestId>5a040aa8-af87-11e8-9cdb-69236bc4bef1</RequestId>
           </ResponseMetadata>
         </DescribeStacksResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:50 GMT
 - request:
     method: post
@@ -621,7 +621,7 @@ http_interactions:
             <RequestId>5a514001-af87-11e8-b531-b71a59d88ca6</RequestId>
           </ResponseMetadata>
         </DescribeStacksResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:50 GMT
 - request:
     method: post
@@ -802,7 +802,7 @@ http_interactions:
         \     <member>Original</member>\n      <member>Processed</member>\n    </StagesAvailable>\n
         \ </GetTemplateResult>\n  <ResponseMetadata>\n    <RequestId>5a9f38c5-af87-11e8-842e-2925a6fb6b81</RequestId>\n
         \ </ResponseMetadata>\n</GetTemplateResponse>\n"
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:51 GMT
 - request:
     method: post
@@ -1025,7 +1025,7 @@ http_interactions:
             <RequestId>5b567b5b-af87-11e8-b13f-cbc83acd995e</RequestId>
           </ResponseMetadata>
         </ListStackResourcesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:52 GMT
 - request:
     method: post
@@ -1341,7 +1341,7 @@ http_interactions:
         \     <member>Original</member>\n      <member>Processed</member>\n    </StagesAvailable>\n
         \ </GetTemplateResult>\n  <ResponseMetadata>\n    <RequestId>5ba92f1d-af87-11e8-87ad-afa8a3af4a81</RequestId>\n
         \ </ResponseMetadata>\n</GetTemplateResponse>\n"
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:53 GMT
 - request:
     method: post
@@ -1412,7 +1412,7 @@ http_interactions:
             <RequestId>5c6e05ee-af87-11e8-87ad-afa8a3af4a81</RequestId>
           </ResponseMetadata>
         </ListStackResourcesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:54 GMT
 - request:
     method: post
@@ -1491,7 +1491,7 @@ http_interactions:
                 </item>
             </imagesSet>
         </DescribeImagesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:55 GMT
 - request:
     method: post
@@ -1584,7 +1584,7 @@ http_interactions:
                 </item>
             </vpcSet>
         </DescribeVpcsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:56 GMT
 - request:
     method: post
@@ -1672,7 +1672,7 @@ http_interactions:
                 </item>
             </subnetSet>
         </DescribeSubnetsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:56 GMT
 - request:
     method: post
@@ -1792,7 +1792,7 @@ http_interactions:
                 </item>
             </securityGroupInfo>
         </DescribeSecurityGroupsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:57 GMT
 - request:
     method: post
@@ -1852,7 +1852,67 @@ http_interactions:
                 </item>
             </addressesSet>
         </DescribeAddressesResponse>
-    http_version: 
+    http_version:
+  recorded_at: Mon, 03 Sep 2018 14:40:57 GMT
+- request:
+    method: post
+    uri: https://ec2.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAddresses&Filter.1.Name=public-ip&Filter.1.Value.1=34.202.178.10&Version=2016-11-15
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.9.44 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20180903T144057Z
+      X-Amz-Content-Sha256:
+      - 221864a389b351f654f1fcc20f3f5102ef53dec1a9a58c912d80615ad8df829d
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AMAZON_CLIENT_ID/20180903/us-east-1/ec2/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=9de685a0c8e32aecf9e031278eefd89b37e415bc4583bc3bbddc2b2a8f572a05
+      Content-Length:
+      - '106'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 03 Sep 2018 14:40:57 GMT
+      Server:
+      - AmazonEC2
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+            <requestId>e4cd826c-a135-4e83-86b0-dedc0eea00a8</requestId>
+            <addressesSet>
+                <item>
+                    <publicIp>34.202.178.10</publicIp>
+                    <allocationId>eipalloc-9a4472ab</allocationId>
+                    <domain>vpc</domain>
+                    <instanceId>i-0bca58e6e540ddc39</instanceId>
+                    <associationId>eipassoc-13766e23</associationId>
+                    <networkInterfaceId>eni-8fefae9b</networkInterfaceId>
+                    <networkInterfaceOwnerId>200278856672</networkInterfaceOwnerId>
+                    <privateIpAddress>10.2.0.239</privateIpAddress>
+                </item>
+            </addressesSet>
+        </DescribeAddressesResponse>
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:57 GMT
 - request:
     method: post
@@ -1923,6 +1983,6 @@ http_interactions:
                 </item>
             </volumeSet>
         </DescribeVolumesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:40:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/vpc_vm_with_floating_ip_and_lbs_full_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/vpc_vm_with_floating_ip_and_lbs_full_refresh.yml
@@ -180,7 +180,7 @@ http_interactions:
                 </item>
             </reservationSet>
         </DescribeInstancesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:18 GMT
 - request:
     method: post
@@ -288,7 +288,7 @@ http_interactions:
                 </item>
             </networkInterfaceSet>
         </DescribeNetworkInterfacesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:19 GMT
 - request:
     method: post
@@ -344,7 +344,7 @@ http_interactions:
                 </item>
             </availabilityZoneInfo>
         </DescribeAvailabilityZonesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:20 GMT
 - request:
     method: post
@@ -396,7 +396,7 @@ http_interactions:
                 </item>
             </keySet>
         </DescribeKeyPairsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:20 GMT
 - request:
     method: post
@@ -479,7 +479,7 @@ http_interactions:
                 </item>
             </imagesSet>
         </DescribeImagesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:22 GMT
 - request:
     method: post
@@ -552,7 +552,7 @@ http_interactions:
                 </item>
             </vpcSet>
         </DescribeVpcsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:22 GMT
 - request:
     method: post
@@ -620,7 +620,7 @@ http_interactions:
                 </item>
             </subnetSet>
         </DescribeSubnetsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:23 GMT
 - request:
     method: post
@@ -718,7 +718,7 @@ http_interactions:
                 </item>
             </securityGroupInfo>
         </DescribeSecurityGroupsResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:23 GMT
 - request:
     method: post
@@ -833,7 +833,7 @@ http_interactions:
             <RequestId>08c75684-af86-11e8-a0bf-21925e51bf05</RequestId>
           </ResponseMetadata>
         </DescribeLoadBalancersResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:24 GMT
 - request:
     method: post
@@ -939,7 +939,7 @@ http_interactions:
             <RequestId>0917c057-af86-11e8-a9bf-559519f41ce3</RequestId>
           </ResponseMetadata>
         </DescribeLoadBalancersResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:24 GMT
 - request:
     method: post
@@ -996,7 +996,7 @@ http_interactions:
             <RequestId>0963213b-af86-11e8-b180-615643315a99</RequestId>
           </ResponseMetadata>
         </DescribeInstanceHealthResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:25 GMT
 - request:
     method: post
@@ -1053,7 +1053,7 @@ http_interactions:
             <RequestId>09b07dbf-af86-11e8-a0bf-21925e51bf05</RequestId>
           </ResponseMetadata>
         </DescribeInstanceHealthResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:25 GMT
 - request:
     method: post
@@ -1113,7 +1113,67 @@ http_interactions:
                 </item>
             </addressesSet>
         </DescribeAddressesResponse>
-    http_version: 
+    http_version:
+  recorded_at: Mon, 03 Sep 2018 14:31:26 GMT
+- request:
+    method: post
+    uri: https://ec2.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAddresses&Filter.1.Name=public-ip&Filter.1.Value.1=54.208.119.197&Version=2016-11-15
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.9.44 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20180903T143125Z
+      X-Amz-Content-Sha256:
+      - 797240de400141eaa48134a4a0ed7234fe1a1d39db5e13945c4e0e0f4973642a
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AMAZON_CLIENT_ID/20180903/us-east-1/ec2/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=3673621d69fa2b1961ced027b42b65f2fc91e9569cabe55ddc2a510f510d2e09
+      Content-Length:
+      - '106'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 03 Sep 2018 14:31:26 GMT
+      Server:
+      - AmazonEC2
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+            <requestId>aa9be73a-a2ad-477f-941b-baba5540c3c6</requestId>
+            <addressesSet>
+                <item>
+                    <publicIp>54.208.119.197</publicIp>
+                    <allocationId>eipalloc-ce53d7a0</allocationId>
+                    <domain>vpc</domain>
+                    <instanceId>i-8b5739f2</instanceId>
+                    <associationId>eipassoc-cc6e58f1</associationId>
+                    <networkInterfaceId>eni-ad25f7cc</networkInterfaceId>
+                    <networkInterfaceOwnerId>200278856672</networkInterfaceOwnerId>
+                    <privateIpAddress>10.0.0.254</privateIpAddress>
+                </item>
+            </addressesSet>
+        </DescribeAddressesResponse>
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:26 GMT
 - request:
     method: post
@@ -1216,6 +1276,6 @@ http_interactions:
                 </item>
             </volumeSet>
         </DescribeVolumesResponse>
-    http_version: 
+    http_version:
   recorded_at: Mon, 03 Sep 2018 14:31:27 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/vpc_vm_with_public_ip_and_template.yml
+++ b/spec/vcr_cassettes/manageiq/providers/amazon/cloud_manager/refresher_targeted/vpc_vm_with_public_ip_and_template.yml
@@ -170,7 +170,7 @@ http_interactions:
                 </item>
             </reservationSet>
         </DescribeInstancesResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:20 GMT
 - request:
     method: post
@@ -269,7 +269,7 @@ http_interactions:
                 </item>
             </networkInterfaceSet>
         </DescribeNetworkInterfacesResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:21 GMT
 - request:
     method: post
@@ -325,7 +325,7 @@ http_interactions:
                 </item>
             </availabilityZoneInfo>
         </DescribeAvailabilityZonesResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:22 GMT
 - request:
     method: post
@@ -379,7 +379,7 @@ http_interactions:
                 </item>
             </keySet>
         </DescribeKeyPairsResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:23 GMT
 - request:
     method: post
@@ -458,7 +458,7 @@ http_interactions:
                 </item>
             </imagesSet>
         </DescribeImagesResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:25 GMT
 - request:
     method: post
@@ -531,7 +531,7 @@ http_interactions:
                 </item>
             </vpcSet>
         </DescribeVpcsResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:26 GMT
 - request:
     method: post
@@ -599,7 +599,7 @@ http_interactions:
                 </item>
             </subnetSet>
         </DescribeSubnetsResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:27 GMT
 - request:
     method: post
@@ -697,7 +697,7 @@ http_interactions:
                 </item>
             </securityGroupInfo>
         </DescribeSecurityGroupsResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:28 GMT
 - request:
     method: post
@@ -746,7 +746,56 @@ http_interactions:
             <requestId>4382a8eb-1089-4895-8af7-64fcc39807f7</requestId>
             <addressesSet/>
         </DescribeAddressesResponse>
-    http_version: 
+    http_version:
+  recorded_at: Tue, 26 Sep 2017 08:18:28 GMT
+- request:
+    method: post
+    uri: https://ec2.us-east-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeAddresses&Filter.1.Name=public-ip&Filter.1.Value.1=54.208.71.4&Version=2016-11-15
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.9.44 ruby/2.3.0 x86_64-linux resources
+      X-Amz-Date:
+      - 20170926T081828Z
+      X-Amz-Content-Sha256:
+      - a31fd8e566b655ae84a1a9ef853231b894fc12a5d9c9fc35d245e559a1bc6a91
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AMAZON_CLIENT_ID/20170926/us-east-1/ec2/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=34a7c01efc134411d521eba3dfbfed7fb75e7571fd0142da88bd91cdf9db6a7c
+      Content-Length:
+      - '100'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Tue, 26 Sep 2017 08:18:22 GMT
+      Server:
+      - AmazonEC2
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+            <requestId>4382a8eb-1089-4895-8af7-64fcc39807f7</requestId>
+            <addressesSet/>
+        </DescribeAddressesResponse>
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:28 GMT
 - request:
     method: post
@@ -851,6 +900,6 @@ http_interactions:
                 </item>
             </volumeSet>
         </DescribeVolumesResponse>
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Sep 2017 08:18:30 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Currently classic EIP's in AWS are not getting picked up by targeted refresh. This is because not all AWS floating IP resources have an `allocationId`. Specifically, a "classic" elastic IP will not have an `allocationId`. But, they do have an IP address.

Consequently, I've updated the targeted refresh collection and event parser to look at both `publicIp` and `allocationId` fields. I felt it was best to look for both, since in some cases the `ems_ref` could be either one since the parser looks for both.

~~The only downside to this is that I could no longer use filters, since the AWS SDK treats multiple filters as an AND rather than an OR, and I could see no way to do that within the SDK API. As a result, I'm filtering with pure Ruby after the fact.~~

Edit: Switched to multiple calls with single filters.

I've also updated the event target parser specs, which I think resolve the TODO items that lsmola had mentioned.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746860