### PR TITLE
Use the AmazonEksCredentials class from Kubeclient

### DIFF
--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -32,30 +32,20 @@ class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kuber
     auth_options[:bearer_token] = options[:bearer] if options[:bearer].present?
 
     # Otherwise request a token from STS with an access_key+secret_access_key
-    auth_options[:bearer_token] ||= sts_eks_token(options[:username], options[:password], options[:region_name], options[:cluster_name])
+    auth_options[:bearer_token] ||= sts_eks_token(options[:username], options[:password], options[:cluster_name])
 
     auth_options
   end
 
-  def self.sts_eks_token(access_key, secret_access_key, region_name, cluster_name)
-    url = sts_presigned_url(access_key, secret_access_key, region_name, cluster_name)
+  def self.sts_eks_token(access_key, secret_access_key, cluster_name)
+    require "kubeclient/aws_eks_credentials"
+    require "aws-sdk-sts"
 
-    "k8s-aws-v1.#{Base64.urlsafe_encode64(url).sub(/=+$/, "")}"
+    credentials = Aws::Credentials.new(access_key, secret_access_key)
+
+    Kubeclient::AmazonEksCredentials.token(credentials, cluster_name)
   end
   private_class_method :sts_eks_token
-
-  def self.sts_presigned_url(access_key, secret_access_key, region_name, cluster_name)
-    require "aws-sdk-sts"
-    sts_client = Aws::STS::Client.new(
-      :credentials => Aws::Credentials.new(access_key, secret_access_key),
-      :region      => region_name
-    )
-
-    Aws::STS::Presigner.new(:client => sts_client).get_caller_identity_presigned_url(
-      :headers => {"X-K8s-Aws-Id" => cluster_name}
-    )
-  end
-  private_class_method :sts_presigned_url
 
   def self.verify_credentials(args)
     # If we are editing an existing EMS we won't be given the existing passwords


### PR DESCRIPTION
Kubeclient has their own AWS EKS Credentials class so we don't need to
do the signing/STS calls ourselves.