### PR TITLE
Parse flavors from the collector not the persister

### DIFF
--- a/app/models/manageiq/providers/amazon/instance_types.rb
+++ b/app/models/manageiq/providers/amazon/instance_types.rb
@@ -21,7 +21,10 @@ module ManageIQ::Providers::Amazon::InstanceTypes
   def self.instance_types
     additional = Hash(Settings.ems.ems_amazon.try!(:additional_instance_types)).stringify_keys
     disabled = Array(Settings.ems.ems_amazon.try!(:disabled_instance_types))
-    ALL_TYPES.merge(additional).except(*disabled)
+
+    instance_types = ALL_TYPES.merge(additional).except(*disabled)
+    instance_types.default = ALL_TYPES["unknown"]
+    instance_types
   end
 
   def self.all

--- a/app/models/manageiq/providers/amazon/inventory/collector.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector.rb
@@ -89,6 +89,10 @@ class ManageIQ::Providers::Amazon::Inventory::Collector < ManageIQ::Providers::I
     @aws_rds ||= manager.connect(:service => :RDS)
   end
 
+  def flavors_by_name
+    @flavors_by_name ||= flavors.index_by { |flavor| flavor[:name] }
+  end
+
   def stack_resources(stack_name)
     @stack_resources.try(:[], stack_name) || []
   end

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -16,6 +16,20 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
     target.manager_refs_by_association.try(:[], collection).try(:[], :name).try(:to_a).try(:compact) || []
   end
 
+  def flavors
+    return @flavors_hashes if @flavors_hashes
+
+    all_instance_types = ManageIQ::Providers::Amazon::InstanceTypes.instance_types
+
+    # Only include flavors which are referenced by the targeted instances
+    targeted_instance_types = instances.collect { |instance| instance["instance_type"] }.uniq.compact
+
+    instance_types = all_instance_types.values_at(*targeted_instance_types)
+    instance_types << all_instance_types["unknown"] if instance_types.any?(nil)
+
+    @flavors_hashes = instance_types.compact
+  end
+
   def instances
     return [] if references(:vms).blank?
     return @instances_hashes if @instances_hashes

--- a/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/target_collection.rb
@@ -19,15 +19,9 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::TargetCollection < Mana
   def flavors
     return @flavors_hashes if @flavors_hashes
 
-    all_instance_types = ManageIQ::Providers::Amazon::InstanceTypes.instance_types
-
     # Only include flavors which are referenced by the targeted instances
-    targeted_instance_types = instances.collect { |instance| instance["instance_type"] }.uniq.compact
-
-    instance_types = all_instance_types.values_at(*targeted_instance_types)
-    instance_types << all_instance_types["unknown"] if instance_types.any?(nil)
-
-    @flavors_hashes = instance_types.compact
+    targeted_instance_types = instances.collect { |instance| instance["instance_type"] }
+    @flavors_hashes = ManageIQ::Providers::Amazon::InstanceTypes.instance_types.values_at(*targeted_instance_types).uniq
   end
 
   def instances

--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -229,8 +229,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       status = instance.fetch_path('state', 'name')
       next if collector.options.ignore_terminated_instances && status.to_sym == :terminated
 
-      flavor   = collector.flavors.detect { |f| f[:name] == instance["instance_type"] }
-      flavor ||= collector.flavors.detect { |f| f[:name] == "unknown" }
+      flavor = collector.flavors_by_name[instance["instance_type"]] || collector.flavors_by_name["unknown"]
 
       uid  = instance['instance_id']
       name = get_from_tags(instance, :name) || uid

--- a/app/models/manageiq/providers/amazon/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/definitions/cloud_collections.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::CloudColl
     %i(auth_key_pairs
        availability_zones
        disks
+       flavors
        hardwares
        networks
        operating_systems
@@ -21,7 +22,6 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::CloudColl
 
     add_miq_templates
 
-    add_flavors
     add_cloud_database_flavors
 
     %i(orchestration_stacks
@@ -46,13 +46,6 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::CloudColl
   def add_miq_templates(extra_properties = {})
     add_collection(cloud, :miq_templates, extra_properties) do |builder|
       builder.add_properties(:model_class => ::ManageIQ::Providers::Amazon::CloudManager::Template)
-    end
-  end
-
-  def add_flavors(extra_properties = {})
-    add_collection(cloud, :flavors, extra_properties) do |builder|
-      # Model we take just from a DB, there is no flavors API
-      builder.add_properties(:strategy => :local_db_find_references) if targeted?
     end
   end
 


### PR DESCRIPTION
By parsing flavors using `persister.flavors.find()` we're assuming that the flavor either exists in the persister cache (aka full refresh) or already exists in the database (targeted refresh).

If someone deletes the "unknown" flavor from the database then the `persister.flavors.find("unknown")` call will return a `nil` which we're assuming can never happen in the instances parser.