### PR TITLE
Delegate storage_manager.cloud_tenants to the cloud_manager

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
@@ -20,8 +20,13 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs < ManageIQ::Providers::St
            :hostname,
            :default_endpoint,
            :endpoints,
+           :cloud_tenants,
+           :volume_availability_zones,
            :to        => :parent_manager,
            :allow_nil => true
+
+  virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
+  virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
 
   def self.ems_type
     @ems_type ||= "ec2_ebs_storage".freeze

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -20,8 +20,13 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
            :hostname,
            :default_endpoint,
            :endpoints,
+           :cloud_tenants,
+           :volume_availability_zones,
            :to        => :parent_manager,
            :allow_nil => true
+
+  virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
+  virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
 
   def self.ems_type
     @ems_type ||= "s3".freeze


### PR DESCRIPTION
Allow all associations required to edit a cloud_volume to be callable from the storage_manager without having to go to the parent_manager.

This allows for cloud_volumes that don't belong to a storage manager to be handled the same was as amazon cloud_volumes which do.

The current query is:
```
return API.get('/api/providers/' + id + '?attributes=type,supports_cinder_volume_types,supports_volume_resizing,supports_volume_availability_zones,parent_manager.volume_availability_zones,parent_manager.cloud_tenants,parent_manager.cloud_volume_snapshots,parent_manager.cloud_volume_types')
```

So the collections being requested from the parent_manager are:
* volume_availability_zones
* cloud_tenants
* cloud_volume_snapshots
* cloud_volume_types

The last two are actually delegated back to the storage manager so we have a nice little loop

Editing an Amazon CloudVolume:
![Screenshot from 2020-06-16 15-30-48](https://user-images.githubusercontent.com/12851112/84819700-747e6200-afe6-11ea-8cea-17c9e3fda857.png)

And editing a GCE CloudVolume (this was failing previously):
![Screenshot from 2020-06-16 15-32-19](https://user-images.githubusercontent.com/12851112/84819825-a4c60080-afe6-11ea-82cb-397979d19c70.png)


Ref: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js#L139

Dependent: https://github.com/ManageIQ/manageiq-ui-classic/pull/7133