### PR TITLE
Lockdown aws-sdk-cloudwatch to v1.125.0

### DIFF
--- a/manageiq-providers-amazon.gemspec
+++ b/manageiq-providers-amazon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-core",                 "~> 3.114"
   spec.add_dependency "aws-sdk-cloudformation",       "~> 1.0"
-  spec.add_dependency "aws-sdk-cloudwatch",           "~> 1.0"
+  spec.add_dependency "aws-sdk-cloudwatch",           "~> 1.125.0"
   spec.add_dependency "aws-sdk-ec2",                  "~> 1.0"
   spec.add_dependency "aws-sdk-elasticloadbalancing", "~> 1.0"
   spec.add_dependency "aws-sdk-iam",                  "~> 1.0"


### PR DESCRIPTION
Fix VCR spec test failures for metrics capture due to a change in protocol from AWSQuery (XML) to AWS JSON.

https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-cloudwatch/CHANGELOG.md#11260-2025-12-10

```
Failures:

  1) ManageIQ::Providers::Amazon::CloudManager::MetricsCapture counters gathered from linux old way 
     Failure/Error: data = cloud_watch.client.list_metrics(:dimensions => filter)
     
     Aws::Json::ParseError:
       unexpected character: '<ListMetricsResponse' at line 1 column 1
     # /home/grare/adam/src/manageiq/aws-sdk-ruby/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb:12:in `rescue in load'
     # /home/grare/adam/src/manageiq/aws-sdk-ruby/gems/aws-sdk-core/lib/aws-sdk-core/json/json_engine.rb:9:in `load'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
