### PR TITLE
Bump Ruby version for instance_types GitHub action

### DIFF
--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: "3.0"
         bundler-cache: true
     - name: Update regions
       run: bundle exec rake aws:extract:regions


### PR DESCRIPTION
@agrare Please review.  Note that Ruby 2.7 is actually failing to bundle install at all.  See https://github.com/ManageIQ/manageiq-providers-amazon/actions/runs/7770305058/job/21329461130