### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -143,13 +143,14 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     {
       :fields => [
         {
-          :component  => "select",
-          :id         => "provider_region",
-          :name       => "provider_region",
-          :label      => _("Region"),
-          :isRequired => true,
-          :validate   => [{:type => "required"}],
-          :options    => provider_region_options
+          :component    => "select",
+          :id           => "provider_region",
+          :name         => "provider_region",
+          :label        => _("Region"),
+          :isRequired   => true,
+          :validate     => [{:type => "required"}],
+          :includeEmpty => true,
+          :options      => provider_region_options
         },
         {
           :component => 'sub-form',

--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -120,13 +120,14 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
     {
       :fields => [
         {
-          :component  => "select",
-          :id         => "provider_region",
-          :name       => "provider_region",
-          :label      => _("Region"),
-          :isRequired => true,
-          :validate   => [{:type => "required"}],
-          :options    => provider_region_options
+          :component    => "select",
+          :id           => "provider_region",
+          :name         => "provider_region",
+          :label        => _("Region"),
+          :isRequired   => true,
+          :includeEmpty => true,
+          :validate     => [{:type => "required"}],
+          :options      => provider_region_options
         },
         {
           :component  => "text-field",
@@ -160,13 +161,14 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
                     :validationDependencies => %w[type zone_id provider_region uid_ems],
                     :fields                 => [
                       {
-                        :component  => "select",
-                        :id         => "endpoints.default.security_protocol",
-                        :name       => "endpoints.default.security_protocol",
-                        :label      => _("Security Protocol"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                        :options    => [
+                        :component    => "select",
+                        :id           => "endpoints.default.security_protocol",
+                        :name         => "endpoints.default.security_protocol",
+                        :label        => _("Security Protocol"),
+                        :isRequired   => true,
+                        :validate     => [{:type => "required"}],
+                        :initialValue => 'ssl-with-validation',
+                        :options      => [
                           {
                             :label => _("SSL"),
                             :value => "ssl-with-validation"

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -138,19 +138,20 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
           },
         },
         {
-          :component  => 'select',
-          :name       => 'availability_zone_id',
-          :id         => 'availability_zone_id',
-          :label      => _('Availability Zone'),
-          :options    => ems.availability_zones.map do |az|
+          :component    => 'select',
+          :name         => 'availability_zone_id',
+          :id           => 'availability_zone_id',
+          :label        => _('Availability Zone'),
+          :includeEmpty => true,
+          :options      => ems.availability_zones.map do |az|
             {
               :label => az.name,
               :value => az.id,
             }
           end,
-          :isRequired => true,
-          :validate   => [{:type => 'required'}],
-          :condition  => {
+          :isRequired   => true,
+          :validate     => [{:type => 'required'}],
+          :condition    => {
             :when => 'edit',
             :is   => false,
           },
@@ -160,6 +161,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
           :name         => 'volume_type',
           :id           => 'volume_type',
           :label        => _('Cloud Volume Type'),
+          :includeEmpty => true,
           :options      => CLOUD_VOLUME_TYPES.map do |value, label|
             option = {
               :label => _(label),
@@ -203,15 +205,16 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
           }
         },
         {
-          :component => 'select',
-          :name      => 'cloud_volume_snapshot_id',
-          :id        => 'cloud_volume_snapshot_id',
-          :label     => _('Base Snapshot'),
-          :condition => {
+          :component    => 'select',
+          :name         => 'cloud_volume_snapshot_id',
+          :id           => 'cloud_volume_snapshot_id',
+          :label        => _('Base Snapshot'),
+          :includeEmpty => true,
+          :condition    => {
             :when => 'edit',
             :is   => false,
           },
-          :options   => ems.cloud_volume_snapshots.map do |cvs|
+          :options      => ems.cloud_volume_snapshots.map do |cvs|
             {
               :value => cvs.id,
               :label => cvs.name,


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare