### PR TITLE
Keep the parent manager's tenant_id in sync with its child managers

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -93,16 +93,19 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     if network_manager
       network_manager.zone_id         = zone_id
       network_manager.provider_region = provider_region
+      network_manager.tenant_id       = tenant_id
     end
 
     if ebs_storage_manager
       ebs_storage_manager.zone_id         = zone_id
       ebs_storage_manager.provider_region = provider_region
+      ebs_storage_manager.tenant_id       = tenant_id
     end
 
     if s3_storage_manager
       s3_storage_manager.zone_id         = zone_id
       s3_storage_manager.provider_region = provider_region
+      s3_storage_manager.tenant_id       = tenant_id
     end
   end
 


### PR DESCRIPTION
When syncing child managers' attributes with the parent we should include the tenant_id.