### PR TITLE
Fix missing required params in AWS auth stubs

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -39,7 +39,7 @@ describe Authenticator::Amazon do
   def aws_get_user_is_root!(resource)
     response = resource.client.stub_data(
       :get_user,
-      :user => {:arn => 'arn:aws:iam::123456789:root'}
+      :user => {:arn => 'arn:aws:iam::123456789:root', :user_id => 'root', :user_name => 'Root', :path => '/', :create_date => Time.now.utc}
     )
     resource.client.stub_responses(:get_user, response)
   end
@@ -58,7 +58,12 @@ describe Authenticator::Amazon do
   end
 
   def aws_allow_list_groups!(resource)
-    response = resource.client.stub_data(:list_groups_for_user, :groups => [:group_name => aws_group_name])
+    response = resource.client.stub_data(
+      :list_groups_for_user,
+      :groups => [
+        {:arn => "arn:aws:group::123456789:group", :path => "/#{aws_group_name}", :group_id => "1", :group_name => aws_group_name, :create_date => Time.now.utc}
+      ]
+    )
     resource.client.stub_responses(:list_groups_for_user, response)
   end
 


### PR DESCRIPTION
Introduced by https://github.com/aws/aws-sdk-ruby/pull/3204 in v3.220.1
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
