### PR TITLE
Bump net-scp gem for openssl 3.0 support

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-servicecatalog",       "~> 1.0"
   spec.add_dependency "aws-sdk-sns",                  "~> 1.0"
   spec.add_dependency "aws-sdk-sqs",                  "~> 1.0"
-  spec.add_dependency "net-scp",                      "~> 1.2"
+  spec.add_dependency "net-scp",                      ">= 1.2", "<5"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Related https://github.com/ManageIQ/manageiq-appliance_console/pull/248

We'll need to merge this when we go to bump the appliance_console gem in the core Gemfile

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
