### PR TITLE
Update tag name for network ports and security groups

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser.rb
@@ -7,6 +7,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser < ManageIQ::Providers::Inve
   # Overridden helper methods, we should put them in helper once we get rid of old refresh
   def get_from_tags(resource, tag_name)
     tag_name = tag_name.to_s.downcase
-    Array.wrap(resource['tags']).detect { |tag, _| tag['key'].downcase == tag_name }.try(:[], 'value').presence
+    tags = resource['tags'].to_a.concat(resource['tag_set'].to_a)
+    Array.wrap(tags).detect { |tag, _| tag['key'].downcase == tag_name }.try(:[], 'value').presence
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -85,7 +85,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
   def security_groups
     collector.security_groups.each do |sg|
       persister_security_group = persister.security_groups.find_or_build(sg['group_id']).assign_attributes(
-        :name                => get_from_tags(sg, 'Name') || sg['group_name'].presence || sg['group_id'],
+        :name                => get_from_tags(sg, 'name') || sg['group_name'].presence || sg['group_id'],
         :description         => sg['description'].try(:truncate, 255),
         :cloud_network       => persister.cloud_networks.lazy_find(sg['vpc_id']),
         :orchestration_stack => persister.orchestration_stacks.lazy_find(
@@ -280,7 +280,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
       end
 
       persister_network_port = persister.network_ports.find_or_build(uid).assign_attributes(
-        :name            => get_from_tags(network_port, 'Name') || uid,
+        :name            => get_from_tags(network_port, 'name') || uid,
         :status          => network_port['status'],
         :mac_address     => network_port['mac_address'],
         :device_owner    => network_port.fetch_path('attachment', 'instance_owner_id'),

--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -85,7 +85,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
   def security_groups
     collector.security_groups.each do |sg|
       persister_security_group = persister.security_groups.find_or_build(sg['group_id']).assign_attributes(
-        :name                => sg['group_name'].presence || sg['group_id'],
+        :name                => get_from_tags(sg, 'Name') || sg['group_name'].presence || sg['group_id'],
         :description         => sg['description'].try(:truncate, 255),
         :cloud_network       => persister.cloud_networks.lazy_find(sg['vpc_id']),
         :orchestration_stack => persister.orchestration_stacks.lazy_find(
@@ -280,7 +280,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
       end
 
       persister_network_port = persister.network_ports.find_or_build(uid).assign_attributes(
-        :name            => uid,
+        :name            => get_from_tags(network_port, 'Name') || uid,
         :status          => network_port['status'],
         :mac_address     => network_port['mac_address'],
         :device_owner    => network_port.fetch_path('attachment', 'instance_owner_id'),

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -52,6 +52,7 @@ module AwsRefresherSpecCommon
     assert_specific_az
     assert_specific_key_pair
     assert_specific_cloud_network
+    assert_specific_network_port
     assert_specific_security_group
     assert_specific_security_group_on_cloud_network
     assert_specific_template
@@ -194,6 +195,16 @@ module AwsRefresherSpecCommon
     expect(@cn.cloud_subnets.size).to eq(3)
     assert_vpc_subnet_1
     assert_vpc_subnet_2
+  end
+
+  def assert_specific_network_port
+    network_port = ManageIQ::Providers::Amazon::NetworkManager::NetworkPort.find_by(:ems_ref => 'i-0e1752ff841801f65')
+
+    expect(network_port).to have_attributes(
+      "type"    => "ManageIQ::Providers::Amazon::NetworkManager::NetworkPort",
+      "ems_ref" => "i-0e1752ff841801f65",
+      "name"    => "EmsRefreshSpec-PoweredOff"
+    )
   end
 
   def assert_specific_security_group


### PR DESCRIPTION
Currently the `name` field for network interfaces is defaulting to the ems_ref. This is unlike most other resources that use a `name` tag if found. Similarly, security groups are not currently using a `name` tag, so I updated that as well.

Oddly, network_interfaces use a `tag_set` field instead of a `tags` field like most AWS resources, so I updated the `get_from_tags` method to search both.

Addresses https://github.com/ManageIQ/manageiq-providers-amazon/issues/636