### PR TITLE
Fix EKS scheduled auth check returning missing creds

### DIFF
--- a/spec/models/manageiq/providers/amazon/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/container_manager/refresher_spec.rb
@@ -17,7 +17,7 @@ describe ManageIQ::Providers::Amazon::ContainerManager::Refresher do
         client_id  = Rails.application.secrets.amazon_eks.try(:[], :client_id) || 'AMAZON_CLIENT_ID'
         client_key = Rails.application.secrets.amazon_eks.try(:[], :client_secret) || 'AMAZON_CLIENT_SECRET'
 
-        ems.update_authentication(:bearer => {:userid => client_id, :password => client_key})
+        ems.update_authentication(:default => {:userid => client_id, :password => client_key})
       end
     end
 


### PR DESCRIPTION
While we are using a bearer token to authenticate with k8s API, we aren't storing this token in the database.  We are only storing userid and password in the authentication record, with an authtype of "bearer" this was causing the scheduled authentication_check to fail with "missing credentials" because it didn't see anything in the `:bearer` column.

https://github.com/ManageIQ/manageiq-providers-amazon/issues/682