### PR TITLE
Update safe_load calls to work with psych 3/4

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_template.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate < Orchest
 
   def parse
     return JSON.parse(content) if format == :json
-    YAML.safe_load(content, [Date])
+    YAML.safe_load(content, :permitted_classes => [Date])
   end
 
   def validate_format_yaml


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/issues/22696

Keep compatibility with psych 3.1+ since permitted_classes and aliases were added as keyword arguments to safe_load.

Note, psych 4 changed the interface to drop support with positional arguments for the permitted_classes. Now, we must explicitly specify them using kwargs.