### PR TITLE
Add eu-south-1 as an atypical region

### DIFF
--- a/app/models/manageiq/providers/amazon/regions.rb
+++ b/app/models/manageiq/providers/amazon/regions.rb
@@ -19,6 +19,7 @@ module ManageIQ
         atypical_regions = [
           'ap-northeast-3', # "To request access to the Asia Pacific (Osaka-Local) Region, contact..."
           'ap-east-1',      # "you must manually enable before you can use..."
+          'eu-south-1',
         ].freeze
         REGIONS.keys.select { |name| atypical_regions.include?(name) || name !~ ORDINARY_REGIONS_REGEXP }
       end.freeze

--- a/db/fixtures/aws_regions.yml
+++ b/db/fixtures/aws_regions.yml
@@ -39,6 +39,10 @@ eu-north-1:
   :name: eu-north-1
   :hostname: ec2.eu-north-1.amazonaws.com
   :description: EU (Stockholm)
+eu-south-1:
+  :name: eu-south-1
+  :hostname: ec2.eu-south-1.amazonaws.com
+  :description: EU (Milan)
 eu-west-1:
   :name: eu-west-1
   :hostname: ec2.eu-west-1.amazonaws.com


### PR DESCRIPTION
The EU (Milan) region exists but isn't returned by aws-sdk .describe_regions which was causing the specs to fail.  Add it to the regions.yml but as an atypical region.

Follow-up to https://github.com/ManageIQ/manageiq-providers-amazon/pull/628 and https://github.com/ManageIQ/manageiq-providers-amazon/pull/629