### PR TITLE
Add a basic container manager for Amazon EKS

### DIFF
--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -43,4 +43,11 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
     )
   end
   private_class_method :sts_presigned_url
+
+  def connect_options(options = {})
+    super.merge(
+      :region_name  => provider_region,
+      :cluster_name => uid_ems
+    )
+  end
 end

--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -11,4 +11,36 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
   def self.description
     @description ||= "Amazon EKS".freeze
   end
+
+  def self.kubernetes_auth_options(options)
+    auth_options = {}
+
+    # If a user has configured a service account we should use that
+    auth_options[:bearer_token] = options[:bearer] if options[:bearer].present?
+
+    # Otherwise request a token from STS with an access_key+secret_access_key
+    auth_options[:bearer_token] ||= sts_eks_token(options[:username], options[:password], options[:region_name], options[:cluster_name])
+
+    auth_options
+  end
+
+  def self.sts_eks_token(access_key, secret_access_key, region_name, cluster_name)
+    url = sts_presigned_url(access_key, secret_access_key, region_name, cluster_name)
+
+    "k8s-aws-v1.#{Base64.urlsafe_encode64(url).sub(/=+$/, "")}"
+  end
+  private_class_method :sts_eks_token
+
+  def self.sts_presigned_url(access_key, secret_access_key, region_name, cluster_name)
+    require "aws-sdk-sts"
+    sts_client = Aws::STS::Client.new(
+      :credentials => Aws::Credentials.new(access_key, secret_access_key),
+      :region      => region_name
+    )
+
+    Aws::STS::Presigner.new(:client => sts_client).get_caller_identity_presigned_url(
+      :headers => {"X-K8s-Aws-Id" => cluster_name}
+    )
+  end
+  private_class_method :sts_presigned_url
 end

--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -1,0 +1,14 @@
+class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
+  require_nested :EventCatcher
+  require_nested :EventParser
+  require_nested :Refresher
+  require_nested :RefreshWorker
+
+  def self.ems_type
+    @ems_type ||= "eks".freeze
+  end
+
+  def self.description
+    @description ||= "Amazon EKS".freeze
+  end
+end

--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -15,6 +15,14 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
     @description ||= "Amazon EKS".freeze
   end
 
+  def self.display_name(number = 1)
+    n_('Container Provider (Amazon)', 'Container Providers (Amazon)', number)
+  end
+
+  def self.default_port
+    443
+  end
+
   def self.kubernetes_auth_options(options)
     auth_options = {}
 
@@ -94,6 +102,143 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
     else
       raise MiqException::MiqInvalidCredentialsError, _("Unsupported endpoint")
     end
