### PR TITLE
Drop supports_feature? and unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/template.rb
@@ -2,10 +2,10 @@ class ManageIQ::Providers::Amazon::CloudManager::Template < ManageIQ::Providers:
   include ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared
 
   supports :provisioning do
-    if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
+    if !ext_management_system
+      _("not connected to ems")
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      ext_management_system.unsupported_reason(:provisioning)
     end
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations
 
   included do
     supports :terminate do
-      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason(:control)
     end
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm/operations/guest.rb
@@ -3,8 +3,11 @@ module ManageIQ::Providers::Amazon::CloudManager::Vm::Operations::Guest
 
   included do
     supports :reboot_guest do
-      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
-      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+      if current_state != "on"
+        _("The VM is not powered on")
+      else
+        unsupported_reason(:control)
+      end
     end
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/vm_or_template_shared/scanning.rb
@@ -4,12 +4,7 @@ module ManageIQ::Providers::Amazon::CloudManager::VmOrTemplateShared::Scanning
   require 'scanning_operations_mixin'
 
   included do
-    supports :smartstate_analysis do
-      feature_supported, reason = check_feature_support('smartstate_analysis')
-      unless feature_supported
-        unsupported_reason_add(:smartstate_analysis, reason)
-      end
-    end
+    supports(:smartstate_analysis) { unsupported_reason(:action) }
   end
 
   def scan_job_class

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs/cloud_volume.rb
@@ -1,20 +1,29 @@
 class ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume < ::CloudVolume
   supports :create
   supports :delete do
-    unsupported_reason_add(:delete, _("the volume is not connected to an active Provider")) unless ext_management_system
-    unsupported_reason_add(:delete, _("cannot delete volume that is in use.")) if status == "in-use"
+    if !ext_management_system
+      _("the volume is not connected to an active Provider")
+    elsif status == "in-use"
+      _("cannot delete volume that is in use.")
+    end
   end
   supports :snapshot_create
   supports :update do
-    unsupported_reason_add(:update, _("the volume is not connected to an active provider")) unless ext_management_system
+    _("the volume is not connected to an active provider") unless ext_management_system
   end
   supports :attach do
-    unsupported_reason_add(:attach, _("the volume is not connected to an active provider")) unless ext_management_system
-    unsupported_reason_add(:attach, _("the volume status is '%{status}' but should be 'available'") % {:status => status}) unless status == "available"
+    if !ext_management_system
+      _("the volume is not connected to an active Provider")
+    elsif status != "available"
+      _("the volume status is '%{status}' but should be 'available'") % {:status => status}
+    end
   end
   supports :detach do
-    unsupported_reason_add(:detach, _("the volume is not connected to an active provider")) unless ext_management_system
-    unsupported_reason_add(:detach, _("the volume status is '%{status}' but should be 'in-use'") % {:status => status}) unless status == "in-use"
+    if !ext_management_system
+      _("the volume is not connected to an active Provider")
+    elsif status != "in-use"
+      _("the volume status is '%{status}' but should be 'in-use'") % {:status => status}
+    end
   end
 
   CLOUD_VOLUME_TYPES = {

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_container.rb
@@ -3,24 +3,19 @@ class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreContainer
 
   supports :delete do
     unless ext_management_system
-      unsupported_reason_add(:delete, _("The Storage Container is not connected to an active %{table}") % {
+      _("The Storage Container is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
-      })
+      }
     end
   end
 
   supports :cloud_object_store_container_clear do
-    unless ext_management_system
-      unsupported_reason_add(
-        :cloud_object_store_container_clear,
-        _("The Storage Container is not connected to an active %{table}") % {
-          :table => ui_lookup(:table => "ext_management_systems")
-        }
-      )
-    end
-
-    unless cloud_object_store_objects.count.positive?
-      unsupported_reason_add(:cloud_object_store_container_clear, _("The Storage Container is already empty"))
+    if !ext_management_system
+      _("The Storage Container is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      }
+    elsif !cloud_object_store_objects.count.positive?
+      _("The Storage Container is already empty")
     end
   end
 

--- a/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/s3/cloud_object_store_object.rb
@@ -1,15 +1,13 @@
 class ManageIQ::Providers::Amazon::StorageManager::S3::CloudObjectStoreObject < ::CloudObjectStoreObject
   supports :delete do
-    unless ext_management_system
-      unsupported_reason_add(:delete, _("The Storage Object is not connected to an active %{table}") % {
+    if !ext_management_system
+      _("The Storage Object is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
-      })
-    end
-
-    unless cloud_object_store_container
-      unsupported_reason_add(:delete, _("The Storage Object is not connected to an active %{table}") % {
+      }
+    elsif !cloud_object_store_container
+      _("The Storage Object is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "cloud_object_store_containers")
-      })
+      }
     end
   end
 

--- a/spec/models/manageiq/providers/amazon/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/vm_spec.rb
@@ -102,10 +102,10 @@ describe ManageIQ::Providers::Amazon::CloudManager::Vm do
     end
   end
 
-  describe "#supports_terminate?" do
+  describe "#supports(:terminate)?" do
     context "when connected to a provider" do
       it "returns true" do
-        expect(vm.supports_terminate?).to be_truthy
+        expect(vm.supports?(:terminate)).to be_truthy
       end
     end
 
@@ -113,7 +113,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Vm do
       let(:archived_vm) { FactoryBot.create(:vm_amazon) }
 
       it "returns false" do
-        expect(archived_vm.supports_terminate?).to be_falsey
+        expect(archived_vm.supports?(:terminate)).to be_falsey
         expect(archived_vm.unsupported_reason(:terminate)).to eq("The VM is not connected to an active Provider")
       end
     end


### PR DESCRIPTION
dropped references to `supports_provisioning?` and `supports_control?`

blocked on:
- [x] https://github.com/ManageIQ/manageiq/pull/22908

part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
