### PR TITLE
Support IPv6 only Subnets

### DIFF
--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -69,9 +69,12 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
 
   def cloud_subnets
     collector.cloud_subnets.each do |subnet|
+      cidr   = subnet['cidr_block']
+      cidr ||= subnet['ipv_6_cidr_block_association_set']&.pluck('ipv_6_cidr_block')&.compact&.first
+
       persister_cloud_subnet = persister.cloud_subnets.find_or_build(subnet['subnet_id']).assign_attributes(
         :name              => get_from_tags(subnet, 'name') || subnet['subnet_id'],
-        :cidr              => subnet['cidr_block'],
+        :cidr              => cidr,
         :status            => subnet['state'].try(:to_s),
         :availability_zone => persister.availability_zones.lazy_find(subnet['availability_zone']),
         :cloud_network     => persister.cloud_networks.lazy_find(subnet['vpc_id']),

--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -300,6 +300,14 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
         )
       end
 
+      network_port['ipv_6_addresses']&.each do |address|
+        persister.cloud_subnet_network_ports.find_or_build_by(
+          :address      => address['ipv_6_address'],
+          :cloud_subnet => persister.cloud_subnets.lazy_find(network_port['subnet_id']),
+          :network_port => persister_network_port
+        )
+      end
+
       public_ips(network_port)
     end
   end

--- a/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/amazon/inventory/parser/network_manager.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::Amazon::Inventory::Parser::NetworkManager < ManageIQ:
   def cloud_subnets
     collector.cloud_subnets.each do |subnet|
       cidr   = subnet['cidr_block']
-      cidr ||= subnet['ipv_6_cidr_block_association_set']&.pluck('ipv_6_cidr_block')&.compact&.first
+      cidr ||= subnet.dig('ipv_6_cidr_block_association_set', 0, 'ipv_6_cidr_block')
 
       persister_cloud_subnet = persister.cloud_subnets.find_or_build(subnet['subnet_id']).assign_attributes(
         :name              => get_from_tags(subnet, 'name') || subnet['subnet_id'],


### PR DESCRIPTION
<img width="860" height="360" alt="image" src="https://github.com/user-attachments/assets/ba2d3285-779d-4ec9-8223-c948f26f5c82" />

<img width="599" height="288" alt="image" src="https://github.com/user-attachments/assets/8bc8c07f-4968-4af1-af92-cd41f19e86c4" />

```
pp subnet
{"availability_zone_id"=>"usw2-az2",
 "map_customer_owned_ip_on_launch"=>false,
 "owner_id"=>"006216435641",
 "assign_ipv_6_address_on_creation"=>true,
 "ipv_6_cidr_block_association_set"=>
  [{"association_id"=>"subnet-cidr-assoc-0f62df830a93264f2",
    "ipv_6_cidr_block"=>"2600:1f14:1895:4800::/56",
    "ipv_6_cidr_block_state"=>{"state"=>"associated"},
    "ipv_6_address_attribute"=>"public",
    "ip_source"=>"amazon"}],
 "tags"=>[{"key"=>"Name", "value"=>"achan-ipv6-subnet"}],
 "subnet_arn"=>"arn:aws:ec2:us-west-2:006216435641:subnet/subnet-09468a3d3254b13ce",
 "enable_dns_64"=>false,
 "ipv_6_native"=>true,
 "private_dns_name_options_on_launch"=>{"hostname_type"=>"resource-name", "enable_resource_name_dns_a_record"=>false, "enable_resource_name_dns_aaaa_record"=>true},
 "block_public_access_states"=>{"internet_gateway_block_mode"=>"off"},
 "subnet_id"=>"subnet-09468a3d3254b13ce",
 "state"=>"available",
 "vpc_id"=>"vpc-03a9bd798d4bcd205",
 "available_ip_address_count"=>0,
 "availability_zone"=>"us-west-2a",
 "default_for_az"=>false,
 "map_public_ip_on_launch"=>false}
```

Fixes https://github.com/ManageIQ/manageiq-providers-amazon/issues/911
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
