### PR TITLE
Set the monitor_running event to unblock the main thread

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
@@ -6,9 +6,9 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Runner < ManageIQ
   end
 
   def monitor_events
+    event_monitor_running
     event_monitor_handle.poll do |event|
       _log.debug { "#{log_prefix} Received event #{event["messageId"]}" }
-      event_monitor_running
       @queue.enq event
     end
   ensure


### PR DESCRIPTION
The do_before_work_loop [starts the event monitor](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/base_manager/event_catcher/runner.rb#L59).

This [spins up the thread](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/base_manager/event_catcher/runner.rb#L155-L169) and [waits for it to be started](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/base_manager/event_catcher/runner.rb#L171).  The amazon event catcher only sets the started event to true [once an event is raised](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb#L11).

This means if you try to stop the event catcher before an event occurs you have to SIGKILL it as it will never shutdown cleanly.