### PR TITLE
Rename tag mapping categories Vm -> VmAmazon

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -289,8 +289,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   end
 
   LABEL_MAPPING_ENTITIES = {
-    "Vm"    => "ManageIQ::Providers::Amazon::CloudManager::Vm",
-    "Image" => "ManageIQ::Providers::Amazon::CloudManager::Template"
+    "VmAmazon"    => "ManageIQ::Providers::Amazon::CloudManager::Vm",
+    "ImageAmazon" => "ManageIQ::Providers::Amazon::CloudManager::Template"
   }.freeze
 
   def self.entities_for_label_mapping


### PR DESCRIPTION
The Amazon provider was the first cloud provider to participate in the (originally) ContainerLabelTagMapping class. It has since been expanded to include many providers including Openstack, Azure, and VMware vSphere.

This means that the original labeled_resource_type of "Vm" and "Image" meaning Amazon VMs and Templates is quite confusing.

Data migration: https://github.com/ManageIQ/manageiq-schema/pull/525
UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/7438