### PR TITLE
Fix gettext interpolation syntax in unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -10,11 +10,11 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
   end
   supports :attach_volume do
     unsupported_reason_add(:attach_volume, _("the volume is not connected to an active provider")) unless ext_management_system
-    unsupported_reason_add(:attach_volume, _("the volume status is '%{status}' but should be 'available'"), {:status => status}) unless status == "available"
+    unsupported_reason_add(:attach_volume, _("the volume status is '%{status}' but should be 'available'") % {:status => status}) unless status == "available"
   end
   supports :detach_volume do
     unsupported_reason_add(:detach_volume, _("the volume is not connected to an active provider")) unless ext_management_system
-    unsupported_reason_add(:detach_volume, _("the volume status is '%{status}' but should be 'in-use'"), {:status => status}) unless status == "in-use"
+    unsupported_reason_add(:detach_volume, _("the volume status is '%{status}' but should be 'in-use'") % {:status => status}) unless status == "in-use"
   end
 
   CLOUD_VOLUME_TYPES = {


### PR DESCRIPTION
These unsupported_region_add calls were using `,` instead of `%` which caused `Internal Error: wrong number of arguments (given 3, expected 1..2)`