### PR TITLE
[WIP] Amazon::NetworkManager belongs to a parent manager

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -12,6 +12,7 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
   require_nested :Refresher
   require_nested :SecurityGroup
 
+  include BelongsToParentManagerMixin
   include ManageIQ::Providers::Amazon::ManagerMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/20229
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/136