### PR TITLE
With rails 7.1, these nil values are not persisted

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -404,7 +404,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
         :name    => service_offering.product_view_summary.name,
         :ems_ref => service_offering.product_view_summary.product_id,
         :extra   => {
-          :product_view_summary => service_offering.product_view_summary,
+          :product_view_summary => service_offering.product_view_summary.to_h,
           :status               => service_offering.status,
           :product_arn          => service_offering.product_arn,
           :created_time         => service_offering.created_time,

--- a/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/amazon/aws_refresher_spec_common.rb
@@ -1437,11 +1437,8 @@ module AwsRefresherSpecCommon
             "owner"               => "EmsRefreshSpecProductWithNoPortfolioOwner",
             "product_id"          => "prod-4v6rc4hwaiiha",
             "distributor"         => "",
-            "support_url"         => nil,
-            "support_email"       => nil,
             "has_default_path"    => false,
             "short_description"   => "EmsRefreshSpecProductWithNoPortfolio desc",
-            "support_description" => nil
           }
         },
         "deleted_on"  => nil,
@@ -1511,11 +1508,8 @@ module AwsRefresherSpecCommon
             "owner"               => "EmsRefreshSpecProductWithRulesowner",
             "product_id"          => "prod-cei2spnzu24lq",
             "distributor"         => "EmsRefreshSpecProductWithRulesVendor",
-            "support_url"         => nil,
-            "support_email"       => nil,
             "has_default_path"    => false,
             "short_description"   => "EmsRefreshSpecProductWithRules desc",
-            "support_description" => nil
           }
         },
         "deleted_on"  => nil,


### PR DESCRIPTION
TODO: This is to get some discussion on possible causes.  I'm not sure why rails 7.1 seems to be changing the persistance of the API results from aws-sdk.

support_url, support_email, and support_description don't exist in the response payload in the cassette for these tests, while others have it, and yet previously, these unset fields were set as nil with rails 7.0.  It's unclear what changed with rails 7.1 but now these nil value fields aren't persisted in the extra column, so I had to remove them in the tests where these values in the cassettes didn't exist in the response.

collector/cloud_manager.rb:

```ruby
  def service_offerings
    aws_service_catalog.client.search_products_as_admin.product_view_details
    ...
  end
```

parser/cloud_manager.rb:


```ruby
  collector.service_offerings.each do |service_offering|
    persister_service_offering = persister.service_offerings.build(...
      ...
      :extra   => {
        :product_view_summary => service_offering.product_view_summary,
    ...
```

Here is my Gemfile.lock with rails 7.0 vs. rails 7.1, using the same aws-sdk gems:

