### PR TITLE
Lock down aws-sdk-core to before 3.220.1

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk-core",                 "~> 3.114"
+  spec.add_dependency "aws-sdk-core",                 "~> 3.114", "< 3.220.1"
   spec.add_dependency "aws-sdk-cloudformation",       "~> 1.0"
   spec.add_dependency "aws-sdk-cloudwatch",           "~> 1.0"
   spec.add_dependency "aws-sdk-ec2",                  "~> 1.0"


### PR DESCRIPTION
Prevent a change to aws-sdk-core stubbing causing failures in our amazon authenticator specs.
This can be unlocked once we fix stubbing issue.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
