### PR TITLE
Fixed react prop errors for cloud_manager

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -230,8 +230,9 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
                           :component    => 'text-field',
                           :name         => 'endpoints.smartstate_docker',
                           :id           => 'endpoints.smartstate_docker',
-                          :type         => 'hidden',
-                          :initialValue => {},
+                          :hideField    => true,
+                          :label        => 'smartstate_docker',
+                          :initialValue => '',
                         },
                         {
                           :component  => "text-field",


### PR DESCRIPTION
Fixed these console errors in the cloud provider form and changed implementation of hidden text-field.
<img width="1186" alt="Screen Shot 2021-07-07 at 11 37 57 AM" src="https://user-images.githubusercontent.com/32444791/125129291-40804e00-e0cd-11eb-8150-24e8261653ec.png">
<img width="959" alt="Screen Shot 2021-07-07 at 11 38 03 AM" src="https://user-images.githubusercontent.com/32444791/125129289-3fe7b780-e0cd-11eb-97c6-71e84f14f925.png">

@miq-bot add_reviewer @agrare 
@miq-bot add-label bug