### PR TITLE
Handle nil case for networkPerformance key in deprecated AWS database types

### DIFF
--- a/db/fixtures/aws_database_types.yml
+++ b/db/fixtures/aws_database_types.yml
@@ -193,7 +193,7 @@ db.m5.large:
   :vcpu: 2
 db.m5.xlarge:
   :deprecated: false
-  :ebs_optimized: true
+  :ebs_optimized: false
   :family: General purpose
   :memory: 17179869184.0
   :name: db.m5.xlarge
@@ -993,7 +993,7 @@ db.r5b.24xlarge:
   :vcpu: 96
 db.r5b.2xlarge:
   :deprecated: false
-  :ebs_optimized: true
+  :ebs_optimized: false
   :family: Memory optimized
   :memory: 68719476736.0
   :name: db.r5b.2xlarge
@@ -1025,7 +1025,7 @@ db.r5b.2xlarge.tpc2.mem8x:
   :vcpu: 8
 db.r5b.4xlarge:
   :deprecated: false
-  :ebs_optimized: true
+  :ebs_optimized: false
   :family: Memory optimized
   :memory: 137438953472.0
   :name: db.r5b.4xlarge
@@ -1081,7 +1081,7 @@ db.r5b.8xlarge.tpc2.mem3x:
   :vcpu: 32
 db.r5b.large:
   :deprecated: false
-  :ebs_optimized: true
+  :ebs_optimized: false
   :family: Memory optimized
   :memory: 17179869184.0
   :name: db.r5b.large
@@ -1097,7 +1097,7 @@ db.r5b.large.tpc1.mem2x:
   :vcpu: 2
 db.r5b.xlarge:
   :deprecated: false
-  :ebs_optimized: true
+  :ebs_optimized: false
   :family: Memory optimized
   :memory: 34359738368.0
   :name: db.r5b.xlarge

--- a/db/fixtures/aws_database_types.yml
+++ b/db/fixtures/aws_database_types.yml
@@ -197,7 +197,7 @@ db.m5.xlarge:
   :family: General purpose
   :memory: 17179869184.0
   :name: db.m5.xlarge
-  :network_performance: :very_high
+  :network_performance:
   :vcpu: 4
 db.m5d.12xlarge:
   :deprecated: false
@@ -389,7 +389,7 @@ db.m6i.16xlarge:
   :family: General purpose
   :memory: 274877906944.0
   :name: db.m6i.16xlarge
-  :network_performance: :25_gbps
+  :network_performance:
   :vcpu: 64
 db.m6i.24xlarge:
   :deprecated: false
@@ -405,7 +405,7 @@ db.m6i.2xlarge:
   :family: General purpose
   :memory: 34359738368.0
   :name: db.m6i.2xlarge
-  :network_performance: :up_to_12.5_gbps
+  :network_performance:
   :vcpu: 8
 db.m6i.32xlarge:
   :deprecated: false
@@ -429,7 +429,7 @@ db.m6i.8xlarge:
   :family: General purpose
   :memory: 137438953472.0
   :name: db.m6i.8xlarge
-  :network_performance: :12.5_gbps
+  :network_performance:
   :vcpu: 32
 db.m6i.large:
   :deprecated: false
@@ -437,7 +437,7 @@ db.m6i.large:
   :family: General purpose
   :memory: 8589934592.0
   :name: db.m6i.large
-  :network_performance: :up_to_12.5_gbps
+  :network_performance:
   :vcpu: 2
 db.m6i.xlarge:
   :deprecated: false
@@ -445,7 +445,7 @@ db.m6i.xlarge:
   :family: General purpose
   :memory: 17179869184.0
   :name: db.m6i.xlarge
-  :network_performance: :up_to_12.5_gbps
+  :network_performance:
   :vcpu: 4
 db.m6id.12xlarge:
   :deprecated: false
@@ -917,7 +917,7 @@ db.r5.8xlarge:
   :family: Memory optimized
   :memory: 274877906944.0
   :name: db.r5.8xlarge
-  :network_performance: :very_high
+  :network_performance:
   :vcpu: 32
 db.r5.8xlarge.tpc2.mem3x:
   :deprecated: false
@@ -997,7 +997,7 @@ db.r5b.2xlarge:
   :family: Memory optimized
   :memory: 68719476736.0
   :name: db.r5b.2xlarge
-  :network_performance: :very_high
+  :network_performance:
   :vcpu: 8
 db.r5b.2xlarge.tpc1.mem2x:
   :deprecated: false
