### PR TITLE
Cloud volume snapshot

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -87,14 +87,6 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
     end
   end
 
-  def create_volume_snapshot(options)
-    ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot.create_snapshot(self, options)
-  end
-
-  def create_volume_snapshot_queue(userid, options)
-    ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot.create_snapshot_queue(userid, self, options)
-  end
-
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.volume(ems_ref)

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot < ::CloudVolumeSnapshot
   supports :create
-  supports :update
   supports :delete
 
   def self.raw_create_snapshot(cloud_volume, options = {})

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume_snapshot.rb
@@ -3,27 +3,7 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolumeSnapshot < ::
   supports :update
   supports :delete
 
-  def self.create_snapshot_queue(userid, cloud_volume, options = {})
-    ext_management_system = cloud_volume.try(:ext_management_system)
-    task_opts = {
-      :action => "creating volume snapshot in #{ext_management_system.inspect} for #{cloud_volume.inspect} with #{options.inspect}",
-      :userid => userid
-    }
-
-    queue_opts = {
-      :class_name  => cloud_volume.class.name,
-      :instance_id => cloud_volume.id,
-      :method_name => 'create_volume_snapshot',
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => my_zone(ext_management_system),
-      :args        => [options]
-    }
-
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
-  def self.create_snapshot(cloud_volume, options = {})
+  def self.raw_create_snapshot(cloud_volume, options = {})
     raise ArgumentError, _("cloud_volume cannot be nil") if cloud_volume.nil?
     ext_management_system = cloud_volume.try(:ext_management_system)
     raise ArgumentError, _("ext_management_system cannot be nil") if ext_management_system.nil?


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq-api/pull/1134

move crud for cloud volume snapshots to core and use raw_ naming convention