### PR TITLE
Add supports :storage_manager and block_storage_manager Function to Amazon CloudManager

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -75,6 +75,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   supports :assume_role
   supports :auth_key_pair_create
   supports :label_mapping
+  supports :storage_manager
 
   def ensure_managers
     build_network_manager unless network_manager
@@ -269,6 +270,10 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   def allow_targeted_refresh?
     true
+  end
+
+  def block_storage_manager
+    ebs_storage_manager
   end
 
   # @param [ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate] template


### PR DESCRIPTION
Add supports `:storage_manager` and function `block_storage_manager` for storage manager access on UI side: https://github.com/ManageIQ/manageiq-ui-classic/pull/7821/files

@miq-bot add_reviewer @agrare
@miq-bot add-label enhancement