### PR TITLE
Added Number Value Validator to Form Schema

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -124,7 +124,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
           :type       => 'number',
           :step       => 1.gigabytes,
           :isRequired => true,
-          :validate   => [{:type => 'required'}],
+          :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 0, :message => _('Size must be greater than or equal to 0')}],
           :condition  => {
             :or => [
               {
@@ -205,7 +205,8 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
           :condition => {
             :when => 'volume_type',
             :is   => 'io1',
-          }
+          },
+          :validate  => [{:type => 'min-number-value', :value => 0, :message => _('Number of IOPS Must be greater than or equal to 0')}],
         },
         {
           :component    => 'select',


### PR DESCRIPTION
Found in: Storage->Block Storage->Volumes
Part of the Fix for: https://github.com/ManageIQ/manageiq-ui-classic/issues/7713

Adds the number value validator from Data Driven Forms to the Cloud Volume schema to ensure the user can't enter a negative number for the size field

Preview:
<img src="https://user-images.githubusercontent.com/64800041/115437778-99c99700-a1da-11eb-98ac-8d87bb88b71a.png" width="400">