### PR TITLE
Prevent services other than EC2 from causing refresh failures

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
@@ -21,6 +21,10 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
 
   def cloud_databases
     hash_collection.new(aws_rds.client.describe_db_instances.flat_map(&:db_instances))
+  rescue
+    # RDS is an optional collection and failures shouldn't prevent the rest of the refresh
+    # from succeeding
+    []
   end
 
   def private_images
@@ -64,6 +68,10 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
 
   def stacks
     hash_collection.new(aws_cloud_formation.client.describe_stacks.flat_map(&:stacks))
+  rescue
+    # CloudFormation is an optional service and failures shouldn't prevent the rest
+    # of the refresh from succeeding
+    []
   end
 
   def stack_resources(stack_name)
@@ -76,10 +84,18 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
     end
 
     hash_collection.new(stack_resources || [])
+  rescue
+    # CloudFormation is an optional service and failures shouldn't prevent the rest
+    # of the refresh from succeeding
+    []
   end
 
   def stack_template(stack_name)
     aws_cloud_formation.client.get_template(:stack_name => stack_name).template_body
+  rescue
+    # CloudFormation is an optional service and failures shouldn't prevent the rest
+    # of the refresh from succeeding
+    []
   end
 
   def service_offerings

--- a/app/models/manageiq/providers/amazon/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/network_manager.rb
@@ -17,12 +17,20 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::NetworkManager < Manage
 
   def load_balancers
     hash_collection.new(aws_elb.client.describe_load_balancers.flat_map(&:load_balancer_descriptions))
+  rescue
+    # ELB is an optional service and failures shouldn't prevent the rest
+    # of the refresh from succeeding
+    []
   end
 
   def health_check_members(load_balancer_name)
     hash_collection.new(aws_elb.client.describe_instance_health(
       :load_balancer_name => load_balancer_name
     ).flat_map(&:instance_states))
+  rescue
+    # ELB is an optional service and failures shouldn't prevent the rest
+    # of the refresh from succeeding
+    []
   end
 
   def floating_ips


### PR DESCRIPTION
Only access to the EC2 service is required for the refresh to complete, other services are optional and failures there (e.g. due to lack of permissions) shouldn't cause the entire refresh to fail.