### PR TITLE
Run update_instance_types daily for troubleshooting

### DIFF
--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -3,7 +3,7 @@ name: Update Instance Types
 on:
   workflow_dispatch:
   schedule:
-  - cron: '0 0 * * 0'
+  - cron: '0 0 * * *'
 
 jobs:
   update-instance-types:


### PR DESCRIPTION
We are noticing some issues pushing a branch on a scheduled run due to token permissions, run daily for faster troubleshooting