```diff
diff --git a/Gemfile.lock70 b/Gemfile.lock71
index 5c9dd6c..4c94758 100644
--- a/Gemfile.lock70
+++ b/Gemfile.lock71
@@ -11,6 +11,15 @@ GIT
       manageiq-gems-pending (~> 0)
       manageiq-smartstate (~> 0.2)
 
+GIT
+  remote: https://github.com/ManageIQ/jquery-rjs.git
+  revision: 3a590dfe66cbd90a487da57c4357a82cb3d83992
+  branch: jquery_rjs_0_1_1
+  specs:
+    jquery-rjs (0.1.1.3)
+      jquery-rails
+      rails (>= 3.2)
+
 GIT
   remote: https://github.com/ManageIQ/manageiq-api
   revision: b11cbf9761f8360f89c6b8f53a114cd499af40ea
@@ -20,15 +29,6 @@ GIT
       config
       jbuilder (~> 2.5, != 2.9.0)
 
-GIT
-  remote: https://github.com/ManageIQ/manageiq-automation_engine
-  revision: 037fd1fd54b89b2c4ea97e268936825825b79e17
-  branch: master
-  specs:
-    manageiq-automation_engine (0.1.0)
-      drb
-      rubyzip (~> 2.0.0)
-
 GIT
   remote: https://github.com/ManageIQ/manageiq-consumption
   revision: bad846a1980c0ded1b166b44438e18f2462836c6
@@ -342,6 +342,31 @@ GIT
       uglifier (~> 4.2.0)
       webpacker (~> 2.0.0)
 
+GIT
+  remote: https://github.com/ManageIQ/ovirt_metrics.git
+  revision: 36a99a40d11de98bd0cce011596777f2c85b9455
+  specs:
+    ovirt_metrics (3.2.0)
+      activerecord (>= 7.0)
+      pg
+
+GIT
+  remote: https://github.com/jrafanie/activerecord-virtual_attributes.git
+  revision: afd9619b5093c408f4243b6867ec0458ab7acdbc
+  branch: rails71
+  specs:
+    activerecord-virtual_attributes (7.0.0)
+      activerecord (~> 7.0)
+
+GIT
+  remote: https://github.com/kbrock/manageiq-automation_engine.git
+  revision: 6e92c8e09ea0d88e8058d759c6f0e7feafc3aa8d
+  branch: alias_attribute_access
+  specs:
+    manageiq-automation_engine (0.1.0)
+      drb
+      rubyzip (~> 2.0.0)
+
 PATH
   remote: .
   specs:
@@ -372,9 +397,6 @@ GEM
       ms_rest_azure (~> 0.12.0)
     handsoap (0.2.5.5)
       nokogiri (>= 1.2.3)
-    jquery-rjs (0.1.1.3)
-      jquery-rails
-      rails (>= 3.2)
     mime-types (3.0.0)
       mini_mime (>= 0.1.1)
 
@@ -383,59 +405,64 @@ GEM
   specs:
     PoParser (3.2.8)
       simple_po_parser (~> 1.1.6)
-    actioncable (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    actioncable (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activestorage (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       mail (>= 2.7.1)
       net-imap
       net-pop
       net-smtp
-    actionmailer (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      actionview (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    actionmailer (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      actionview (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.8.7)
-      actionview (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
-      rack (~> 2.0, >= 2.2.4)
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.5.1)
+      actionview (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activestorage (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.0.8.7)
-      activesupport (= 7.0.8.7)
+    actionview (7.1.5.1)
+      activesupport (= 7.1.5.1)
       builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.8.7)
-      activesupport (= 7.0.8.7)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.1.5.1)
+      activesupport (= 7.1.5.1)
       globalid (>= 0.3.6)
-    activemodel (7.0.8.7)
-      activesupport (= 7.0.8.7)
-    activerecord (7.0.8.7)
-      activemodel (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    activemodel (7.1.5.1)
+      activesupport (= 7.1.5.1)
+    activerecord (7.1.5.1)
+      activemodel (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      timeout (>= 0.4.0)
     activerecord-id_regions (0.5.0)
       activerecord (>= 7.0.8, < 8.0)
       activesupport (>= 7.0.8, < 8.0)
@@ -447,19 +474,24 @@ GEM
       multi_json (~> 1.11, >= 1.11.2)
       rack (>= 2.0.8, < 4)
       railties (>= 6.1)
-    activerecord-virtual_attributes (7.0.0)
-      activerecord (~> 7.0)
-    activestorage (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    activestorage (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.8.7)
+    activesupport (7.1.5.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
     acts_as_tree (2.9.1)
       activerecord (>= 3.0.0)
@@ -544,6 +576,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
+    benchmark (0.4.0)
     bigdecimal (3.1.9)
     binary_struct (2.1.0)
     bootsnap (1.18.4)
@@ -578,8 +611,8 @@ GEM
     csv (3.3.2)
     dalli (3.2.8)
     date (3.4.1)
-    db-query-matchers (0.11.0)
-      activesupport (>= 4.0, < 7.1)
+    db-query-matchers (0.13.0)
+      activesupport (>= 4.0, < 7.3)
       rspec (>= 3.0)
     dbus-systemd (1.1.2)
       ruby-dbus (~> 0.14)
@@ -849,6 +882,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     locale (2.1.4)
+    logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -859,8 +893,8 @@ GEM
       net-imap
       net-pop
       net-smtp
-    manageiq-api-client (0.5.0)
-      activesupport (>= 6.0, < 7.1)
+    manageiq-api-client (0.6.0)
+      activesupport (>= 7.0, < 8.0)
       faraday (>= 1.0, < 3.0)
       faraday-follow_redirects
       json (~> 2.3)
@@ -1000,9 +1034,6 @@ GEM
     ostruct (0.6.1)
     ovirt-engine-sdk (4.6.0)
       json (>= 1, < 3)
-    ovirt_metrics (3.2.0)
-      activerecord (>= 6.0)
-      pg
     parallel (1.26.3)
     parallel_tests (4.9.0)
       parallel
@@ -1048,22 +1079,27 @@ GEM
     rack (2.2.10)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rails (7.0.8.7)
-      actioncable (= 7.0.8.7)
-      actionmailbox (= 7.0.8.7)
-      actionmailer (= 7.0.8.7)
-      actionpack (= 7.0.8.7)
-      actiontext (= 7.0.8.7)
-      actionview (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activemodel (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activestorage (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    rackup (1.0.1)
+      rack (< 3)
+      webrick
+    rails (7.1.5.1)
+      actioncable (= 7.1.5.1)
+      actionmailbox (= 7.1.5.1)
+      actionmailer (= 7.1.5.1)
+      actionpack (= 7.1.5.1)
+      actiontext (= 7.1.5.1)
+      actionview (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activemodel (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       bundler (>= 1.15.0)
-      railties (= 7.0.8.7)
+      railties (= 7.1.5.1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -1074,13 +1110,14 @@ GEM
     rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    railties (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
-      method_source
+    railties (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      irb
+      rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
@@ -1190,6 +1227,7 @@ GEM
     sd_notify (0.1.1)
     secure_headers (3.9.0)
       useragent
+    securerandom (0.4.1)
     server_sent_events (0.1.3)
     sexp_processor (4.17.3)
     signet (0.19.0)
@@ -1302,6 +1340,7 @@ GEM
       activesupport (>= 4.2)
       multi_json (~> 1.2)
       railties (>= 4.2)
+    webrick (1.9.1)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -1329,7 +1368,7 @@ PLATFORMS
 DEPENDENCIES
   PoParser
   activerecord-session_store (~> 2.0)
-  activerecord-virtual_attributes (~> 7.0.0)
+  activerecord-virtual_attributes!
   acts_as_tree (~> 2.7)
   amazon_ssa_support!
   american_date
@@ -1349,11 +1388,10 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   cgi (~> 0.3.5)
   color (~> 1.8)
-  concurrent-ruby (< 1.3.5)
   config (~> 5.1)
   connection_pool
   dalli (~> 3.2.3)
-  db-query-matchers (~> 0.11.0)
+  db-query-matchers (~> 0.13.0)
   dbus-systemd (~> 1.1.0)
   default_value_for (~> 4.0)
   docker-api (~> 1.33.6)
@@ -1369,24 +1407,24 @@ DEPENDENCIES
   hamlit (~> 2.11.0)
   handsoap (= 0.2.5.5)!
   inifile (~> 3.0)
-  inventory_refresh (~> 2.1)
+  inventory_refresh (~> 2.2)
   irb (= 1.4.1)
-  jquery-rjs (= 0.1.1.3)!
+  jquery-rjs!
   kubeclient (~> 4.0)
   linux_admin (>= 3.0, < 5)
   listen (~> 3.2)
   manageiq-api!
-  manageiq-api-client (~> 0.5.0)
+  manageiq-api-client (~> 0.6.0)
   manageiq-appliance_console (~> 10.0)
   manageiq-automation_engine!
   manageiq-consumption!
   manageiq-content!
   manageiq-decorators!
   manageiq-gems-pending (> 0)!
-  manageiq-loggers (~> 1.0, >= 1.1.1)
-  manageiq-messaging (~> 1.0, >= 1.4.3)
+  manageiq-loggers (~> 1.2)
+  manageiq-messaging (~> 1.5)
   manageiq-password (~> 1.0)
-  manageiq-postgres_ha_admin (~> 3.3)
+  manageiq-postgres_ha_admin (~> 3.4)
   manageiq-providers-amazon!
   manageiq-providers-ansible_tower!
   manageiq-providers-autosde!
@@ -1429,6 +1467,7 @@ DEPENDENCIES
   net-ping (~> 1.7.4)
   openscap (~> 0.4.8)
   optimist (~> 3.0)
+  ovirt_metrics!
   parallel_tests (~> 4.4)
   pg (>= 1.4.1)
   pg-dsn_parser (~> 0.1.1)
@@ -1441,7 +1480,7 @@ DEPENDENCIES
   query_relation (~> 0.1.0)
   rack (>= 2.2.6.4)
   rack-attack (~> 6.5.0)
-  rails (~> 7.0.8, >= 7.0.8.7)
+  rails (~> 7.1.5, >= 7.1.5.1)
   rails-i18n (~> 7.x)
   rake (>= 12.3.3)
   rdoc
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
