### PR TITLE
Bump aws-sdk-core to fix a frozen hash error

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
+  s.add_dependency "aws-sdk-core",                 ">= 3.104.3"
   s.add_dependency "aws-sdk-cloudformation",       "~> 1.0"
   s.add_dependency "aws-sdk-cloudwatch",           "~> 1.0"
   s.add_dependency "aws-sdk-ec2",                  "~> 1.0"


### PR DESCRIPTION
aws-sdk-core v3.104.0 introduced an issue that causes metrics collection to fail with a frozen hash error.

Fixed in v3.104.3

```
[FrozenError]: can't modify frozen Hash
aws-sdk-core-3.104.0/lib/seahorse/client/plugins/request_callback.rb:67:in `delete'
aws-sdk-core-3.104.0/lib/seahorse/client/plugins/request_callback.rb:67:in `call'
aws-sdk-core-3.104.0/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
aws-sdk-core-3.104.0/lib/seahorse/client/plugins/response_target.rb:24:in `call'
aws-sdk-core-3.104.0/lib/seahorse/client/request.rb:72:in `send_request'
aws-sdk-cloudwatch-1.41.0/lib/aws-sdk-cloudwatch/client.rb:1658:in `get_metric_statistics'
manageiq-providers-amazon-dd5052771d9a/app/models/manageiq/providers/amazon/cloud_manager/metrics_capture.rb:178:in `block (3 levels) in metrics_by_counter_name
```
https://github.com/aws/aws-sdk-ruby/issues/2366