### PR TITLE
Subclassed provider classes should mark the parent as a leaf class

### DIFF
--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
   require_nested :Container
   require_nested :ContainerGroup

--- a/app/models/manageiq/providers/amazon/container_manager/container.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/container.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::Container.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Amazon::ContainerManager::Container < ManageIQ::Providers::Kubernetes::ContainerManager::Container
 end

--- a/app/models/manageiq/providers/amazon/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/container_group.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Amazon::ContainerManager::ContainerGroup < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup
 end

--- a/app/models/manageiq/providers/amazon/container_manager/container_node.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/container_node.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Amazon::ContainerManager::ContainerNode < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode
 end


### PR DESCRIPTION
- [ ] Depends on https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/433

@agrare Please review.