### PR TITLE
Declared DDF schema for cloud volume creation and editing

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
@@ -28,6 +28,9 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs < ManageIQ::Providers::St
   virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
   virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
 
+  supports :cloud_volume
+  supports :cloud_volume_create
+
   def self.ems_type
     @ems_type ||= "ec2_ebs_storage".freeze
   end

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -113,7 +113,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
           :id         => 'size',
           :label      => _('Size (in bytes)'),
           :type       => 'number',
-          :step       => 1024 * 1024 * 1024,
+          :step       => 1.gigabytes,
           :isRequired => true,
           :validate   => [{:type => 'required'}],
           :condition  => {

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -2,6 +2,14 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
   supports :create
   supports :snapshot_create
 
+  CLOUD_VOLUME_TYPES = {
+    :gp2      => N_('General Purpose SSD (GP2)'),
+    :io1      => N_('Provisioned IOPS SSD (IO1)'),
+    :st1      => N_('Throughput Optimized HDD (ST1)'),
+    :sc1      => N_('Cold HDD (SC1)'),
+    :standard => N_('Magnetic'),
+  }.freeze
+
   def available_vms
     availability_zone.vms
   end
@@ -94,6 +102,131 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.volume(ems_ref)
+  end
+
+  def self.params_for_create(ems)
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'size',
+          :id         => 'size',
+          :label      => _('Size (in bytes)'),
+          :type       => 'number',
+          :step       => 1024 * 1024 * 1024,
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+          :condition  => {
+            :or => [
+              {
+                :not => {
+                  :when => 'volume_type',
+                  :is   => 'standard',
+                },
+              },
+              {
+                :when => 'edit',
+                :is   => false,
+              },
+            ],
+          },
+        },
+        {
+          :component  => 'select',
+          :name       => 'availability_zone_id',
+          :id         => 'availability_zone_id',
+          :label      => _('Availability Zone'),
+          :options    => ems.availability_zones.map do |az|
+            {
+              :label => az.name,
+              :value => az.id,
+            }
+          end,
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+          :condition  => {
+            :when => 'edit',
+            :is   => false,
+          },
+        },
+        {
+          :component    => 'select',
+          :name         => 'volume_type',
+          :id           => 'volume_type',
+          :label        => _('Cloud Volume Type'),
+          :options      => CLOUD_VOLUME_TYPES.map do |value, label|
+            option = {
+              :label => _(label),
+              :value => value,
+            }
+
+            # The standard (magnetic) volume_type is a special case. I can only be set upon creation
+            # or when editing an entity that has its volume_type set to standard. Conditional options
+            # are not supported by DDF, but resolveProps allows us to overwrite these options before
+            # rendering.
+            if value == :standard
+              option[:condition] = {
+                :or => [
+                  {
+                    :when => 'edit',
+                    :is   => false,
+                  },
+                  {
+                    :when => 'volume_type',
+                    :is   => 'standard',
+                  }
+                ]
+              }
+            end
+
+            option
+          end,
+          :isRequired   => true,
+          :validate     => [{:type => 'required'}],
+          :initialValue => 'gp2',
+        },
+        {
+          :component => 'text-field',
+          :name      => 'iops',
+          :id        => 'iops',
+          :label     => _('IOPS'),
+          :type      => 'number',
+          :condition => {
+            :when => 'volume_type',
+            :is   => 'io1',
+          }
+        },
+        {
+          :component => 'select',
+          :name      => 'cloud_volume_snapshot_id',
+          :id        => 'cloud_volume_snapshot_id',
+          :label     => _('Base Snapshot'),
+          :condition => {
+            :when => 'edit',
+            :is   => false,
+          },
+          :options   => ems.cloud_volume_snapshots.map do |cvs|
+            {
+              :value => cvs.id,
+              :label => cvs.name,
+            }
+          end
+        },
+        {
+          :component  => 'switch',
+          :name       => 'encrypted',
+          :id         => 'encrypted',
+          :label      => _('Encrypted'),
+          :onText     => _('Yes'),
+          :offText    => _('No'),
+          :isRequired => true,
+          :condition  => {
+            :when => 'edit',
+            :is   => false,
+          },
+        }
+      ]
+    }
   end
 
   private


### PR DESCRIPTION
This is an initial Cloud Volume form schema for the fields that are specific to the amazon-provided cloud volumes. I couldn't find any place where the possible types were declared, so I created a constant that now holds them.

The idea is to call this method from the API when an options request hits the `/api/cloud_volumes` endpoint with a valid `ems_id`. I am not entirely sure if the method should take the `ems_id` as an argument or I should do a lookup in the API before calling it, but this is how it works in the provider forms as well.

@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare 

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7334