@@ -1029,7 +1029,7 @@ db.r5b.4xlarge:
   :family: Memory optimized
   :memory: 137438953472.0
   :name: db.r5b.4xlarge
-  :network_performance: :very_high
+  :network_performance:
   :vcpu: 16
 db.r5b.4xlarge.tpc2.mem2x:
   :deprecated: false
@@ -1085,7 +1085,7 @@ db.r5b.large:
   :family: Memory optimized
   :memory: 17179869184.0
   :name: db.r5b.large
-  :network_performance: :very_high
+  :network_performance:
   :vcpu: 2
 db.r5b.large.tpc1.mem2x:
   :deprecated: false
@@ -1101,7 +1101,7 @@ db.r5b.xlarge:
   :family: Memory optimized
   :memory: 34359738368.0
   :name: db.r5b.xlarge
-  :network_performance: :very_high
+  :network_performance:
   :vcpu: 4
 db.r5b.xlarge.tpc2.mem2x:
   :deprecated: false
@@ -1325,7 +1325,7 @@ db.r6i.24xlarge:
   :family: Memory optimized
   :memory: 824633720832.0
   :name: db.r6i.24xlarge
-  :network_performance: :37.5_gbps
+  :network_performance:
   :vcpu: 96
 db.r6i.2xlarge:
   :deprecated: false
@@ -1365,7 +1365,7 @@ db.r6i.32xlarge:
   :family: Memory optimized
   :memory: 1099511627776.0
   :name: db.r6i.32xlarge
-  :network_performance: :50_gbps
+  :network_performance:
   :vcpu: 128
 db.r6i.4xlarge:
   :deprecated: false
@@ -1421,7 +1421,7 @@ db.r6i.8xlarge:
   :family: Memory optimized
   :memory: 274877906944.0
   :name: db.r6i.8xlarge
-  :network_performance: :12.5_gbps
+  :network_performance:
   :vcpu: 32
 db.r6i.8xlarge.tpc2.mem3x:
   :deprecated: false
@@ -1445,7 +1445,7 @@ db.r6i.large:
   :family: Memory optimized
   :memory: 17179869184.0
   :name: db.r6i.large
-  :network_performance: :up_to_12.5_gbps
+  :network_performance:
   :vcpu: 2
 db.r6i.large.tpc1.mem2x:
   :deprecated: false
@@ -1461,7 +1461,7 @@ db.r6i.xlarge:
   :family: Memory optimized
   :memory: 34359738368.0
   :name: db.r6i.xlarge
-  :network_performance: :up_to_12.5_gbps
+  :network_performance:
   :vcpu: 4
 db.r6i.xlarge.tpc2.mem2x:
   :deprecated: false
@@ -2101,7 +2101,7 @@ db.x2iedn.xlarge:
   :family: Memory optimized
   :memory: 137438953472.0
   :name: db.x2iedn.xlarge
-  :network_performance: :up_to_25_gbps
+  :network_performance:
   :vcpu: 4
 db.x2iezn.12xlarge:
   :deprecated: false
@@ -2109,7 +2109,7 @@ db.x2iezn.12xlarge:
   :family: Memory optimized
   :memory: 1649267441664.0
   :name: db.x2iezn.12xlarge
-  :network_performance: :100_gbps
+  :network_performance:
   :vcpu: 48
 db.x2iezn.2xlarge:
   :deprecated: false
@@ -2117,7 +2117,7 @@ db.x2iezn.2xlarge:
   :family: Memory optimized
   :memory: 274877906944.0
   :name: db.x2iezn.2xlarge
-  :network_performance: :up_to_25_gbps
+  :network_performance:
   :vcpu: 8
 db.x2iezn.4xlarge:
   :deprecated: false
@@ -2125,7 +2125,7 @@ db.x2iezn.4xlarge:
   :family: Memory optimized
   :memory: 549755813888.0
   :name: db.x2iezn.4xlarge
-  :network_performance: :up_to_25_gbps
+  :network_performance:
   :vcpu: 16
 db.x2iezn.6xlarge:
   :deprecated: false

--- a/db/fixtures/aws_database_types.yml
+++ b/db/fixtures/aws_database_types.yml
@@ -192,7 +192,7 @@ db.m5.large:
   :network_performance: :very_high
   :vcpu: 2
 db.m5.xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: General purpose
   :memory: 17179869184.0
@@ -384,7 +384,7 @@ db.m6i.12xlarge:
   :network_performance: :18.75_gbps
   :vcpu: 48
 db.m6i.16xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: General purpose
   :memory: 274877906944.0
