### PR TITLE
Add github action to update instance-types

### DIFF
--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -1,6 +1,7 @@
 name: Update Instance Types
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: '0 0 * * 0'
 

--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -24,3 +24,4 @@ jobs:
         add-paths: db/fixtures/aws_instance_types.yml
         commit-message: Update AWS instance_types
         title: Update AWS instance_types
+        token: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -1,0 +1,26 @@
+name: Update Instance Types
+
+on:
+  schedule:
+  - cron: '0 0 * * 0'
+
+jobs:
+  update-instance-types:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up system
+      run: bin/before_install
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - name: Run instance_types rake task
+      run: bundle exec rake aws:extract:instance_types
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        add-paths: db/fixtures/aws_instance_types.yml
+        commit-message: Update AWS instance_types
+        title: Update AWS instance_types

--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -24,5 +24,7 @@ jobs:
       with:
         add-paths: db/fixtures/aws_instance_types.yml
         commit-message: Update AWS instance_types
+        branch: update_aws_instance_types
         title: Update AWS instance_types
+        body: Update the saved list of AWS instance_types from https://instances.vantage.sh/instances.json
         token: ${{ secrets.DEPLOY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle
 
 .rubocop-*
 /bundler.d/*


### PR DESCRIPTION
Example run: https://github.com/agrare/manageiq-providers-amazon/actions/runs/1993106302
Example PR: https://github.com/agrare/manageiq-providers-amazon/pull/2, https://github.com/agrare/manageiq-providers-amazon/pull/5

TODO:
- [x] Drop postgres service requirement
- [x] Use a personal access token so that tests can run on the created PR