### PR TITLE
Add custom schema fields to Amazon attach cloud volume form

### DIFF
--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -290,6 +290,21 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVol
     }
   end
 
+  def params_for_attach
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'device_mountpoint',
+          :id         => 'device_mountpoint',
+          :label      => _('Device Mountpoint'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+        },
+      ]
+    }
+  end
+
   private
 
   def modify_volume_options(options = {})


### PR DESCRIPTION
Pre-requisite / companion PR to [1141](https://github.com/ManageIQ/manageiq-api/pull/1141) and [8205](https://github.com/ManageIQ/manageiq-ui-classic/pull/8205). 

Part of the process for upgrading [_attach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_attach.html.haml#L33) and [_detach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_detach.html.haml#L25) to react as per https://github.com/ManageIQ/manageiq-ui-classic/issues/7603.