### PR TITLE
Bump aws-sdk-s3 to include xml parser fix

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk-core",                 ">= 3.104.3"
+  spec.add_dependency "aws-sdk-core",                 "~> 3.114"
   spec.add_dependency "aws-sdk-cloudformation",       "~> 1.0"
   spec.add_dependency "aws-sdk-cloudwatch",           "~> 1.0"
   spec.add_dependency "aws-sdk-ec2",                  "~> 1.0"
   spec.add_dependency "aws-sdk-elasticloadbalancing", "~> 1.0"
   spec.add_dependency "aws-sdk-iam",                  "~> 1.0"
   spec.add_dependency "aws-sdk-rds",                  "~> 1.0"
-  spec.add_dependency "aws-sdk-s3",                   "~> 1.0"
+  spec.add_dependency "aws-sdk-s3",                   "~> 1.0", ">= 1.96.1"
   spec.add_dependency "aws-sdk-servicecatalog",       "~> 1.0"
   spec.add_dependency "aws-sdk-sns",                  "~> 1.0"
   spec.add_dependency "aws-sdk-sqs",                  "~> 1.0"


### PR DESCRIPTION
Pull in https://github.com/aws/aws-sdk-ruby/pull/2538 which fixes https://github.com/aws/aws-sdk-ruby/issues/2536