### PR TITLE
Dynamically check flavors count from aws_instance_types.yml

### DIFF
--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -30,6 +30,11 @@ module AwsRefresherSpecCommon
     }
   ].freeze
 
+  def flavors_count
+    aws_instance_types_path = ManageIQ::Providers::Amazon::Engine.root.join("db/fixtures/aws_instance_types.yml")
+    YAML.load_file(aws_instance_types_path).keys.count
+  end
+
   def stub_refresh_settings(settings)
     # TODO(lsmola) extract the batch sizes to the settings and stub the settings instead
     # Lower batch sizes to test multiple batches for each collection

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_counts.rb
@@ -152,7 +152,7 @@ module AwsRefresherSpecCounts
       :custom_attribute              => custom_attributes_count,
       :disk                          => disks_count,
       :firewall_rule                 => firewall_rules_count,
-      :flavor                        => 479,
+      :flavor                        => flavors_count,
       :floating_ip                   => floating_ips_count,
       :hardware                      => instances_and_images_count,
       :miq_template                  => images_count,

--- a/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/stubbed_refresher_spec.rb
@@ -139,7 +139,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     {
       :auth_private_key                  => test_counts[:key_pair_count],
       :ext_management_system             => expected_ext_management_systems_count,
-      :flavor                            => 479,
+      :flavor                            => flavors_count,
       :availability_zone                 => 5,
       :vm_or_template                    => vm_count_plus_disconnect_inv + image_count_plus_disconnect_inv,
       :vm                                => vm_count_plus_disconnect_inv,


### PR DESCRIPTION
Allow for auto-updating the list of aws_instance_types without having to manually edit the spec tests to update the flavors count