### PR TITLE
Dependent destroy network_manager and don't delegate zone

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -26,7 +26,9 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::Amazon::NetworkManager",
-          :autosave    => true
+          :autosave    => true,
+          :dependent   => :destroy,
+          :inverse_of  => :parent_manager
 
   has_many :storage_managers,
            :foreign_key => :parent_ems_id,

--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -20,7 +20,6 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
            :authentication_status_ok?,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :connect,
            :verify_credentials,
            :with_provider_connection,

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
@@ -10,7 +10,6 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs < ManageIQ::Providers::St
            :authentication_status,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :connect,
            :verify_credentials,
            :with_provider_connection,

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -13,7 +13,6 @@ class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::Sto
            :authentication_status,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :verify_credentials,
            :address,
            :ip_address,


### PR DESCRIPTION
Match the behavior of the storage managers and dependent destroy the network_manager.  Also remove the delegation of zone to the parent manager since the zone_id is sync'd to the child managers already.  This allows us to add the `inverse_of => :parent_manager` without breaking

Dependent:

- [x] https://github.com/ManageIQ/manageiq/pull/21300