### PR TITLE
Fix Amazon Authenticator Spec

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -435,7 +435,7 @@ describe Authenticator::Amazon do
             expect(AuditEvent).to receive(:failure).with({
               :event   => 'authorize',
               :userid  => username,
-              :message => "Authentication failed for userid #{username}, unable to match user's group membership to an EVM role",
+              :message => "Authentication failed for userid #{username}, unable to match user's group membership to an EVM role. The incoming groups are: #{aws_group_name}",
             })
             authenticate
           end


### PR DESCRIPTION
The failure exception message now includes the requested incoming groups, changed by https://github.com/ManageIQ/manageiq/pull/22382

Fix for failing CI starting at https://github.com/ManageIQ/manageiq-providers-amazon/actions/runs/4485061610