### PR TITLE
Revert "Merge pull request #628 from agrare/add_eu_south_1_milan_region"

### DIFF
--- a/db/fixtures/aws_regions.yml
+++ b/db/fixtures/aws_regions.yml
@@ -39,10 +39,6 @@ eu-north-1:
   :name: eu-north-1
   :hostname: ec2.eu-north-1.amazonaws.com
   :description: EU (Stockholm)
-eu-south-1:
-  :name: eu-south-1
-  :hostname: ec2.eu-south-1.amazonaws.com
-  :description: EU (Milan)
 eu-west-1:
   :name: eu-west-1
   :hostname: ec2.eu-west-1.amazonaws.com


### PR DESCRIPTION
I jumped the gun on this one, the region isn't being returned by the API yet so even after re-recording the regions vcr_cassette this test fails.

Fixes failing specs introduced by #628 