### PR TITLE
AWS instance_types update push to fork

### DIFF
--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -25,6 +25,7 @@ jobs:
         add-paths: db/fixtures/aws_instance_types.yml
         commit-message: Update AWS instance_types
         branch: update_aws_instance_types
+        push-to-fork: miq-bot/manageiq-providers-amazon
         title: Update AWS instance_types
         body: Update the saved list of AWS instance_types from https://instances.vantage.sh/instances.json
         token: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
When automatically updating the AWS instance types via github actions push to fork instead of the main repository

Follow-up to: https://github.com/ManageIQ/manageiq-providers-amazon/pull/752
https://github.com/ManageIQ/manageiq-providers-amazon/pull/762#issuecomment-1113657088