@@ -400,7 +400,7 @@ db.m6i.24xlarge:
   :network_performance: :37.5_gbps
   :vcpu: 96
 db.m6i.2xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: General purpose
   :memory: 34359738368.0
@@ -424,7 +424,7 @@ db.m6i.4xlarge:
   :network_performance: :up_to_12.5_gbps
   :vcpu: 16
 db.m6i.8xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: General purpose
   :memory: 137438953472.0
@@ -432,7 +432,7 @@ db.m6i.8xlarge:
   :network_performance:
   :vcpu: 32
 db.m6i.large:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: General purpose
   :memory: 8589934592.0
@@ -440,7 +440,7 @@ db.m6i.large:
   :network_performance:
   :vcpu: 2
 db.m6i.xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: General purpose
   :memory: 17179869184.0
@@ -912,7 +912,7 @@ db.r5.6xlarge.tpc2.mem4x:
   :network_performance: :very_high
   :vcpu: 24
 db.r5.8xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 274877906944.0
@@ -992,7 +992,7 @@ db.r5b.24xlarge:
   :network_performance: :very_high
   :vcpu: 96
 db.r5b.2xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 68719476736.0
@@ -1024,7 +1024,7 @@ db.r5b.2xlarge.tpc2.mem8x:
   :network_performance: :very_high
   :vcpu: 8
 db.r5b.4xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 137438953472.0
@@ -1080,7 +1080,7 @@ db.r5b.8xlarge.tpc2.mem3x:
   :network_performance: :very_high
   :vcpu: 32
 db.r5b.large:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 17179869184.0
@@ -1096,7 +1096,7 @@ db.r5b.large.tpc1.mem2x:
   :network_performance: :very_high
   :vcpu: 2
 db.r5b.xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 34359738368.0
@@ -1320,7 +1320,7 @@ db.r6i.16xlarge:
   :network_performance: :25_gbps
   :vcpu: 64
 db.r6i.24xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 824633720832.0
@@ -1360,7 +1360,7 @@ db.r6i.2xlarge.tpc2.mem8x:
   :network_performance: :25_gbps
   :vcpu: 8
 db.r6i.32xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 1099511627776.0
@@ -1416,7 +1416,7 @@ db.r6i.6xlarge.tpc2.mem4x:
   :network_performance: :37.5_gbps
   :vcpu: 24
 db.r6i.8xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 274877906944.0
@@ -1440,7 +1440,7 @@ db.r6i.8xlarge.tpc2.mem4x:
   :network_performance: :50_gbps
   :vcpu: 32
 db.r6i.large:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 17179869184.0
@@ -1456,7 +1456,7 @@ db.r6i.large.tpc1.mem2x:
   :network_performance: :up_to_12.5_gbps
   :vcpu: 2
 db.r6i.xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 34359738368.0
@@ -2096,7 +2096,7 @@ db.x2iedn.8xlarge:
   :network_performance: :25_gbps
   :vcpu: 32
 db.x2iedn.xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 137438953472.0
@@ -2104,7 +2104,7 @@ db.x2iedn.xlarge:
   :network_performance:
   :vcpu: 4
 db.x2iezn.12xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 1649267441664.0
@@ -2112,7 +2112,7 @@ db.x2iezn.12xlarge:
   :network_performance:
   :vcpu: 48
 db.x2iezn.2xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 274877906944.0
@@ -2120,7 +2120,7 @@ db.x2iezn.2xlarge:
   :network_performance:
   :vcpu: 8
 db.x2iezn.4xlarge:
-  :deprecated: false
+  :deprecated: true
   :ebs_optimized: false
   :family: Memory optimized
   :memory: 549755813888.0

--- a/lib/tasks_private/database_types.rake
+++ b/lib/tasks_private/database_types.rake
@@ -8,7 +8,9 @@ namespace 'aws:extract' do
     end
 
     results = instances.map do |instance|
-      network_performance = if instance["networkPerformance"].match?(/(\d+ Gigabit)/)
+      network_performance = if instance["networkPerformance"].nil?
+                              nil
+                            elsif instance["networkPerformance"].match?(/(\d+ Gigabit)/)
                               :very_high
                             else
                               instance["networkPerformance"].downcase.tr(' ', '_').to_sym


### PR DESCRIPTION
Handle case where deprecated AWS database types have a nil `networkPerformance` key

@miq-bot assign @agrare 
@miq-bot add_label bug
@miq-bot add_reviewer @agrare 