### PR TITLE
adjust relationship count in specs

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -152,7 +152,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
       :operating_system                  => vm_count_plus_disconnect_inv + image_count_plus_disconnect_inv,
       :snapshot                          => 0,
       :system_service                    => 0,
-      :relationship                      => vm_count_plus_disconnect_inv + image_count_plus_disconnect_inv,
+      :relationship                      => 0,
       # :miq_queue                         => 2,
       :orchestration_template            => 1,
       :orchestration_stack               => test_counts[:stack_count],


### PR DESCRIPTION
fix specs for the refactor of vms to use ancestry, not relationships


needs
https://github.com/ManageIQ/manageiq/pull/20788 


tested here: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/283