### PR TITLE
Add missing dependency on net-scp, consolidate gem loader to the namespaced location

### DIFF
--- a/lib/manageiq-providers-amazon.rb
+++ b/lib/manageiq-providers-amazon.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/amazon/engine"
-require "manageiq/providers/amazon/version"

--- a/lib/manageiq/providers/amazon.rb
+++ b/lib/manageiq/providers/amazon.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/amazon/engine"
+require "manageiq/providers/amazon/version"

--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-servicecatalog",       "~> 1.0"
   spec.add_dependency "aws-sdk-sns",                  "~> 1.0"
   spec.add_dependency "aws-sdk-sqs",                  "~> 1.0"
+  spec.add_dependency "net-scp",                      "~> 1.2"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-amazon"
+require "manageiq/providers/amazon"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-amazon/blob/a22095fd65085a052202ce707aea69839550ed87/app/models/manageiq/providers/amazon/agent_coordinator.rb#L3

ManageIQ::ApplianceConsole was pulling in this dependency for us but if zeitwerk
autoloads this provider first, the gem dependency doesn't exist yet.

See: https://github.com/ManageIQ/manageiq-appliance_console/blob/master/manageiq-appliance_console.gemspec#L32


Additionally, consolidate the gem loader to the one in the namespaced directory location.

