### PR TITLE
Switch to standard persister definitions for multi-manager refresh

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/definitions/cloud_collections.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::CloudColl
        service_offerings
        service_parameters_sets).each do |name|
 
-      add_collection(cloud, name)
+      add_cloud_collection(name)
     end
 
     add_cloud_database_flavors
@@ -29,21 +29,21 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::CloudColl
        orchestration_stacks_parameters
        orchestration_templates).each do |name|
 
-      add_collection(cloud, name)
+      add_cloud_collection(name)
     end
 
     # Custom processing of Ancestry
     %i(vm_and_miq_template_ancestry
        orchestration_stack_ancestry).each do |name|
 
-      add_collection(cloud, name)
+      add_cloud_collection(name)
     end
   end
 
   # ------ IC provider specific definitions -------------------------
 
   def add_cloud_database_flavors(extra_properties = {})
-    add_collection(cloud, :cloud_database_flavors, extra_properties) do |builder|
+    add_cloud_collection(:cloud_database_flavors, extra_properties) do |builder|
       # Model we take just from a DB, there is no flavors API
       builder.add_properties(:strategy => :local_db_find_references) if targeted?
     end

--- a/app/models/manageiq/providers/amazon/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/definitions/network_collections.rb
@@ -13,10 +13,7 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::NetworkCo
        load_balancer_listener_pools
        load_balancer_health_checks
        load_balancer_health_check_members).each do |name|
-
-      add_collection(network, name) do |builder|
-        builder.add_properties(:parent => manager.network_manager) if targeted?
-      end
+      add_network_collection(name)
     end
 
     add_cloud_subnet_network_ports
@@ -31,34 +28,30 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::NetworkCo
   # ------ IC provider specific definitions -------------------------
 
   def add_network_ports(extra_properties = {})
-    add_collection(network, :network_ports, extra_properties) do |builder|
+    add_network_collection(:network_ports, extra_properties) do |builder|
       if targeted?
         builder.add_properties(:manager_uuids => references(:vms) + references(:network_ports) + references(:load_balancers))
-        builder.add_properties(:parent => manager.network_manager)
       end
     end
   end
 
   def add_floating_ips(extra_properties = {})
-    add_collection(network, :floating_ips, extra_properties) do |builder|
+    add_network_collection(:floating_ips, extra_properties) do |builder|
       if targeted?
         builder.add_properties(:manager_uuids => references(:floating_ips) + references(:load_balancers))
-        builder.add_properties(:parent => manager.network_manager)
       end
     end
   end
 
   def add_cloud_subnet_network_ports(extra_properties = {})
-    add_collection(network, :cloud_subnet_network_ports, extra_properties) do |builder|
+    add_network_collection(:cloud_subnet_network_ports, extra_properties) do |builder|
       builder.add_properties(:manager_ref_allowed_nil => %i(cloud_subnet))
-      builder.add_properties(:parent => manager.network_manager) if targeted?
     end
   end
 
   def add_firewall_rules(extra_properties = {})
-    add_collection(network, :firewall_rules, extra_properties) do |builder|
+    add_network_collection(:firewall_rules, extra_properties) do |builder|
       builder.add_properties(:manager_ref_allowed_nil => %i(source_security_group))
-      builder.add_properties(:parent => manager.network_manager) if targeted?
     end
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/persister/definitions/storage_collections.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/definitions/storage_collections.rb
@@ -8,56 +8,48 @@ module ManageIQ::Providers::Amazon::Inventory::Persister::Definitions::StorageCo
   # ------ IC provider specific definitions -------------------------
 
   def add_cloud_volumes(extra_properties = {})
-    add_collection(storage, :cloud_volumes, extra_properties) do |builder|
+    add_ebs_collection(:cloud_volumes, extra_properties) do |builder|
       builder.add_properties(:model_class => ::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume)
