### PR TITLE
Fix stack template errors causing [].encode exception

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/cloud_manager.rb
@@ -95,7 +95,7 @@ class ManageIQ::Providers::Amazon::Inventory::Collector::CloudManager < ManageIQ
   rescue
     # CloudFormation is an optional service and failures shouldn't prevent the rest
     # of the refresh from succeeding
-    []
+    nil
   end
 
   def service_offerings

--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -190,10 +190,13 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
 
   def stack_template(stack)
     stack_name = get_stack_name(stack)
+    content    = collector.stack_template(stack_name)
+    return if content.nil?
+
     persister.orchestration_templates.find_or_build(stack['stack_id']).assign_attributes(
       :name        => stack_name,
       :description => stack['description'],
-      :content     => collector.stack_template(stack_name),
+      :content     => content,
       :orderable   => false
     )
   end


### PR DESCRIPTION
If we encounter an error collecting the stack template we shouldn't return an empty array since the `collector.stack_template()` method returns a single item not a collection.

```
[NoMethodError]: undefined method `encode' for []:Array  Method:[block (2 levels) in <class:LogProxy>]
/var/www/miq/vmdb/app/models/orchestration_template.rb:211:in `with_universal_newline'
/var/www/miq/vmdb/app/models/orchestration_template.rb:46:in `block in find_or_create_by_contents'
/var/www/miq/vmdb/app/models/orchestration_template.rb:40:in `reject'
/var/www/miq/vmdb/app/models/orchestration_template.rb:40:in `find_or_create_by_contents'
/var/www/miq/vmdb/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb:79:in `block in orchestration_templates'
```