### PR TITLE
The instances.json file has been removed from github

### DIFF
--- a/lib/tasks_private/instance_types.rake
+++ b/lib/tasks_private/instance_types.rake
@@ -16,7 +16,7 @@ namespace 'aws:extract' do
 
     def instances
       require 'open-uri'
-      URI.open("https://raw.githubusercontent.com/powdahound/ec2instances.info/master/www/instances.json") do |io|
+      URI.open("https://instances.vantage.sh/instances.json") do |io|
         JSON.parse(io.read)
       end
     end


### PR DESCRIPTION
The ec2instances.info project no longer maintains a static instances.json file in their github repo as of https://github.com/vantage-sh/ec2instances.info/commit/d6a25fb7690b98201629e9f5b19447a08319e583
It is available at https://instances.vantage.sh/instances.json however