### PR TITLE
Drop unused default_blacklisted_events from NetworkManager

### DIFF
--- a/app/models/manageiq/providers/amazon/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/network_manager.rb
@@ -34,14 +34,6 @@ class ManageIQ::Providers::Amazon::NetworkManager < ManageIQ::Providers::Network
     false
   end
 
-  def self.default_blacklisted_event_names
-    %w(
-      ConfigurationSnapshotDeliveryCompleted
-      ConfigurationSnapshotDeliveryStarted
-      ConfigurationSnapshotDeliveryFailed
-    )
-  end
-
   def self.display_name(number = 1)
     n_('Network Provider (Amazon)', 'Network Providers (Amazon)', number)
   end


### PR DESCRIPTION
The Amazon NetworkManager doesn't run an EventCatcher so there is no need for a `.default_blacklisted_event_names` method.  This was a copy&paste from the `CloudManager` and not specific to network-type events.

https://github.com/ManageIQ/manageiq/issues/19707
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
