### PR TITLE
Auto-delete instance_types branch after merge

### DIFF
--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -25,6 +25,7 @@ jobs:
         add-paths: db/fixtures/aws_instance_types.yml
         commit-message: Update AWS instance_types
         branch: update_aws_instance_types
+        delete-branch: true
         push-to-fork: miq-bot/manageiq-providers-amazon
         title: Update AWS instance_types
         body: Update the saved list of AWS instance_types from https://instances.vantage.sh/instances.json


### PR DESCRIPTION
Automatically delete the remote branch created during the automatic instance_types action