### PR TITLE
Delay load the net-scp require to avoid bloating eager loading

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -1,6 +1,5 @@
 require 'yaml'
 require 'open3'
-require 'net/scp'
 require 'tempfile'
 require 'linux_admin'
 require 'awesome_spawn'
@@ -148,6 +147,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
   private
 
   def scp_file(ip, username, auth_key, local_file, remote_file)
+    require 'net/scp'
     Net::SCP.upload!(ip, username, local_file, remote_file, :ssh => {:key_data => auth_key})
   rescue => err
     _log.error(err.message)


### PR DESCRIPTION
require net/scp seems to be around 5 MB of memory and requires 122 files:

`  0  <+  net/scp (0.236512) (5308416) (122)`

If we ever are to eager load plugins, we need to avoid having them requiring client code at code load time.