### PR TITLE
Fix linter issues

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -3,3 +3,5 @@ Style/GlobalVars:
   # Loggers
   - $aws_log
   - $log
+Lint/RescueException:
+  Enabled: false

--- a/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
@@ -12,6 +12,7 @@ module ManageIQ::Providers::Amazon::CloudManager::Provision::Configuration
 
   def userdata_payload
     raw_script = super
-    Base64.encode64(raw_script) if raw_script
+    return unless raw_script
+    Base64.encode64(raw_script)
   end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers::Amazon::CloudManager::Provision::Configuration
   end
 
   def userdata_payload
-    return unless raw_script = super
-    Base64.encode64(raw_script)
+    raw_script = super
+    Base64.encode64(raw_script) if raw_script
   end
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision_workflow.rb
@@ -47,14 +47,14 @@ class ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow < ManageIQ::P
     allowed_ci(:availability_zones, [:cloud_network, :cloud_subnet, :security_group], targets.map(&:id))
   end
 
+  def self.provider_model
+    ManageIQ::Providers::Amazon::CloudManager
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')
     super(message, {'platform' => 'amazon'})
-  end
-
-  def self.provider_model
-    ManageIQ::Providers::Amazon::CloudManager
   end
 
   def security_group_to_availability_zones(src)

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -43,7 +43,7 @@ class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::Cloud
 
   def set_custom_field(key, value)
     with_provider_object do |instance|
-      tags = instance.create_tags ({
+      tags = instance.create_tags({
         tags: [
                 {
                   key: key,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -76,8 +76,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
       # Pull out the password from the database if a provider ID is available
       secret_access_key ||= find(args["id"]).authentication_password('default')
 
-      # rubocop:disable Lint/UselessAssignment (see #588)
-      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => service_account)
+      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => service_account) # rubocop:disable Lint/UselessAssignment (see #588)
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -76,7 +76,8 @@ module ManageIQ::Providers::Amazon::ManagerMixin
       # Pull out the password from the database if a provider ID is available
       secret_access_key ||= find(args["id"]).authentication_password('default')
 
-      !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => service_account) # rubocop:disable Lint/UselessAssignment (see #588)
+      connection = raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, :assume_role => service_account)
+      !!validate_connection(connection)
     end
 
     def raw_connect(access_key_id, secret_access_key, service, region,

--- a/app/models/manageiq/providers/amazon/manager_mixin.rb
+++ b/app/models/manageiq/providers/amazon/manager_mixin.rb
@@ -76,6 +76,7 @@ module ManageIQ::Providers::Amazon::ManagerMixin
       # Pull out the password from the database if a provider ID is available
       secret_access_key ||= find(args["id"]).authentication_password('default')
 
+      # rubocop:disable Lint/UselessAssignment (see #588)
       !!raw_connect(access_key, secret_access_key, :EC2, region, proxy_uri, validate = true, :assume_role => service_account)
     end
 


### PR DESCRIPTION
This PR cleans up the last of the rubocop linter issues that I see locally. Specifically:

* The `provider_model` singleton method isn't actually private, so moves it out of the private block.
* Disables the `RescueException` warning (I don't see us changing that without risking breakage).
* Changes something that looks like a comparison (even though it isn't) in `userdata_payload` into more readable code.
* Simple whitespace fix (whitespace between method name and parens) that was causing a group expression warning.
* Disabled a specific useless assignment warning, along with a reference to why we did that.