### PR TITLE
Updates to database schema

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/cloud_database.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/cloud_database.rb
@@ -59,6 +59,8 @@ class ManageIQ::Providers::Amazon::CloudManager::CloudDatabase < ::CloudDatabase
           :id        => 'username',
           :name      => 'username',
           :label     => _('Master Username'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
         },
         {
           :component => 'password-field',
@@ -66,6 +68,8 @@ class ManageIQ::Providers::Amazon::CloudManager::CloudDatabase < ::CloudDatabase
           :id        => 'password',
           :name      => 'password',
           :label     => _('Master Password'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
         },
       ],
     }


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/403

~~db.t1.micro is now deprecated, as seen by this error: `["status", "Error"], ["message", "Invalid DB Instance class: db.t1.micro"]` and we can see that it is no longer listed [here](https://aws.amazon.com/rds/instance-types/).~~ <- Handled in seperate PR, see discussion below. 