### PR TITLE
Fix labeled_resource_type for Amazon Vms/Images

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -66,7 +66,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       image_hardware(persister_image, image)
       image_operating_system(persister_image, image)
       vm_and_template_labels(persister_image, image["tags"] || [])
-      vm_and_template_taggings(persister_image, map_labels("Image", image["tags"] || []))
+      vm_and_template_taggings(persister_image, map_labels("ImageAmazon", image["tags"] || []))
     end
   end
 
@@ -280,7 +280,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
       instance_hardware(persister_instance, instance, flavor)
       instance_operating_system(persister_instance, instance)
       vm_and_template_labels(persister_instance, instance["tags"] || [])
-      vm_and_template_taggings(persister_instance, map_labels("Vm", instance["tags"] || []))
+      vm_and_template_taggings(persister_instance, map_labels("VmAmazon", instance["tags"] || []))
     end
   end
 

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -1375,11 +1375,11 @@ module AwsRefresherSpecCommon
 
   def create_tag_mapping
     @all_tag_mapping = FactoryBot.create(:tag_mapping_with_category,
-                                          :label_name => "owner")
+                                         :all_entities, :label_name => "owner")
     @all_tag_mapping_category = @all_tag_mapping.tag.classification
 
     @image_tag_mapping = FactoryBot.create(:tag_mapping_with_category,
-                                            :label_name => "Name", :labeled_resource_type => "Image")
+                                           :label_name => "Name", :labeled_resource_type => "ImageAmazon")
     @image_tag_mapping_category = @image_tag_mapping.tag.classification
   end
 

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -65,15 +65,11 @@ module AwsRefresherSpecCounts
     # Custom attributes of all Vms and Images
     custom_attributes_count = (vms_tags + images_tags).size
 
-    vms_mappings = ProviderTagMapping.where(:labeled_resource_type => nil).or(
-      ProviderTagMapping.where(:labeled_resource_type => "Vm")
-    ).pluck(:label_name)
+    vms_mappings = ProviderTagMapping.where(:labeled_resource_type => ["_all_entities_", "VmAmazon"]).pluck(:label_name)
     # Correct count of mapped tags for Vms
     vms_tags_count = vms_tags.select { |x| vms_mappings.include?(x["key"]) && x["value"].present? }.count
 
-    images_mappings = ProviderTagMapping.where(:labeled_resource_type => nil).or(
-      ProviderTagMapping.where(:labeled_resource_type => "Image")
-    ).pluck(:label_name)
+    images_mappings = ProviderTagMapping.where(:labeled_resource_type => ["_all_entities_", "ImageAmazon"]).pluck(:label_name)
     # Correct count of mapped tags for Images
     images_tags_count = images_tags.select { |x| images_mappings.include?(x["key"]) && x["value"].present? }.count
 


### PR DESCRIPTION
These were renamed from Vm and Image to VmAmazon and ImageAmazon in the UI https://github.com/ManageIQ/manageiq-ui-classic/pull/7438 and the pluggable mapper was updated in the provider https://github.com/ManageIQ/manageiq-providers-amazon/pull/671 but the parser was never updated to match.