### PR TITLE
Parse AWS instance ipv6 address

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/cloud_manager.rb
@@ -315,24 +315,27 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::CloudManager < ManageIQ::P
     hardware_network(persister_hardware,
                      instance['private_ip_address'].presence,
                      instance['private_dns_name'].presence,
+                     nil,
                      "private")
 
     hardware_network(persister_hardware,
                      instance['public_ip_address'].presence,
                      instance['public_dns_name'].presence,
+                     instance['ipv_6_address'].presence,
                      "public")
   end
 
-  def hardware_network(persister_hardware, ip_address, hostname, description)
-    unless ip_address.blank?
-      persister.networks.find_or_build_by(
-        :hardware    => persister_hardware,
-        :description => description
-      ).assign_attributes(
-        :ipaddress => ip_address,
-        :hostname  => hostname,
-      )
-    end
+  def hardware_network(persister_hardware, ip_address, hostname, ipv6_address, description)
+    return if ip_address.blank? && ipv6_address.blank?
+
+    persister.networks.find_or_build_by(
+      :hardware    => persister_hardware,
+      :description => description
+    ).assign_attributes(
+      :ipaddress   => ip_address,
+      :ipv6address => ipv6_address,
+      :hostname    => hostname,
+    )
   end
 
   def hardware_disks(persister_hardware, instance, flavor)


### PR DESCRIPTION
We were ignoring the `ipv6_address` attribute of aws instances.

see also:
- https://github.com/ManageIQ/manageiq-providers-amazon/issues/911
- https://github.com/ManageIQ/manageiq-providers-amazon/pull/914
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
