### PR TITLE
Rename default_blacklisted_event_names

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -108,7 +108,7 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     false
   end
 
-  def self.default_blacklisted_event_names
+  def self.filtered_event_names
     Settings.ems.ems_amazon.blacklisted_event_names
   end
 

--- a/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::Amazon::CloudManager::EventCatcher::Runner < ManageIQ
   private
 
   def filtered?(event)
-    filtered_events.include?(event["eventType"])
+    @ems.filtered_event_names.include?(event["eventType"])
   end
 
   def event_monitor_handle

--- a/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager_spec.rb
@@ -49,6 +49,12 @@ describe ManageIQ::Providers::Amazon::CloudManager do
     expect(described_class.description).to eq('Amazon EC2')
   end
 
+  it ".filtered_event_names" do
+    expect(described_class.filtered_event_names).to match_array(
+      %w(ConfigurationSnapshotDeliveryCompleted ConfigurationSnapshotDeliveryStarted ConfigurationSnapshotDeliveryFailed)
+    )
+  end
+
   context "#pause!" do
     let(:zone) { FactoryBot.create(:zone) }
     let(:ems)  { FactoryBot.create(:ems_amazon, :zone => zone) }

--- a/spec/models/manageiq/providers/amazon/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/amazon/network_manager_spec.rb
@@ -21,16 +21,6 @@ describe ManageIQ::Providers::Amazon::NetworkManager do
       expect(described_class.hostname_required?).to eq(false)
     end
 
-    it "returns the expected value for the default_blacklisted_event_names method" do
-      array = %w(
-        ConfigurationSnapshotDeliveryCompleted
-        ConfigurationSnapshotDeliveryStarted
-        ConfigurationSnapshotDeliveryFailed
-      )
-
-      expect(described_class.default_blacklisted_event_names).to eq(array)
-    end
-
     it "returns the expected value for the display_name method" do
       expect(described_class.display_name).to eq('Network Provider (Amazon)')
       expect(described_class.display_name(2)).to eq('Network Providers (Amazon)')


### PR DESCRIPTION
The Amazon CloudManager ems_type is ec2 not amazon so we still have to override the filtered_event_names method.

https://github.com/ManageIQ/manageiq/pull/23320
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