+  end
+
+  private_class_method def self.provider_region_options
+    ManageIQ::Providers::Amazon::Regions
+      .all
+      .sort_by { |r| r[:description].downcase }
+      .map do |r|
+        {
+          :label => r[:description],
+          :value => r[:name]
+        }
+      end
+  end
+
+  def self.params_for_create
+    {
+      :fields => [
+        {
+          :component  => "select",
+          :id         => "provider_region",
+          :name       => "provider_region",
+          :label      => _("Region"),
+          :isRequired => true,
+          :validate   => [{:type => "required"}],
+          :options    => provider_region_options
+        },
+        {
+          :component  => "text-field",
+          :id         => "uid_ems",
+          :name       => "uid_ems",
+          :label      => _("Cluster Name"),
+          :isRequired => true,
+          :validate   => [{:type => "required"}]
+        },
+        {
+          :component => 'sub-form',
+          :id        => 'endpoints-subform',
+          :name      => 'endpoints-subform',
+          :title     => _('Endpoints'),
+          :fields    => [
+            :component => 'tabs',
+            :name      => 'tabs',
+            :fields    => [
+              {
+                :component => 'tab-item',
+                :id        => 'default-tab',
+                :name      => 'default-tab',
+                :title     => _('Default'),
+                :fields    => [
+                  {
+                    :component              => 'validate-provider-credentials',
+                    :id                     => 'authentications.default.valid',
+                    :name                   => 'authentications.default.valid',
+                    :skipSubmit             => true,
+                    :isRequired             => true,
+                    :validationDependencies => %w[type zone_id provider_region uid_ems],
+                    :fields                 => [
+                      {
+                        :component  => "select",
+                        :id         => "endpoints.default.security_protocol",
+                        :name       => "endpoints.default.security_protocol",
+                        :label      => _("Security Protocol"),
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                        :options    => [
+                          {
+                            :label => _("SSL"),
+                            :value => "ssl-with-validation"
+                          },
+                          {
+                            :label => _("SSL trusting custom CA"),
+                            :value => "ssl-with-validation-custom-ca"
+                          },
+                          {
+                            :label => _("SSL without validation"),
+                            :value => "ssl-without-validation",
+                          },
+                        ]
+                      },
+                      {
+                        :component  => "text-field",
+                        :id         => "endpoints.default.hostname",
+                        :name       => "endpoints.default.hostname",
+                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                      },
+                      {
+                        :component    => "text-field",
+                        :id           => "endpoints.default.port",
+                        :name         => "endpoints.default.port",
+                        :label        => _("API Port"),
+                        :type         => "number",
+                        :initialValue => default_port,
+                        :isRequired   => true,
+                        :validate     => [{:type => "required"}],
+                      },
+                      {
+                        :component  => "textarea",
+                        :id         => "endpoints.default.certificate_authority",
+                        :name       => "endpoints.default.certificate_authority",
+                        :label      => _("Trusted CA Certificates"),
+                        :rows       => 10,
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                        :condition  => {
+                          :when => 'endpoints.default.security_protocol',
+                          :is   => 'ssl-with-validation-custom-ca',
+                        },
+                      },
+                      {
+                        :component  => "text-field",
+                        :id         => "authentications.bearer.userid",
+                        :name       => "authentications.bearer.userid",
+                        :label      => _("Access Key ID"),
+                        :helperText => _("Should have privileged access, such as root or administrator."),
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}]
+                      },
+                      {
+                        :component  => "password-field",
+                        :id         => "authentications.bearer.password",
+                        :name       => "authentications.bearer.password",
+                        :label      => _("Secret Access Key"),
+                        :type       => "password",
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}]
+                      },
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      ]
+    }
   end
 
   def connect_options(options = {})

--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -1,4 +1,7 @@
 class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
+  require_nested :Container
+  require_nested :ContainerGroup
+  require_nested :ContainerNode
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Refresher

--- a/app/models/manageiq/providers/amazon/container_manager/container.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/container.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::ContainerManager::Container < ManageIQ::Providers::Kubernetes::ContainerManager::Container
+end

--- a/app/models/manageiq/providers/amazon/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/container_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::ContainerManager::ContainerGroup < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup
+end

--- a/app/models/manageiq/providers/amazon/container_manager/container_node.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/container_node.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::ContainerManager::ContainerNode < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode
+end

--- a/app/models/manageiq/providers/amazon/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/event_catcher.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Amazon::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+
+  def self.settings_name
+    :event_catcher_amazon_eks
+  end
+end

--- a/app/models/manageiq/providers/amazon/container_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/event_catcher/runner.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Amazon::ContainerManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  include ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
+end

--- a/app/models/manageiq/providers/amazon/container_manager/event_parser.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/event_parser.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::ContainerManager::EventParser < ManageIQ::Providers::Kubernetes::ContainerManager::EventParser
+end

--- a/app/models/manageiq/providers/amazon/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/refresh_worker.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Amazon::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
+  require_nested :Runner
+
+  def self.settings_name
+    :ems_refresh_worker_amazon_eks
+  end
+end

--- a/app/models/manageiq/providers/amazon/container_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/refresh_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::ContainerManager::RefreshWorker::Runner < ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker::Runner
+end

--- a/app/models/manageiq/providers/amazon/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/refresher.rb
@@ -1,0 +1,6 @@
+module ManageIQ::Providers
+  module Amazon
+    class ContainerManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+    end
+  end
+end

--- a/app/models/manageiq/providers/amazon/inventory/collector.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Amazon::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :CloudManager
+  require_nested :ContainerManager
   require_nested :NetworkManager
   require_nested :TargetCollection
 

--- a/app/models/manageiq/providers/amazon/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/container_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
+end

--- a/app/models/manageiq/providers/amazon/inventory/parser.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Amazon::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :CloudManager
+  require_nested :ContainerManager
   require_nested :NetworkManager
 
   include ManageIQ::Providers::Amazon::ParserHelperMethods

--- a/app/models/manageiq/providers/amazon/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/container_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
+end

--- a/app/models/manageiq/providers/amazon/inventory/persister.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Amazon::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :CloudManager
+  require_nested :ContainerManager
   require_nested :NetworkManager
   require_nested :TargetCollection
 

--- a/app/models/manageiq/providers/amazon/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/container_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Amazon::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,6 +87,12 @@
   :ec2_network:
     :inventory_collections:
       :saver_strategy: batch
+  :eks:
+    :refresh_interval: 15.minutes
+    :streaming_refresh: false
+    :chunk_size: 1_000
+    :inventory_collections:
+      :saver_strategy: batch
   :s3:
     :inventory_collections:
       :saver_strategy: batch
@@ -109,11 +115,14 @@
     :event_catcher:
       :event_catcher_amazon:
         :poll: 15.seconds
+      :event_catcher_amazon_eks:
+        :poll: 1.seconds
     :queue_worker_base:
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_amazon: {}
       :ems_refresh_worker:
         :ems_refresh_worker_amazon: {}
+        :ems_refresh_worker_amazon_eks: {}
         :ems_refresh_worker_amazon_s3: {}
 :prototype:
   :amazon:

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -23,4 +23,13 @@ FactoryBot.define do
       ems.authentications << FactoryBot.create(:authentication, cred)
     end
   end
+
+  factory :ems_amazon_eks,
+          :aliases => ["manageiq/providers/amazon/container_manager"],
+          :class   => "ManageIQ::Providers::Amazon::ContainerManager",
+          :parent  => :ems_container do
+    provider_region { "us-east-1" }
+    security_protocol { "ssl-without-validation" }
+    port { 443 }
+  end
 end

--- a/spec/models/manageiq/providers/amazon/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/container_manager/refresher_spec.rb
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::Amazon::ContainerManager::Refresher do
       container_project = ems.container_projects.find_by(:name => "kube-system")
       expect(container_project).to have_attributes(
         :name             => "kube-system",
-        :resource_version => "4",
+        :resource_version => "4"
       )
     end
 
@@ -70,9 +70,9 @@ describe ManageIQ::Providers::Amazon::ContainerManager::Refresher do
         :name                 => "coredns",
         :type                 => "ManageIQ::Providers::Amazon::ContainerManager::Container",
         :request_cpu_cores    => 0.1,
-        :request_memory_bytes => 73400320,
+        :request_memory_bytes => 73_400_320,
         :limit_cpu_cores      => nil,
-        :limit_memory_bytes   => 178257920,
+        :limit_memory_bytes   => 178_257_920,
         :image                => "602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.7.0-eksbuild.1",
         :image_pull_policy    => "IfNotPresent",
         :memory               => nil,

--- a/spec/models/manageiq/providers/amazon/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/container_manager/refresher_spec.rb
@@ -1,0 +1,86 @@
+describe ManageIQ::Providers::Amazon::ContainerManager::Refresher do
+  it ".ems_type" do
+    expect(described_class.ems_type).to eq(:eks)
+  end
+
+  describe "#refresh" do
+    let(:zone) do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone
+    end
+
+    let!(:ems) do
+      hostname = Rails.application.secrets.amazon_eks.try(:[], :hostname) || "HOSTNAME"
+      cluster_name = Rails.application.secrets.amazon_eks.try(:[], :cluster_name) || "CLUSTER_NAME"
+
+      FactoryBot.create(:ems_amazon_eks, :hostname => hostname, :port => 443, :uid_ems => cluster_name, :zone => zone).tap do |ems|
+        client_id  = Rails.application.secrets.amazon_eks.try(:[], :client_id) || 'AMAZON_CLIENT_ID'
+        client_key = Rails.application.secrets.amazon_eks.try(:[], :client_secret) || 'AMAZON_CLIENT_SECRET'
+
+        ems.update_authentication(:bearer => {:userid => client_id, :password => client_key})
+      end
+    end
+
+    it "will perform a full refresh" do
+      2.times do
+        VCR.use_cassette(described_class.name.underscore) { EmsRefresh.refresh(ems) }
+
+        ems.reload
+
+        assert_table_counts
+        assert_specific_container_project
+        assert_specific_container_group
+        assert_specific_container
+      end
+    end
+
+    def assert_table_counts
+      expect(ems.container_projects.count).to eq(4)
+      expect(ems.container_nodes.count).to eq(0)
+      expect(ems.container_groups.count).to eq(2)
+      expect(ems.containers.count).to eq(2)
+    end
+
+    def assert_specific_container_project
+      container_project = ems.container_projects.find_by(:name => "kube-system")
+      expect(container_project).to have_attributes(
+        :name             => "kube-system",
+        :resource_version => "4",
+      )
+    end
+
+    def assert_specific_container_group
+      container_group = ems.container_groups.find_by(:name => "coredns-c79dcb98c-v6chb")
+      expect(container_group).to have_attributes(
+        :ems_ref           => "8bca6c7d-b5a0-48f1-a8a7-984586bd80a6",
+        :name              => "coredns-c79dcb98c-v6chb",
+        :resource_version  => "1066525",
+        :restart_policy    => "Always",
+        :dns_policy        => "Default",
+        :type              => "ManageIQ::Providers::Amazon::ContainerManager::ContainerGroup",
+        :container_project => ems.container_projects.find_by(:name => "kube-system"),
+        :phase             => "Pending"
+      )
+    end
+
+    def assert_specific_container
+      container = ems.containers.find_by(:name => "coredns", :container_group => ems.container_groups.find_by(:name => "coredns-c79dcb98c-v6chb"))
+      expect(container).to have_attributes(
+        :ems_ref              => "8bca6c7d-b5a0-48f1-a8a7-984586bd80a6_coredns_602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.7.0-eksbuild.1",
+        :name                 => "coredns",
+        :type                 => "ManageIQ::Providers::Amazon::ContainerManager::Container",
+        :request_cpu_cores    => 0.1,
+        :request_memory_bytes => 73400320,
+        :limit_cpu_cores      => nil,
+        :limit_memory_bytes   => 178257920,
+        :image                => "602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.7.0-eksbuild.1",
+        :image_pull_policy    => "IfNotPresent",
+        :memory               => nil,
+        :cpu_cores            => 0.0,
+        :container_group      => ems.container_groups.find_by(:name => "coredns-c79dcb98c-v6chb"),
+        :capabilities_add     => "NET_BIND_SERVICE",
+        :capabilities_drop    => "all"
+      )
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/amazon/container_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/amazon/container_manager/refresher.yml
@@ -1,0 +1,412 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://hostname/api/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - b19e7d87-55d7-4c0d-9520-2d08133cbb45
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"componentstatuses","singularName":"","namespaced":false,"kind":"ComponentStatus","verbs":["get","list"],"shortNames":["cs"]},{"name":"configmaps","singularName":"","namespaced":true,"kind":"ConfigMap","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cm"],"storageVersionHash":"qFsyl6wFWjQ="},{"name":"endpoints","singularName":"","namespaced":true,"kind":"Endpoints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ep"],"storageVersionHash":"fWeeMqaN/OA="},{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"],"storageVersionHash":"r2yiGXH7wu8="},{"name":"limitranges","singularName":"","namespaced":true,"kind":"LimitRange","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["limits"],"storageVersionHash":"EBKMFVe6cwo="},{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["ns"],"storageVersionHash":"Q3oi5N2YM8M="},{"name":"namespaces/finalize","singularName":"","namespaced":false,"kind":"Namespace","verbs":["update"]},{"name":"namespaces/status","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","patch","update"]},{"name":"nodes","singularName":"","namespaced":false,"kind":"Node","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["no"],"storageVersionHash":"XwShjMxG9Fs="},{"name":"nodes/proxy","singularName":"","namespaced":false,"kind":"NodeProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"nodes/status","singularName":"","namespaced":false,"kind":"Node","verbs":["get","patch","update"]},{"name":"persistentvolumeclaims","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pvc"],"storageVersionHash":"QWTyNDq0dC4="},{"name":"persistentvolumeclaims/status","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["get","patch","update"]},{"name":"persistentvolumes","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pv"],"storageVersionHash":"HN/zwEC+JgM="},{"name":"persistentvolumes/status","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["get","patch","update"]},{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["po"],"categories":["all"],"storageVersionHash":"xPOwRZ+Yhw8="},{"name":"pods/attach","singularName":"","namespaced":true,"kind":"PodAttachOptions","verbs":["create","get"]},{"name":"pods/binding","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"pods/eviction","singularName":"","namespaced":true,"group":"policy","version":"v1beta1","kind":"Eviction","verbs":["create"]},{"name":"pods/exec","singularName":"","namespaced":true,"kind":"PodExecOptions","verbs":["create","get"]},{"name":"pods/log","singularName":"","namespaced":true,"kind":"Pod","verbs":["get"]},{"name":"pods/portforward","singularName":"","namespaced":true,"kind":"PodPortForwardOptions","verbs":["create","get"]},{"name":"pods/proxy","singularName":"","namespaced":true,"kind":"PodProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"pods/status","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","patch","update"]},{"name":"podtemplates","singularName":"","namespaced":true,"kind":"PodTemplate","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"LIXB2x4IFpk="},{"name":"replicationcontrollers","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rc"],"categories":["all"],"storageVersionHash":"Jond2If31h0="},{"name":"replicationcontrollers/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicationcontrollers/status","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["get","patch","update"]},{"name":"resourcequotas","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["quota"],"storageVersionHash":"8uhSgffRX6w="},{"name":"resourcequotas/status","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["get","patch","update"]},{"name":"secrets","singularName":"","namespaced":true,"kind":"Secret","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"S6u1pOWzb84="},{"name":"serviceaccounts","singularName":"","namespaced":true,"kind":"ServiceAccount","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sa"],"storageVersionHash":"pbx9ZvyFpBE="},{"name":"serviceaccounts/token","singularName":"","namespaced":true,"group":"authentication.k8s.io","version":"v1","kind":"TokenRequest","verbs":["create"]},{"name":"services","singularName":"","namespaced":true,"kind":"Service","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["svc"],"categories":["all"],"storageVersionHash":"0/CO1lhkEBI="},{"name":"services/proxy","singularName":"","namespaced":true,"kind":"ServiceProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"services/status","singularName":"","namespaced":true,"kind":"Service","verbs":["get","patch","update"]}]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/nodes?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - 5d56045b-405e-489a-9df9-e30330de238f
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '117'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"NodeList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/nodes","resourceVersion":"1115364"},"items":[]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/namespaces?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - 20be22bc-4cf1-410a-9f5d-de33d8e849ea
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '1864'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"NamespaceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces","resourceVersion":"1115364"},"items":[{"metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"c078e08f-2950-41a6-a12d-7d4d5ac85210","resourceVersion":"151","creationTimestamp":"2021-01-29T21:12:32Z","managedFields":[{"manager":"kube-apiserver","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:32Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:phase":{}}}}]},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-node-lease","selfLink":"/api/v1/namespaces/kube-node-lease","uid":"df93f79b-bb67-4fbb-bd63-483cd49a6b9f","resourceVersion":"7","creationTimestamp":"2021-01-29T21:12:30Z","managedFields":[{"manager":"kube-apiserver","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:30Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:phase":{}}}}]},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-public","selfLink":"/api/v1/namespaces/kube-public","uid":"b3639ca2-1d15-4e0e-b48c-bf354c8c54b9","resourceVersion":"5","creationTimestamp":"2021-01-29T21:12:30Z","managedFields":[{"manager":"kube-apiserver","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:30Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:phase":{}}}}]},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-system","selfLink":"/api/v1/namespaces/kube-system","uid":"c90a2929-b75c-4142-9feb-8b386f231aa7","resourceVersion":"4","creationTimestamp":"2021-01-29T21:12:30Z","managedFields":[{"manager":"kube-apiserver","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:30Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:phase":{}}}}]},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/resourcequotas?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - ca4cf12b-5b02-400c-bf06-0ed53389ff11
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ResourceQuotaList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/resourcequotas","resourceVersion":"1115364"},"items":[]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/limitranges?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - d690a14a-1385-4fdb-af84-e953fbbd71f0
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"LimitRangeList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/limitranges","resourceVersion":"1115364"},"items":[]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/replicationcontrollers?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - 4d7b7c11-c6cb-46ac-bf4a-84d6f1810f13
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationControllerList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/replicationcontrollers","resourceVersion":"1115364"},"items":[]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/persistentvolumeclaims?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - fc8cff3a-c013-4039-8b42-5f91690618c8
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"PersistentVolumeClaimList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/persistentvolumeclaims","resourceVersion":"1115364"},"items":[]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/persistentvolumes?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - 50c0b585-9f13-4752-96a1-a3a7042a850c
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Content-Length:
+      - '141'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"PersistentVolumeList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/persistentvolumes","resourceVersion":"1115364"},"items":[]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/pods?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - e361f5b6-b58f-41fb-b568-31075bd7d0ca
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/pods","resourceVersion":"1115366"},"items":[{"metadata":{"name":"coredns-c79dcb98c-v6chb","generateName":"coredns-c79dcb98c-","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/pods/coredns-c79dcb98c-v6chb","uid":"8bca6c7d-b5a0-48f1-a8a7-984586bd80a6","resourceVersion":"1066525","creationTimestamp":"2021-02-03T15:56:28Z","labels":{"eks.amazonaws.com/component":"coredns","k8s-app":"kube-dns","pod-template-hash":"c79dcb98c"},"annotations":{"eks.amazonaws.com/compute-type":"ec2","kubernetes.io/psp":"eks.privileged"},"ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","name":"coredns-c79dcb98c","uid":"aeb52bf9-4d02-4bcf-9565-7fcfec073323","controller":true,"blockOwnerDeletion":true}],"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2021-02-03T15:56:28Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:eks.amazonaws.com/compute-type":{}},"f:generateName":{},"f:labels":{".":{},"f:eks.amazonaws.com/component":{},"f:k8s-app":{},"f:pod-template-hash":{}},"f:ownerReferences":{".":{},"k:{\"uid\":\"aeb52bf9-4d02-4bcf-9565-7fcfec073323\"}":{".":{},"f:apiVersion":{},"f:blockOwnerDeletion":{},"f:controller":{},"f:kind":{},"f:name":{},"f:uid":{}}}},"f:spec":{"f:affinity":{".":{},"f:nodeAffinity":{".":{},"f:requiredDuringSchedulingIgnoredDuringExecution":{".":{},"f:nodeSelectorTerms":{}}},"f:podAntiAffinity":{".":{},"f:preferredDuringSchedulingIgnoredDuringExecution":{}}},"f:containers":{"k:{\"name\":\"coredns\"}":{".":{},"f:args":{},"f:image":{},"f:imagePullPolicy":{},"f:livenessProbe":{".":{},"f:failureThreshold":{},"f:httpGet":{".":{},"f:path":{},"f:port":{},"f:scheme":{}},"f:initialDelaySeconds":{},"f:periodSeconds":{},"f:successThreshold":{},"f:timeoutSeconds":{}},"f:name":{},"f:ports":{".":{},"k:{\"containerPort\":53,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:name":{},"f:protocol":{}},"k:{\"containerPort\":53,\"protocol\":\"UDP\"}":{".":{},"f:containerPort":{},"f:name":{},"f:protocol":{}},"k:{\"containerPort\":9153,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:name":{},"f:protocol":{}}},"f:readinessProbe":{".":{},"f:failureThreshold":{},"f:httpGet":{".":{},"f:path":{},"f:port":{},"f:scheme":{}},"f:periodSeconds":{},"f:successThreshold":{},"f:timeoutSeconds":{}},"f:resources":{".":{},"f:limits":{".":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:add":{},"f:drop":{}},"f:readOnlyRootFilesystem":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/etc/coredns\"}":{".":{},"f:mountPath":{},"f:name":{},"f:readOnly":{}},"k:{\"mountPath\":\"/tmp\"}":{".":{},"f:mountPath":{},"f:name":{}}}}},"f:dnsPolicy":{},"f:enableServiceLinks":{},"f:priorityClassName":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{},"f:serviceAccount":{},"f:serviceAccountName":{},"f:terminationGracePeriodSeconds":{},"f:tolerations":{},"f:volumes":{".":{},"k:{\"name\":\"config-volume\"}":{".":{},"f:configMap":{".":{},"f:defaultMode":{},"f:items":{},"f:name":{}},"f:name":{}},"k:{\"name\":\"tmp\"}":{".":{},"f:emptyDir":{},"f:name":{}}}}}},{"manager":"kube-scheduler","operation":"Update","apiVersion":"v1","time":"2021-02-03T15:56:28Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{".":{},"k:{\"type\":\"PodScheduled\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}}}}}}]},"spec":{"volumes":[{"name":"tmp","emptyDir":{}},{"name":"config-volume","configMap":{"name":"coredns","items":[{"key":"Corefile","path":"Corefile"}],"defaultMode":420}},{"name":"coredns-token-mjrmf","secret":{"secretName":"coredns-token-mjrmf","defaultMode":420}}],"containers":[{"name":"coredns","image":"602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.7.0-eksbuild.1","args":["-conf","/etc/coredns/Corefile"],"ports":[{"name":"dns","containerPort":53,"protocol":"UDP"},{"name":"dns-tcp","containerPort":53,"protocol":"TCP"},{"name":"metrics","containerPort":9153,"protocol":"TCP"}],"resources":{"limits":{"memory":"170Mi"},"requests":{"cpu":"100m","memory":"70Mi"}},"volumeMounts":[{"name":"config-volume","readOnly":true,"mountPath":"/etc/coredns"},{"name":"tmp","mountPath":"/tmp"},{"name":"coredns-token-mjrmf","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"livenessProbe":{"httpGet":{"path":"/health","port":8080,"scheme":"HTTP"},"initialDelaySeconds":60,"timeoutSeconds":5,"periodSeconds":10,"successThreshold":1,"failureThreshold":5},"readinessProbe":{"httpGet":{"path":"/health","port":8080,"scheme":"HTTP"},"timeoutSeconds":1,"periodSeconds":10,"successThreshold":1,"failureThreshold":3},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent","securityContext":{"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["all"]},"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"Default","serviceAccountName":"coredns","serviceAccount":"coredns","securityContext":{},"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"beta.kubernetes.io/os","operator":"In","values":["linux"]},{"key":"beta.kubernetes.io/arch","operator":"In","values":["amd64","arm64"]}]}]}},"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"k8s-app","operator":"In","values":["kube-dns"]}]},"topologyKey":"kubernetes.io/hostname"}}]}},"schedulerName":"default-scheduler","tolerations":[{"key":"node-role.kubernetes.io/master","effect":"NoSchedule"},{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node.kubernetes.io/not-ready","operator":"Exists","effect":"NoExecute","tolerationSeconds":300},{"key":"node.kubernetes.io/unreachable","operator":"Exists","effect":"NoExecute","tolerationSeconds":300}],"priorityClassName":"system-cluster-critical","priority":2000000000,"enableServiceLinks":true},"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","lastProbeTime":null,"lastTransitionTime":"2021-02-03T15:56:28Z","reason":"Unschedulable","message":"no
+        nodes available to schedule pods"}],"qosClass":"Burstable"}},{"metadata":{"name":"coredns-c79dcb98c-znpqn","generateName":"coredns-c79dcb98c-","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/pods/coredns-c79dcb98c-znpqn","uid":"0cb64edc-caf7-4641-8af6-97be6777dddc","resourceVersion":"1065413","creationTimestamp":"2021-02-03T15:49:28Z","labels":{"eks.amazonaws.com/component":"coredns","k8s-app":"kube-dns","pod-template-hash":"c79dcb98c"},"annotations":{"eks.amazonaws.com/compute-type":"ec2","kubernetes.io/psp":"eks.privileged"},"ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","name":"coredns-c79dcb98c","uid":"aeb52bf9-4d02-4bcf-9565-7fcfec073323","controller":true,"blockOwnerDeletion":true}],"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2021-02-03T15:49:28Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:eks.amazonaws.com/compute-type":{}},"f:generateName":{},"f:labels":{".":{},"f:eks.amazonaws.com/component":{},"f:k8s-app":{},"f:pod-template-hash":{}},"f:ownerReferences":{".":{},"k:{\"uid\":\"aeb52bf9-4d02-4bcf-9565-7fcfec073323\"}":{".":{},"f:apiVersion":{},"f:blockOwnerDeletion":{},"f:controller":{},"f:kind":{},"f:name":{},"f:uid":{}}}},"f:spec":{"f:affinity":{".":{},"f:nodeAffinity":{".":{},"f:requiredDuringSchedulingIgnoredDuringExecution":{".":{},"f:nodeSelectorTerms":{}}},"f:podAntiAffinity":{".":{},"f:preferredDuringSchedulingIgnoredDuringExecution":{}}},"f:containers":{"k:{\"name\":\"coredns\"}":{".":{},"f:args":{},"f:image":{},"f:imagePullPolicy":{},"f:livenessProbe":{".":{},"f:failureThreshold":{},"f:httpGet":{".":{},"f:path":{},"f:port":{},"f:scheme":{}},"f:initialDelaySeconds":{},"f:periodSeconds":{},"f:successThreshold":{},"f:timeoutSeconds":{}},"f:name":{},"f:ports":{".":{},"k:{\"containerPort\":53,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:name":{},"f:protocol":{}},"k:{\"containerPort\":53,\"protocol\":\"UDP\"}":{".":{},"f:containerPort":{},"f:name":{},"f:protocol":{}},"k:{\"containerPort\":9153,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:name":{},"f:protocol":{}}},"f:readinessProbe":{".":{},"f:failureThreshold":{},"f:httpGet":{".":{},"f:path":{},"f:port":{},"f:scheme":{}},"f:periodSeconds":{},"f:successThreshold":{},"f:timeoutSeconds":{}},"f:resources":{".":{},"f:limits":{".":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:add":{},"f:drop":{}},"f:readOnlyRootFilesystem":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/etc/coredns\"}":{".":{},"f:mountPath":{},"f:name":{},"f:readOnly":{}},"k:{\"mountPath\":\"/tmp\"}":{".":{},"f:mountPath":{},"f:name":{}}}}},"f:dnsPolicy":{},"f:enableServiceLinks":{},"f:priorityClassName":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{},"f:serviceAccount":{},"f:serviceAccountName":{},"f:terminationGracePeriodSeconds":{},"f:tolerations":{},"f:volumes":{".":{},"k:{\"name\":\"config-volume\"}":{".":{},"f:configMap":{".":{},"f:defaultMode":{},"f:items":{},"f:name":{}},"f:name":{}},"k:{\"name\":\"tmp\"}":{".":{},"f:emptyDir":{},"f:name":{}}}}}},{"manager":"kube-scheduler","operation":"Update","apiVersion":"v1","time":"2021-02-03T15:49:28Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{".":{},"k:{\"type\":\"PodScheduled\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}}}}}}]},"spec":{"volumes":[{"name":"tmp","emptyDir":{}},{"name":"config-volume","configMap":{"name":"coredns","items":[{"key":"Corefile","path":"Corefile"}],"defaultMode":420}},{"name":"coredns-token-mjrmf","secret":{"secretName":"coredns-token-mjrmf","defaultMode":420}}],"containers":[{"name":"coredns","image":"602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.7.0-eksbuild.1","args":["-conf","/etc/coredns/Corefile"],"ports":[{"name":"dns","containerPort":53,"protocol":"UDP"},{"name":"dns-tcp","containerPort":53,"protocol":"TCP"},{"name":"metrics","containerPort":9153,"protocol":"TCP"}],"resources":{"limits":{"memory":"170Mi"},"requests":{"cpu":"100m","memory":"70Mi"}},"volumeMounts":[{"name":"config-volume","readOnly":true,"mountPath":"/etc/coredns"},{"name":"tmp","mountPath":"/tmp"},{"name":"coredns-token-mjrmf","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"livenessProbe":{"httpGet":{"path":"/health","port":8080,"scheme":"HTTP"},"initialDelaySeconds":60,"timeoutSeconds":5,"periodSeconds":10,"successThreshold":1,"failureThreshold":5},"readinessProbe":{"httpGet":{"path":"/health","port":8080,"scheme":"HTTP"},"timeoutSeconds":1,"periodSeconds":10,"successThreshold":1,"failureThreshold":3},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent","securityContext":{"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["all"]},"readOnlyRootFilesystem":true,"allowPrivilegeEscalation":false}}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"Default","serviceAccountName":"coredns","serviceAccount":"coredns","securityContext":{},"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"beta.kubernetes.io/os","operator":"In","values":["linux"]},{"key":"beta.kubernetes.io/arch","operator":"In","values":["amd64","arm64"]}]}]}},"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":100,"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"k8s-app","operator":"In","values":["kube-dns"]}]},"topologyKey":"kubernetes.io/hostname"}}]}},"schedulerName":"default-scheduler","tolerations":[{"key":"node-role.kubernetes.io/master","effect":"NoSchedule"},{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node.kubernetes.io/not-ready","operator":"Exists","effect":"NoExecute","tolerationSeconds":300},{"key":"node.kubernetes.io/unreachable","operator":"Exists","effect":"NoExecute","tolerationSeconds":300}],"priorityClassName":"system-cluster-critical","priority":2000000000,"enableServiceLinks":true},"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","lastProbeTime":null,"lastTransitionTime":"2021-02-03T15:49:28Z","reason":"Unschedulable","message":"no
+        nodes available to schedule pods"}],"qosClass":"Burstable"}}]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/services?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - 37556ed6-8ca6-44de-b576-fa9d3f664de4
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:18 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/services","resourceVersion":"1115366"},"items":[{"metadata":{"name":"kubernetes","namespace":"default","selfLink":"/api/v1/namespaces/default/services/kubernetes","uid":"2f824f67-7521-4a10-b5d1-5e597b87a62e","resourceVersion":"153","creationTimestamp":"2021-01-29T21:12:32Z","labels":{"component":"apiserver","provider":"kubernetes"},"managedFields":[{"manager":"kube-apiserver","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:32Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:component":{},"f:provider":{}}},"f:spec":{"f:clusterIP":{},"f:ports":{".":{},"k:{\"port\":443,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:sessionAffinity":{},"f:type":{}}}}]},"spec":{"ports":[{"name":"https","protocol":"TCP","port":443,"targetPort":443}],"clusterIP":"172.20.0.1","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"kube-dns","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/services/kube-dns","uid":"9fbc328d-98b2-4039-8603-30562f4a1079","resourceVersion":"179","creationTimestamp":"2021-01-29T21:12:36Z","labels":{"eks.amazonaws.com/component":"kube-dns","k8s-app":"kube-dns","kubernetes.io/cluster-service":"true","kubernetes.io/name":"CoreDNS"},"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"prometheus.io/port\":\"9153\",\"prometheus.io/scrape\":\"true\"},\"labels\":{\"eks.amazonaws.com/component\":\"kube-dns\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"kubernetes.io/name\":\"CoreDNS\"},\"name\":\"kube-dns\",\"namespace\":\"kube-system\"},\"spec\":{\"clusterIP\":\"172.20.0.10\",\"ports\":[{\"name\":\"dns\",\"port\":53,\"protocol\":\"UDP\"},{\"name\":\"dns-tcp\",\"port\":53,\"protocol\":\"TCP\"}],\"selector\":{\"k8s-app\":\"kube-dns\"}}}\n","prometheus.io/port":"9153","prometheus.io/scrape":"true"},"managedFields":[{"manager":"kubectl","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:36Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{},"f:prometheus.io/port":{},"f:prometheus.io/scrape":{}},"f:labels":{".":{},"f:eks.amazonaws.com/component":{},"f:k8s-app":{},"f:kubernetes.io/cluster-service":{},"f:kubernetes.io/name":{}}},"f:spec":{"f:clusterIP":{},"f:ports":{".":{},"k:{\"port\":53,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}},"k:{\"port\":53,\"protocol\":\"UDP\"}":{".":{},"f:name":{},"f:port":{},"f:protocol":{},"f:targetPort":{}}},"f:selector":{".":{},"f:k8s-app":{}},"f:sessionAffinity":{},"f:type":{}}}}]},"spec":{"ports":[{"name":"dns","protocol":"UDP","port":53,"targetPort":53},{"name":"dns-tcp","protocol":"TCP","port":53,"targetPort":53}],"selector":{"k8s-app":"kube-dns"},"clusterIP":"172.20.0.10","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:18 GMT
+- request:
+    method: get
+    uri: https://hostname/api/v1/endpoints?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.7.2p137
+      Authorization:
+      - Bearer k8s-aws-v1.aHR0cHM6Ly9zdHMudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1HZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBUzVJTU0yUFFMTkQ1SVZNQSUyRjIwMjEwMjAzJTJGdXMtZWFzdC0xJTJGc3RzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMTAyMDNUMjExMTE4WiZYLUFtei1FeHBpcmVzPTkwMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QlM0J4LWs4cy1hd3MtaWQmWC1BbXotU2lnbmF0dXJlPTBmZGM3OTczOTUyNmM1NDY5MzdjMGQzZDU0NjhiM2M2NGMzMGIzMjg0M2FmODljMjRkYjgwODYyYmI4ODYxOWM
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Audit-Id:
+      - 9e85d768-d75f-466a-83e5-bff1165a1013
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Feb 2021 21:11:19 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"EndpointsList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/endpoints","resourceVersion":"1115366"},"items":[{"metadata":{"name":"kubernetes","namespace":"default","selfLink":"/api/v1/namespaces/default/endpoints/kubernetes","uid":"5c83cc10-5896-4d88-941b-a35259ad4bd9","resourceVersion":"1152","creationTimestamp":"2021-01-29T21:12:32Z","managedFields":[{"manager":"kube-apiserver","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:18:21Z","fieldsType":"FieldsV1","fieldsV1":{"f:subsets":{}}}]},"subsets":[{"addresses":[{"ip":"10.0.0.53"},{"ip":"10.0.1.46"}],"ports":[{"name":"https","port":443,"protocol":"TCP"}]}]},{"metadata":{"name":"kube-controller-manager","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/endpoints/kube-controller-manager","uid":"fab33aa3-e09b-4574-81f3-d1883b9190e9","resourceVersion":"1115363","creationTimestamp":"2021-01-29T21:12:39Z","annotations":{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"ip-172-16-106-133.ec2.internal_220028d7-2717-4a54-84ac-601ffe1a1b6e\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2021-01-29T21:12:39Z\",\"renewTime\":\"2021-02-03T21:11:18Z\",\"leaderTransitions\":0}"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2021-02-03T21:11:18Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:control-plane.alpha.kubernetes.io/leader":{}}}}}]}},{"metadata":{"name":"kube-dns","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/endpoints/kube-dns","uid":"04122cfb-cce9-4350-8353-a7da4b390539","resourceVersion":"326","creationTimestamp":"2021-01-29T21:12:43Z","labels":{"eks.amazonaws.com/component":"kube-dns","k8s-app":"kube-dns","kubernetes.io/cluster-service":"true","kubernetes.io/name":"CoreDNS"},"annotations":{"endpoints.kubernetes.io/last-change-trigger-time":"2021-01-29T21:12:36Z"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2021-01-29T21:12:43Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:endpoints.kubernetes.io/last-change-trigger-time":{}},"f:labels":{".":{},"f:eks.amazonaws.com/component":{},"f:k8s-app":{},"f:kubernetes.io/cluster-service":{},"f:kubernetes.io/name":{}}}}}]}},{"metadata":{"name":"kube-scheduler","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/endpoints/kube-scheduler","uid":"01e256b4-0460-4445-9468-cdad4521aaa4","resourceVersion":"1115365","creationTimestamp":"2021-01-29T21:13:30Z","annotations":{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"ip-172-16-106-133.ec2.internal_f2d9a48d-4fd2-4a6a-bf2f-1dbea5166239\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2021-01-29T21:13:30Z\",\"renewTime\":\"2021-02-03T21:11:18Z\",\"leaderTransitions\":0}"},"managedFields":[{"manager":"kube-scheduler","operation":"Update","apiVersion":"v1","time":"2021-02-03T21:11:18Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:control-plane.alpha.kubernetes.io/leader":{}}}}}]}}]}
+
+        '
+    http_version:
+  recorded_at: Wed, 03 Feb 2021 21:11:19 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
Add an `Amazon::ContainerManager` which subclasses the main `Kubernetes::ContainerManager` to support Amazon Web Service's Elastic Kubernetes Service (https://aws.amazon.com/eks/)

EKS uses STS or IAM for authentication (https://docs.aws.amazon.com/eks/latest/userguide/managing-auth.html) but after that it is a standard Kubernetes API.  This means that we simply have to add methods to acquire an STS token with a user's access_key/secret_access_key and return that as the bearer token and the base Kubernetes code takes over.

The STS tokens are valid for ~15 minutes which is sufficient for operations and the tokens stay live during a `watch` operation

In order to get an STS token you have to give the eks cluster name, I've chosen to put this in the uid_ems column rather than the name column but I'm open to other suggestions.

TODO:
- [x] Fetch an STS token in raw_connect
- [x] Merge `#provider_region` and `#uid_ems` into instance-level connect_options
- [x] Full refresh
- [x] ~~Streaming refresh / watches (Might tackle this in a follow-up)~~
- [x] `.verify_credentials`
- [x] Update DDF forms
- [x] VCR Refresher specs

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/422

Cross-Repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/293