### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -18,6 +18,10 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Amazon::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ec2_network".freeze
   end

--- a/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
+++ b/app/models/manageiq/providers/amazon/storage_manager/ebs.rb
@@ -26,6 +26,10 @@ class ManageIQ::Providers::Amazon::StorageManager::Ebs < ManageIQ::Providers::St
   supports :cloud_volume
   supports :cloud_volume_create
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Amazon::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ec2_ebs_storage".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,6 +85,9 @@
     :inventory_collections:
       :saver_strategy: batch
   :ec2_network:
+    # Disable scheduled full refresh for the network manager as this will be
+    # refreshed automatically by the parent cloud manager.
+    :refresh_interval: 0
     :inventory_collections:
       :saver_strategy: batch
   :eks:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -100,6 +100,9 @@
     :inventory_collections:
       :saver_strategy: batch
   :ec2_ebs_storage:
+    # Disable scheduled full refresh for the storage manager as this will be
+    # refreshed automatically by the parent cloud manager.
+    :refresh_interval: 0
     :inventory_collections:
       :saver_strategy: batch
 :http_proxy:


### PR DESCRIPTION
Refreshes should be done via the cloud manager. Instance methods are already delegated however the class level refresh methods were not delegated.

Following changes in https://github.com/ManageIQ/manageiq-providers-azure/pull/564

@miq-bot assign @agrare 
@miq-bot add_label bug
@miq-bot add_reviewer @agrare 