### PR TITLE
[JANSA] Update the amazon smartstate docker image

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,7 +61,7 @@
       :agent_ami_name: CentOS Atomic Host 7 x86_64 HVM EBS 1706_01
       :agent_idle_period: 900
       :agent_label: smartstate
-      :docker_image: manageiq/amazon-smartstate:latest
+      :docker_image: manageiq/amazon-smartstate:latest-jansa
       :docker_login_required: false
       :docker_registry:
       :heartbeat_interval: 120


### PR DESCRIPTION
On jansa we should use the `amazon-smartstate:latest-jansa` docker image not `:latest`

Reference: https://github.com/ManageIQ/container-amazon-smartstate/pull/12#issuecomment-700686672