### PR TITLE
Fix SSA issues in AWS: keypair param, IAM role check, route table logic

### DIFF
--- a/app/models/manageiq/providers/amazon/agent_coordinator.rb
+++ b/app/models/manageiq/providers/amazon/agent_coordinator.rb
@@ -392,7 +392,7 @@ class ManageIQ::Providers::Amazon::AgentCoordinator
       unless route_tables.empty?
         _log.debug("Found route tables #{route_tables} on the gateway [#{igw_ids.first}]")
         # From AWS docs: checks if associated with a subnet_id or is the main route table
-        subnets = route_tables.any? do |rt|
+        subnets = route_tables.select do |rt|
           rt.associations.any? { |assoc| assoc.subnet_id.present? || assoc.main }
         end
 


### PR DESCRIPTION
## Summary
This PR addresses three critical issues in the AWS Agent Coordinator that prevent Smart State Analysis from working correctly.

## Issues Fixed

### 1. Fix symbol/string key mismatch in keypair creation
**Problem**: The [find_or_create_keypair](https://github.com/ManageIQ/manageiq-providers-amazon/blob/5f946e81d3a7c8d793eb4f1b7ad8b1c1110bc7a8/app/models/manageiq/providers/amazon/agent_coordinator.rb#L414) method passes a `:name` symbol key, but [raw_create_key_pair](https://github.com/ManageIQ/manageiq-providers-amazon/blob/5f946e81d3a7c8d793eb4f1b7ad8b1c1110bc7a8/app/models/manageiq/providers/amazon/cloud_manager/auth_key_pair.rb#L8) expects a string key `"name"`, causing keypair creation to fail with "missing required parameter params[:key_name]".

**Root Cause**: This was introduced by PR #750 which changed the API to use string keys instead of symbols for JSON params, but the agent_coordinator wasn't updated accordingly.


### 2. Fix AWS SDK compatibility issue with IAM Role collection
**Problem**: The AWS SDK changed IAM roles from an array to an `Aws::IAM::Role::Collection` object, which doesn't support the `.empty?` method, causing "undefined method `empty?`" errors.

**Fix**: Replace `.empty?` with `.count.zero?` which works with both arrays and collection objects.


### 3. Fix route table association logic for subnet selection
**Problem**: The code assumes route table associations always have a `subnet_id`, but main route tables have `main: true` instead of a subnet_id, causing subnet selection to fail.

**Fix**: Update the logic to handle both subnet associations and main route table associations.


## Files Changed
- `app/models/manageiq/providers/amazon/agent_coordinator.rb`

The Smart State VM authentication issue still persists; I will create a separate issue to track it.