### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker.rb
@@ -2,8 +2,6 @@ class ManageIQ::Providers::Amazon::AgentCoordinatorWorker < MiqWorker
   include ProviderWorkerMixin
   include MiqWorker::ReplicaPerWorker
 
-  require_nested :Runner
-
   self.required_roles = ['smartproxy']
   self.workers        = 1
 

--- a/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator_worker/runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Amazon::AgentCoordinatorWorker::Runner < MiqWorker::Runner
-  include_concern 'ResponseThread'
+  include ResponseThread
   def do_before_work_loop
     @coordinators = self.class.all_agent_coordinators_in_zone
     @coordinators.each(&:cleanup_agents)

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -1,24 +1,4 @@
 class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AuthKeyPair
-  require_nested :AvailabilityZone
-  require_nested :CloudDatabase
-  require_nested :CloudDatabaseFlavor
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Flavor
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :OrchestrationServiceOptionConverter
-  require_nested :OrchestrationStack
-  require_nested :OrchestrationTemplate
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :Scanning
-  require_nested :Template
-  require_nested :Vm
-
   OrchestrationTemplate.register_eligible_manager(self)
 
   include ManageIQ::Providers::Amazon::ManagerMixin

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Amazon::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Amazon::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "amazon"
 
   def friendly_name

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
-  require_nested :Status
-
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     options = format_v2_options(options)
     orchestration_manager.with_provider_connection(:service => :CloudFormation) do |service|

--- a/app/models/manageiq/providers/amazon/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/provision.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Amazon::CloudManager::Provision < ManageIQ::Providers::CloudManager::Provision
-  include_concern 'Cloning'
-  include_concern 'StateMachine'
-  include_concern 'Configuration'
+  include Cloning
+  include StateMachine
+  include Configuration
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Amazon::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-
   def self.combined_managers(ems)
     super.reject { |e| e.kind_of?(ManageIQ::Providers::Amazon::StorageManager::S3) }
   end

--- a/app/models/manageiq/providers/amazon/cloud_manager/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Amazon::CloudManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/amazon/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/template.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Amazon::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
-  include_concern 'ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared'
+  include ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared
 
   supports :provisioning do
     if ext_management_system

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Amazon::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
-  include_concern 'Operations'
-  include_concern 'ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared'
+  include Operations
+  include ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared
 
   supports :capture
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
@@ -1,8 +1,7 @@
 module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'Guest'
-  include_concern 'Power'
+  include Guest
+  include Power
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared.rb
@@ -1,4 +1,4 @@
 module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared
   extend ActiveSupport::Concern
-  include_concern 'Scanning'
+  include Scanning
 end

--- a/app/models/manageiq/providers/amazon/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/container_manager.rb
@@ -1,18 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Amazon::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-  require_nested :ServiceParametersSet
-
   supports :create
 
   def self.ems_type

--- a/app/models/manageiq/providers/amazon/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Amazon::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_amazon_eks
   end

--- a/app/models/manageiq/providers/amazon/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/container_manager/refresh_worker.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::Amazon::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
-
   def self.settings_name
     :ems_refresh_worker_amazon_eks
   end

--- a/app/models/manageiq/providers/amazon/inventory.rb
+++ b/app/models/manageiq/providers/amazon/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Amazon::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/amazon/inventory/collector.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::Amazon::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   attr_reader :instances
   attr_reader :flavors
   attr_reader :availability_zones

--- a/app/models/manageiq/providers/amazon/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/collector/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Amazon::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/amazon/inventory/parser.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Amazon::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-
   include ManageIQ::Providers::Amazon::ParserHelperMethods
 
   # Overridden helper methods, we should put them in helper once we get rid of old refresh

--- a/app/models/manageiq/providers/amazon/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Amazon::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/amazon/inventory/persister.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::Amazon::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :ContainerManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   # TODO(lsmola) figure out a way to pass collector info, probably via target, then remove the below
   attr_reader :collector
 end

--- a/app/models/manageiq/providers/amazon/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/persister/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Amazon::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -1,17 +1,4 @@
 class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :FloatingIp
-  require_nested :LoadBalancer
-  require_nested :LoadBalancerHealthCheck
-  require_nested :LoadBalancerListener
-  require_nested :LoadBalancerPool
-  require_nested :LoadBalancerPoolMember
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Amazon::ManagerMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs < ManageIQ::Providers::StorageManager
-  require_nested :CloudVolume
-  require_nested :CloudVolumeSnapshot
-  require_nested :Refresher
-
   include ManageIQ::Providers::Amazon::ManagerMixin
 
   delegate :availability_zones,

--- a/app/models/manageiq/providers/amazon/storage_manager/s3.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::Amazon::StorageManager::S3 < ManageIQ::Providers::StorageManager
-  require_nested :CloudObjectStoreContainer
-  require_nested :CloudObjectStoreObject
-  require_nested :RefreshWorker
-  require_nested :Refresher
-
   supports :object_storage
 
   include ManageIQ::Providers::Amazon::ManagerMixin

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_amazon_s3
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854