### PR TITLE
Remove unused validate_update_volume

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -46,10 +46,6 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
     raise MiqException::MiqVolumeCreateError, e.to_s, e.backtrace
   end
 
-  def validate_update_volume
-    validate_volume
-  end
-
   def raw_update_volume(options)
     with_provider_object do |volume|
       # Update the name in case it was provided in the options.


### PR DESCRIPTION
Follow-up to: https://github.com/ManageIQ/manageiq/pull/21181

This has been replaced with `supports :update`