-      builder.add_properties(:parent => manager.ebs_storage_manager) if targeted?
-
-      builder.add_default_values(
-        :ems_id => block_storage_manager_id
-      )
     end
   end
 
   def add_cloud_volume_snapshots(extra_properties = {})
-    add_collection(storage, :cloud_volume_snapshots, extra_properties) do |builder|
+    add_ebs_collection(:cloud_volume_snapshots, extra_properties) do |builder|
       builder.add_properties(:model_class => ::ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot)
-      builder.add_properties(:parent => manager.ebs_storage_manager) if targeted?
-
-      builder.add_default_values(
-        :ems_id => block_storage_manager_id
-      )
     end
   end
 
   def add_cloud_object_store_containers(extra_properties = {})
-    add_collection(storage, :cloud_object_store_containers, extra_properties) do |builder|
+    add_s3_collection(:cloud_object_store_containers, extra_properties) do |builder|
       builder.add_properties(:model_class => ::ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer)
-      builder.add_properties(:parent => manager.s3_storage_manager) if targeted?
-
-      builder.add_default_values(
-        :ems_id => object_storage_manager_id
-      )
     end
   end
 
   def add_cloud_object_store_objects(extra_properties = {})
-    add_collection(storage, :cloud_object_store_objects, extra_properties) do |builder|
+    add_s3_collection(:cloud_object_store_objects, extra_properties) do |builder|
       builder.add_properties(:model_class => ::ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject)
-      builder.add_properties(:parent => manager.s3_storage_manager) if targeted?
-
-      builder.add_default_values(
-        :ems_id => object_storage_manager_id
-      )
     end
   end
 
   protected
 
-  def block_storage_manager_id
-    manager.try(:ebs_storage_manager).try(:id) || manager.id
+  def ebs_manager
+    manager.kind_of?(ManageIQ::Providers::Amazon::StorageManager::Ebs) ? manager : manager.ebs_storage_manager
   end
 
-  def object_storage_manager_id
-    manager.try(:s3_storage_manager).try(:id) || manager.id
+  def s3_manager
+    manager.kind_of?(ManageIQ::Providers::Amazon::StorageManager::S3) ? manager : manager.s3_storage_manager
+  end
+
+  def add_ebs_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    settings[:parent] ||= ebs_manager
+
+    add_collection(storage, collection_name, extra_properties, settings, &block)
+  end
+
+  def add_s3_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    settings[:parent] ||= s3_manager
+
+    add_collection(storage, collection_name, extra_properties, settings, &block)
   end
 end

--- a/app/models/manageiq/providers/amazon/inventory/persister/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/network_manager.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::Amazon::Inventory::Persister::NetworkManager < Manage
   def initialize_network_inventory_collections
     super
 
-    add_collection(network, :network_routers)
+    add_network_collection(:network_routers)
   end
 
   def initialize_cloud_inventory_collections
@@ -19,11 +19,8 @@ class ManageIQ::Providers::Amazon::Inventory::Persister::NetworkManager < Manage
        orchestration_stacks
        vms).each do |name|
 
-      add_collection(cloud, name) do |builder|
-        builder.add_properties(
-          :parent   => manager.parent_manager,
-          :strategy => :local_db_cache_all
-        )
+      add_cloud_collection(name) do |builder|
+        builder.add_properties(:strategy => :local_db_cache_all)
       end
     end
   end

--- a/app/models/manageiq/providers/amazon/inventory/persister/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/storage_manager/ebs.rb
@@ -20,9 +20,7 @@ class ManageIQ::Providers::Amazon::Inventory::Persister::StorageManager::Ebs < M
        vms
        disks).each do |name|
 
-      add_collection(cloud, name) do |builder|
-        builder.add_properties(:parent => manager.parent_manager)
-
+      add_cloud_collection(name) do |builder|
         builder.add_properties(:update_only => true) if name == :disks
         builder.add_properties(:strategy => :local_db_cache_all) unless name == :disks
       end


### PR DESCRIPTION
We have added methods to core to handle setting the parent for child-managers doing combined-targeted-refresh