### PR TITLE
Drop MiqLdap stubbing in specs

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -79,7 +79,6 @@ describe Authenticator::Amazon do
     allow(User).to receive(:authenticator).and_return(subject)
 
     miq_group = FactoryBot.create(:miq_group, :description => miq_group_name)
-    allow(MiqLdap).to receive(:using_ldap?) { false }
 
     allow_any_instance_of(described_class).to receive(:aws_connect) do |_instance, access_key_id, _secret_access_key, service|
       service ||= :IAM


### PR DESCRIPTION
The core repository will return false by default, so this stubbing is not needed (and will be deleted in https://github.com/ManageIQ/manageiq/pull/21127 anyway.  This PR ensures we don't have dependent PRs.