### PR TITLE
Update instance_types action to Ruby 3.3

### DIFF
--- a/.github/workflows/instance_types.yaml
+++ b/.github/workflows/instance_types.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.0"
+        ruby-version: "3.3"
         bundler-cache: true
     - name: Update regions
       run: bundle exec rake aws:extract:regions


### PR DESCRIPTION
Since the core repo has now upgraded to no longer support Ruby 3.0, this
now fails on Ruby 3.0 with

    Your Ruby version is 3.0.7, but your Gemfile specified >= 3.1.1, < 3.5.0

This commit upgrades the Ruby version to 3.3 to fix this.

@agrare Please review.