### PR TITLE
[KASPAROV] Replace authentication_status_ok? with provider specific version

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinatorWorker < MiqWorker
   end
 
   def self.all_valid_ems_in_zone
-    ems_class.where(:zone_id => MiqServer.my_server.zone.id).select { |e| e.enabled && e.authentication_status_ok? }
+    ems_class.where(:zone_id => MiqServer.my_server.zone.id).select { |e| e.enabled && e.provider_authentication_status_ok? }
   end
 
   def self.ems_class


### PR DESCRIPTION
This wasn't required when this was done for master because the provider_worker_mixin refactoring meant this automatically picked up the improved `all_valid_ems_in_zone` method.

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/21198